### PR TITLE
260515-IOS-Fix missing text avatar channel voice

### DIFF
--- a/MezonChat/Features/ChannelList/ChannelItemCellNode.swift
+++ b/MezonChat/Features/ChannelList/ChannelItemCellNode.swift
@@ -223,12 +223,6 @@ struct VoiceMemberDisplay {
 }
 
 private func makeVoiceAvatarNodes(member m: VoiceMemberDisplay, size s: CGFloat) -> (wrapper: ASDisplayNode, img: ASNetworkImageNode, initLabel: ASTextNode2) {
-    let wrapper = ASDisplayNode()
-    wrapper.style.preferredSize = CGSize(width: s, height: s)
-    wrapper.cornerRadius = s / 2
-    wrapper.clipsToBounds = true
-    wrapper.backgroundColor = UIColor.avatarColor(for: m.username)
-
     let imgNode = ASNetworkImageNode()
     imgNode.style.preferredSize = CGSize(width: s, height: s)
     imgNode.cornerRadius = s / 2
@@ -238,11 +232,19 @@ private func makeVoiceAvatarNodes(member m: VoiceMemberDisplay, size s: CGFloat)
     let initNode = ASTextNode2()
     initNode.maximumNumberOfLines = 1
 
+    let wrapper = ASDisplayNode()
+    wrapper.automaticallyManagesSubnodes = true
+    wrapper.style.preferredSize = CGSize(width: s, height: s)
+    wrapper.cornerRadius = s / 2
+    wrapper.clipsToBounds = true
+
     if let av = m.avatarURL, !av.isEmpty {
+        wrapper.backgroundColor = .clear
         let proxy = ImgproxyURL.create(from: av, width: 150, height: 150)
         imgNode.url = URL(string: proxy)
         initNode.isHidden = true
     } else {
+        wrapper.backgroundColor = UIColor.avatarColor(for: m.username)
         imgNode.isHidden = true
         let initial = String(m.username.prefix(1)).uppercased()
         let fontSize: CGFloat = s < 20 ? 8 : 10
@@ -254,8 +256,11 @@ private func makeVoiceAvatarNodes(member m: VoiceMemberDisplay, size s: CGFloat)
             ])
     }
 
-    wrapper.addSubnode(imgNode)
-    wrapper.addSubnode(initNode)
+    wrapper.layoutSpecBlock = { _, _ in
+        let center = ASCenterLayoutSpec(centeringOptions: .XY, sizingOptions: [], child: initNode)
+        return ASOverlayLayoutSpec(child: center, overlay: imgNode)
+    }
+
     return (wrapper, imgNode, initNode)
 }
 
@@ -290,9 +295,6 @@ final class VoiceMemberExpandedCellNode: ASCellNode {
 
     override func layout() {
         super.layout()
-        let s = Self.avatarSize
-        avatarImg.frame = CGRect(origin: .zero, size: CGSize(width: s, height: s))
-        avatarInit.frame = CGRect(origin: .zero, size: CGSize(width: s, height: s))
     }
 
     override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
@@ -368,12 +370,6 @@ final class VoiceChannelMembersCollapsedCellNode: ASCellNode {
 
     override func layout() {
         super.layout()
-        let s = Self.avatarSize
-        for wrapper in avatarNodes {
-            for sub in wrapper.subnodes ?? [] {
-                sub.frame = CGRect(origin: .zero, size: CGSize(width: s, height: s))
-            }
-        }
     }
 
     override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {

--- a/MezonChat/Features/DirectMessages/DmListItemCell.swift
+++ b/MezonChat/Features/DirectMessages/DmListItemCell.swift
@@ -106,7 +106,7 @@ final class DmListItemCell: UITableViewCell {
         let avatarSize: CGFloat = 40.swh
 
         let nameTopConstraint = nameLabel.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 8.sh)
-        let nameCenterYConstraint = nameLabel.centerYAnchor.constraint(equalTo: avatarView.centerYAnchor)
+        let nameCenterYConstraint = nameLabel.centerYAnchor.constraint(equalTo: textAvatar.centerYAnchor)
         let lastMessageZeroHeightConstraint = lastMessageLabel.heightAnchor.constraint(equalToConstant: 0)
         nameCenterYConstraint.isActive = false
         lastMessageZeroHeightConstraint.isActive = false

--- a/MezonChat/Features/VoiceChannel/VoiceChannelRoomViewController.swift
+++ b/MezonChat/Features/VoiceChannel/VoiceChannelRoomViewController.swift
@@ -4097,7 +4097,7 @@ private final class VoiceParticipantRowView: UIView {
     private var soundReactionTrailingToCard: NSLayoutConstraint?
     private var soundReactionTrailingToRaiseHand: NSLayoutConstraint?
     private var lastAvatarURL: String?
-    private var lastTileVisualState: (displayName: String, micOn: Bool, speaking: Bool, mirrorVideo: Bool, track: VideoTrack?, avatarURL: String?)?
+    private var lastTileVisualState: (username: String, displayName: String, micOn: Bool, speaking: Bool, mirrorVideo: Bool, track: VideoTrack?, avatarURL: String?)?
     private var badgeMicOn = true
     private var layoutMetrics = VoiceParticipantTileLayoutMetrics.fallback
     private var avatarWidthConstraint: NSLayoutConstraint!
@@ -4449,7 +4449,9 @@ private final class VoiceParticipantRowView: UIView {
         videoTrack: VideoTrack?,
         mirrorVideo: Bool
     ) {
+        let usernameChanged = lastTileVisualState?.username != username
         if let s = lastTileVisualState,
+           !usernameChanged,
            s.displayName == displayName,
            s.micOn == micOn,
            s.speaking == speaking,
@@ -4488,9 +4490,12 @@ private final class VoiceParticipantRowView: UIView {
             card.layer.borderColor = UIColor.theme.borderDim.cgColor
         }
 
-        if avatarURL != lastAvatarURL {
+        if avatarURL != lastAvatarURL || usernameChanged {
+            let urlChanged = avatarURL != lastAvatarURL
             lastAvatarURL = avatarURL
-            avatarView.image = nil
+            if urlChanged {
+                avatarView.image = nil
+            }
             textAvatar.configure(username: username, fontSize: layoutMetrics.initialFontSize)
             if let raw = avatarURL, !raw.isEmpty {
                 let proxy = ImgproxyURL.create(from: raw, width: 150, height: 150)
@@ -4505,6 +4510,6 @@ private final class VoiceParticipantRowView: UIView {
                 avatarView.image = nil
             }
         }
-        lastTileVisualState = (displayName, micOn, speaking, mirrorVideo, videoTrack, avatarURL)
+        lastTileVisualState = (username, displayName, micOn, speaking, mirrorVideo, videoTrack, avatarURL)
     }
 }


### PR DESCRIPTION
issue: https://github.com/mezonai/mezon-ios/issues/131
Seft test:
- Join room channel voice và quan sát tên avatar text tại room
- Quan sát tên avatar text tại list user ở channel voice trong channel list

Root cause: So sánh sai trong logic dẫn đến hàm set username không được call
result:
<img width="200" height="58" alt="image" src="https://github.com/user-attachments/assets/4679a931-bded-4d26-b59d-823678ee75b8" />
<img width="380" height="296" alt="image" src="https://github.com/user-attachments/assets/fb7d30cc-ec3f-485c-a5b4-1b14326720f5" />

