### PR TITLE
260515-IOS-Fix missing text avatar channel voice mini popup

### DIFF
--- a/MezonChat/Features/VoiceChannel/VoiceChannelRoomViewController.swift
+++ b/MezonChat/Features/VoiceChannel/VoiceChannelRoomViewController.swift
@@ -314,6 +314,7 @@ final class VoiceChannelPiPOverlay: NSObject {
     private let badgeIcon = UIImageView()
     private let badgeLabel = UILabel()
     private var lastAvatarURL: String?
+    private var lastParticipantIdentity: String?
     private var isDragging = false
     private var participantRefreshCallback: (() -> Void)?
 
@@ -580,6 +581,7 @@ final class VoiceChannelPiPOverlay: NSObject {
         context = nil
         channel = nil
         lastAvatarURL = nil
+        lastParticipantIdentity = nil
         preservedAudioRoute = nil
         crossClanVoiceExitAlignClanId = nil
         applyCrossClanVoiceHomeExitFromPiPIfNeeded(alignClanId: savedAlign, channelId: savedChannelId)
@@ -681,6 +683,7 @@ final class VoiceChannelPiPOverlay: NSObject {
         context = nil
         channel = nil
         lastAvatarURL = nil
+        lastParticipantIdentity = nil
         crossClanVoiceExitAlignClanId = nil
         return (b, joinFlag, leaveFlag, route)
     }
@@ -751,12 +754,19 @@ final class VoiceChannelPiPOverlay: NSObject {
         }
         textAvatar.isHidden = false
 
-        let key = participant.identity?.stringValue ?? ""
-        let url = resolveAvatarURL(key, participant: participant)
+        let isLocal = participant is LocalParticipant
+        let identity: String
+        if isLocal {
+            identity = context?.currentUser?.id ?? ""
+        } else {
+            identity = participant.identity?.stringValue ?? ""
+        }
+        let url = resolveAvatarURL(identity, participant: participant)
         let name = resolveDisplayName(participant)
 
-        if url != lastAvatarURL {
+        if url != lastAvatarURL || identity != lastParticipantIdentity {
             lastAvatarURL = url
+            lastParticipantIdentity = identity
             avatarView.image = nil
             let username = resolveUsername(participant)
             textAvatar.configure(username: username, fontSize: 20)


### PR DESCRIPTION
issue: https://github.com/mezonai/mezon-ios/issues/134

self test: quan sát mini popup
root cause: so sánh sai khiến hàm set username không được call

result:
<img width="376" height="246" alt="image" src="https://github.com/user-attachments/assets/096403cd-9dcc-4812-a57a-742b31476bb7" />