### PR TITLE
fix: foward message

### DIFF
--- a/MezonChat.xcodeproj/project.pbxproj
+++ b/MezonChat.xcodeproj/project.pbxproj
@@ -153,7 +153,6 @@
 		46AE41D0F733CC49E465CC57 /* PollData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FBFF6B270E3C4E4B55F1A5 /* PollData.swift */; };
 		46D6A8760CF4DAB5027387D6 /* UniversalMasterController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 393A7534D077AA187486557A /* UniversalMasterController.swift */; };
 		46F8610D281B9535C6C7131C /* EscapeGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A5C825F0B49E835666DEFE /* EscapeGuard.swift */; };
-		47881456FF6F732A054344CB /* Pods_MezonChat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4BB9AD4EAB9B69253A5BBA1 /* Pods_MezonChat.framework */; };
 		4794BDC038CF3AED99F41332 /* Signal_Take.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4456907CC223AD1573461B6 /* Signal_Take.swift */; };
 		48AA3A91E7724523E5A69D83 /* MessageTopicNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9515916F23867D931F806F56 /* MessageTopicNode.swift */; };
 		490A7C34CA44AA088C336A35 /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8228F77FEA2EC6D988AC9EE0 /* TabBarController.swift */; };
@@ -210,6 +209,7 @@
 		62623D69C2FDCE2D27CE0962 /* MessageLocationNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D5510ECC05B079EB97CDE8D /* MessageLocationNode.swift */; };
 		628F552A3F5A25BF10E0FB22 /* SSubscriber.m in Sources */ = {isa = PBXBuildFile; fileRef = 97C961A66EB3877EDD29FF80 /* SSubscriber.m */; };
 		62D4FE7D5F261A1175CC7A11 /* ChannelMemberRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F3C98DD7CD7588632AF5EA /* ChannelMemberRecord.swift */; };
+		631E24FBE4430AB85919D702 /* Pods_MezonChat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85FE52C4CBE33EA29337838A /* Pods_MezonChat.framework */; };
 		6392436A7E791CA65DE544D0 /* ListViewItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3EE8DA45D3BB7A0CACBF22 /* ListViewItem.swift */; };
 		63B9DB4C96206F1EFE41364E /* ChannelBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B23BEA15E0F21603451529E0 /* ChannelBannerView.swift */; };
 		64A7A825E83B5A28C4E0192D /* ImageUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = E322BFBEDA641EC842A02B22 /* ImageUtilities.swift */; };
@@ -697,7 +697,6 @@
 		3B487D961011A54C11B25211 /* MessageRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageRecord.swift; sourceTree = "<group>"; };
 		3BC9BBD8CE1356E06FA17A26 /* ChannelDetailActionButtonsNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelDetailActionButtonsNode.swift; sourceTree = "<group>"; };
 		3BFE60C6455F30BDFF58D1CD /* SBlockDisposable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SBlockDisposable.h; sourceTree = "<group>"; };
-		3C190EBB2A494DED6B6050D2 /* Pods-MezonChat.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MezonChat.release.xcconfig"; path = "Target Support Files/Pods-MezonChat/Pods-MezonChat.release.xcconfig"; sourceTree = "<group>"; };
 		3C5DA8FB1CCC85930A8CB062 /* RoundedRectangle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedRectangle.swift; sourceTree = "<group>"; };
 		3C8EDFC6DA55BA15B9F136D3 /* Rectangle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rectangle.swift; sourceTree = "<group>"; };
 		3D08457B35F8D67AC0902501 /* UpdateEmailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateEmailViewController.swift; sourceTree = "<group>"; };
@@ -837,6 +836,7 @@
 		79DDB9EFFDE1B6ECBFEF6F31 /* List.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = List.swift; sourceTree = "<group>"; };
 		7A1614BDC3FD9434A6F2F4A9 /* CanvasWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasWebViewController.swift; sourceTree = "<group>"; };
 		7BC05A1D70218FEF88ECD091 /* ThemeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeManager.swift; sourceTree = "<group>"; };
+		7BCEB69B2269CC9BB78458BD /* Pods-MezonChat.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MezonChat.release.xcconfig"; path = "Target Support Files/Pods-MezonChat/Pods-MezonChat.release.xcconfig"; sourceTree = "<group>"; };
 		7C9DD86C33B3394AABB6B02C /* SAtomic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SAtomic.h; sourceTree = "<group>"; };
 		7CBD0290A77BC1FAC28E6FEE /* NotificationService.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		7D231D0BB4770A6BAAC1ACE2 /* NSWeakReference.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSWeakReference.h; sourceTree = "<group>"; };
@@ -869,6 +869,7 @@
 		845C5E3AF84A8BA0BB3ED96B /* MessageContentParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageContentParser.swift; sourceTree = "<group>"; };
 		859F5D7416A27DC41E2B263B /* PortalSourceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalSourceView.swift; sourceTree = "<group>"; };
 		85A1FD53749AF15825DDD0B8 /* NavigationLayoutEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLayoutEnvironment.swift; sourceTree = "<group>"; };
+		85FE52C4CBE33EA29337838A /* Pods_MezonChat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MezonChat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		86FD4A3143D8EC7A0F470236 /* OpenURLHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OpenURLHelper.m; sourceTree = "<group>"; };
 		872B2357D03FAC002169FB75 /* PollDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollDetailViewController.swift; sourceTree = "<group>"; };
 		8742D1794B61567C6B48E0B5 /* Signal_Catch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Signal_Catch.swift; sourceTree = "<group>"; };
@@ -893,7 +894,6 @@
 		90D8A9DDE9FE88189636C58F /* TransformContents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransformContents.swift; sourceTree = "<group>"; };
 		914E58605DF47952DCCB0653 /* NotificationSettingsSheetController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsSheetController.swift; sourceTree = "<group>"; };
 		91B282C71181CC075A6EF957 /* RuntimeUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeUtils.swift; sourceTree = "<group>"; };
-		92C8374F1D010ACCD06C3F39 /* Pods-MezonChat.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MezonChat.debug.xcconfig"; path = "Target Support Files/Pods-MezonChat/Pods-MezonChat.debug.xcconfig"; sourceTree = "<group>"; };
 		938CD478A6578D888E1A6C46 /* SharingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharingManager.swift; sourceTree = "<group>"; };
 		942246BD9C444A1F0D4FC84C /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		949E52C35D137BC83370B3E5 /* PreferencesTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesTable.swift; sourceTree = "<group>"; };
@@ -966,6 +966,7 @@
 		B2D2F5ECB3CF7C64DB76F934 /* FriendRequestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendRequestViewController.swift; sourceTree = "<group>"; };
 		B2E51B5A7E4D668AC3A8ECE3 /* NavigationTransitionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationTransitionCoordinator.swift; sourceTree = "<group>"; };
 		B3FBFF6B270E3C4E4B55F1A5 /* PollData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollData.swift; sourceTree = "<group>"; };
+		B4500B3B18ABB90261B71DB0 /* Pods-MezonChat.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MezonChat.debug.xcconfig"; path = "Target Support Files/Pods-MezonChat/Pods-MezonChat.debug.xcconfig"; sourceTree = "<group>"; };
 		B48A2B7C54658E4FF8C4C4AC /* PeerCallVideoRenderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerCallVideoRenderView.swift; sourceTree = "<group>"; };
 		B4D69DC509BC57816F86328C /* UIViewController+Navigation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Navigation.h"; sourceTree = "<group>"; };
 		B4E9A9FA5EBA97181B5FBE05 /* TransformImageArguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransformImageArguments.swift; sourceTree = "<group>"; };
@@ -1129,7 +1130,6 @@
 		F4246A30A1CCB6800D4FBEA7 /* ClanMemberView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClanMemberView.swift; sourceTree = "<group>"; };
 		F459C315BF26CCB81156CB4C /* SharedAccountContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedAccountContext.swift; sourceTree = "<group>"; };
 		F478EAE98B5D006F30DC4771 /* ChannelAppNodes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelAppNodes.swift; sourceTree = "<group>"; };
-		F4BB9AD4EAB9B69253A5BBA1 /* Pods_MezonChat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MezonChat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F57350295E15EA5F8E811509 /* TabBarControllerNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarControllerNode.swift; sourceTree = "<group>"; };
 		F5A86910C224D6AE8B32CDF6 /* NavigationOverlayContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationOverlayContainer.swift; sourceTree = "<group>"; };
 		F60ECB1D09A821409B2999A5 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -1161,7 +1161,7 @@
 				0F1B01761353884FA4FBAAA0 /* LiveKit in Frameworks */,
 				E198763D3F940271D8AC6957 /* LiveKitWebRTC in Frameworks */,
 				969538DEB3C57CBDDCBF47E0 /* SwiftProtobuf in Frameworks */,
-				47881456FF6F732A054344CB /* Pods_MezonChat.framework in Frameworks */,
+				631E24FBE4430AB85919D702 /* Pods_MezonChat.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1739,6 +1739,14 @@
 			path = Tabs;
 			sourceTree = "<group>";
 		};
+		61368490FADF9BBC394E0D2E /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				85FE52C4CBE33EA29337838A /* Pods_MezonChat.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		6234DF10D7F5EC9259A35E98 /* Messages */ = {
 			isa = PBXGroup;
 			children = (
@@ -1832,7 +1840,7 @@
 				CD7E9FEB6B0B50ABBC05F659 /* NotificationService */,
 				EA83705E3BB7ABF26349CE36 /* Pods */,
 				5D009DF3818076C7CDE50BF0 /* Products */,
-				FD932A7F24F9ABD7CB306192 /* Frameworks */,
+				61368490FADF9BBC394E0D2E /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -2415,8 +2423,8 @@
 			isa = PBXGroup;
 			children = (
 				1813841AB9729992EC4419D3 /* Target Support Files */,
-				92C8374F1D010ACCD06C3F39 /* Pods-MezonChat.debug.xcconfig */,
-				3C190EBB2A494DED6B6050D2 /* Pods-MezonChat.release.xcconfig */,
+				B4500B3B18ABB90261B71DB0 /* Pods-MezonChat.debug.xcconfig */,
+				7BCEB69B2269CC9BB78458BD /* Pods-MezonChat.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -2521,14 +2529,6 @@
 			path = Roles;
 			sourceTree = "<group>";
 		};
-		FD932A7F24F9ABD7CB306192 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				F4BB9AD4EAB9B69253A5BBA1 /* Pods_MezonChat.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		FF266101A20702F6EE625F0A /* VerifyOTP */ = {
 			isa = PBXGroup;
 			children = (
@@ -2559,14 +2559,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = EC72BD5A9A9D143AE179DBD5 /* Build configuration list for PBXNativeTarget "MezonChat" */;
 			buildPhases = (
-				DD45CFAB6C6DB0328F7E89DF /* [CP] Check Pods Manifest.lock */,
+				5FE950E08A59AE496783A35D /* [CP] Check Pods Manifest.lock */,
 				92A6A179EF8E12E0B4022079 /* Validate Secrets.swift */,
 				19F4DA105C897E310E067B9B /* Sources */,
 				BE4910FC6D318402623B7340 /* Resources */,
 				5A295EE582C60FFCE8897D74 /* Frameworks */,
 				F43D6A2CE84BF39FC2D3BE56 /* Embed Foundation Extensions */,
 				99F43EB3C132A8A6F8012E98 /* Generate LiveKitWebRTC dSYM */,
-				B96CFF2FCE64B4395AE93990 /* [CP] Copy Pods Resources */,
+				A3D8613CBC06FBC32F6EAE61 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -2673,6 +2673,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		5FE950E08A59AE496783A35D /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-MezonChat-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		92A6A179EF8E12E0B4022079 /* Validate Secrets.swift */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -2711,7 +2733,7 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"${SRCROOT}/scripts/generate_livekit_webrtc_dsym.sh\"\n";
 		};
-		B96CFF2FCE64B4395AE93990 /* [CP] Copy Pods Resources */ = {
+		A3D8613CBC06FBC32F6EAE61 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2730,28 +2752,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MezonChat/Pods-MezonChat-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		DD45CFAB6C6DB0328F7E89DF /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-MezonChat-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -3373,7 +3373,7 @@
 		};
 		433A5251B2769A74EDD27D32 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3C190EBB2A494DED6B6050D2 /* Pods-MezonChat.release.xcconfig */;
+			baseConfigurationReference = 7BCEB69B2269CC9BB78458BD /* Pods-MezonChat.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -3459,7 +3459,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = NotificationService/NotificationService.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = E9Y2J54ZH3;
 				INFOPLIST_FILE = NotificationService/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3480,7 +3480,7 @@
 				CODE_SIGN_ENTITLEMENTS = MezonSharing/MezonSharing.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = E9Y2J54ZH3;
 				INFOPLIST_FILE = MezonSharing/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3499,7 +3499,7 @@
 		};
 		D6110184B3C571C58191E396 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 92C8374F1D010ACCD06C3F39 /* Pods-MezonChat.debug.xcconfig */;
+			baseConfigurationReference = B4500B3B18ABB90261B71DB0 /* Pods-MezonChat.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -3508,7 +3508,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = E9Y2J54ZH3;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",

--- a/MezonChat/Core/Localization/L10n.swift
+++ b/MezonChat/Core/Localization/L10n.swift
@@ -261,6 +261,8 @@ enum L10n {
         static let luckyMoneyWalletNotReady = "qrScanner.luckyMoneyWalletNotReady"
         static let luckyMoneyServiceNotConfigured = "qrScanner.luckyMoneyServiceNotConfigured"
         static let luckyMoneyInvalidPayload = "qrScanner.luckyMoneyInvalidPayload"
+        static let scannedPayloadTitle = "qrScanner.scannedPayloadTitle"
+        static let copyContent = "qrScanner.copyContent"
     }
 
     enum Language {
@@ -522,9 +524,18 @@ enum L10n {
         static let success                = "forward.success"
         static let attachmentsSingular    = "forward.attachmentsSingular"
         static let attachmentsPlural      = "forward.attachmentsPlural"
+        static let filesSingular          = "forward.filesSingular"
+        static let filesPlural            = "forward.filesPlural"
+        static let audioSingular          = "forward.audioSingular"
+        static let audioPlural            = "forward.audioPlural"
         static let moreBundledMessages    = "forward.moreBundledMessages"
         static let previewPlaceholder     = "forward.previewPlaceholder"
         static let commentTooLong        = "forward.commentTooLong"
+        static let noResults             = "forward.noResults"
+        static let blockedByYou          = "forward.blockedByYou"
+        static let blockedYou            = "forward.blockedYou"
+        static let cannotMessage         = "forward.cannotMessage"
+        static let toastCannotForward    = "forward.toastCannotForward"
     }
 
     enum Sharing {
@@ -1269,9 +1280,18 @@ extension L10n {
         "forward.success": "Messages forwarded",
         "forward.attachmentsSingular": "attachment",
         "forward.attachmentsPlural": "attachments",
+        "forward.filesSingular": "file",
+        "forward.filesPlural": "files",
+        "forward.audioSingular": "audio",
+        "forward.audioPlural": "audio",
         "forward.moreBundledMessages": "more messages included",
         "forward.previewPlaceholder": "Message preview",
         "forward.commentTooLong": "Comment is too long",
+        "forward.noResults": "No results found",
+        "forward.blockedByYou": "You blocked this user",
+        "forward.blockedYou": "This user blocked you",
+        "forward.cannotMessage": "You can't message each other",
+        "forward.toastCannotForward": "You can't forward messages to this conversation",
 
         "sharing.title":                    "Share",
         "sharing.suggestionsSection":       "Suggestions",
@@ -1504,7 +1524,7 @@ extension L10n {
         "messageAction.giveACoffee": "Give A Coffee",
         "messageAction.giveCoffeeSuccess": "Coffee sent",
         "messageAction.forwardMessage": "Forward Message",
-        "messageAction.forwardAll": "Forward all nearby",
+        "messageAction.forwardAll": "Forward All Nearby",
         "messageAction.createThread": "Create Thread",
         "messageAction.markUnread": "Mark Unread",
         "messageAction.topicDiscussion": "Topic Discussion",
@@ -1652,6 +1672,8 @@ extension L10n {
         "qrScanner.luckyMoneyWalletNotReady": "Wallet is not ready. Please try again later.",
         "qrScanner.luckyMoneyServiceNotConfigured": "Claim service is not configured.",
         "qrScanner.luckyMoneyInvalidPayload": "This QR code is not valid lucky money.",
+        "qrScanner.scannedPayloadTitle": "Scanned content",
+        "qrScanner.copyContent": "Copy",
 
         "error.networkError": "Network Error",
         "error.connectionFailed": "Connection failed. Please try again.",
@@ -2077,9 +2099,18 @@ extension L10n {
         "forward.success": "Đã chuyển tiếp tin nhắn",
         "forward.attachmentsSingular": "đính kèm",
         "forward.attachmentsPlural": "đính kèm",
+        "forward.filesSingular": "tệp",
+        "forward.filesPlural": "tệp",
+        "forward.audioSingular": "âm thanh",
+        "forward.audioPlural": "âm thanh",
         "forward.moreBundledMessages": "tin nhắn khác được gộp",
         "forward.previewPlaceholder": "Xem trước tin nhắn",
         "forward.commentTooLong": "Nội dung nhập quá dài",
+        "forward.noResults": "Không tìm thấy kết quả",
+        "forward.blockedByYou": "Bạn đã chặn người dùng này",
+        "forward.blockedYou": "Người dùng này đã chặn bạn",
+        "forward.cannotMessage": "Không thể nhắn tin cho nhau",
+        "forward.toastCannotForward": "Không thể chuyển tiếp tin nhắn tới cuộc trò chuyện này",
 
         "sharing.title":                    "Chia sẻ",
         "sharing.suggestionsSection":       "Gợi ý",
@@ -2459,6 +2490,8 @@ extension L10n {
         "qrScanner.luckyMoneyWalletNotReady": "Ví chưa sẵn sàng. Vui lòng thử lại sau.",
         "qrScanner.luckyMoneyServiceNotConfigured": "Dịch vụ nhận lì xì chưa được cấu hình.",
         "qrScanner.luckyMoneyInvalidPayload": "Mã QR không phải lì xì hợp lệ.",
+        "qrScanner.scannedPayloadTitle": "Nội dung quét được",
+        "qrScanner.copyContent": "Sao chép",
 
         "error.networkError": "Lỗi kết nối mạng",
         "error.connectionFailed": "Kết nối thất bại. Vui lòng thử lại.",

--- a/MezonChat/Core/MezonEngine/MezonEngine+ClanData.swift
+++ b/MezonChat/Core/MezonEngine/MezonEngine+ClanData.swift
@@ -567,6 +567,12 @@ extension MezonEngine {
             pendingIncomingFriends().count
         }
 
+        func blockedUserIds() -> Set<Int64> {
+            Set(allFriends().filter { friend in
+                friend.state == EStateFriend.block.rawValue && friend.hasUser && friend.user.id != 0
+            }.map(\.user.id))
+        }
+
         func lookupByUsername() -> [String: Mezon_Api_Friend] {
             var result: [String: Mezon_Api_Friend] = [:]
             for friend in allFriends() {

--- a/MezonChat/Core/Postbox/Messages/MessageRecord.swift
+++ b/MezonChat/Core/Postbox/Messages/MessageRecord.swift
@@ -75,9 +75,12 @@ extension MessageRecord {
         let isPoll = api.code == 18 || parsedPoll != nil
         
         let createdAt   = Date(timeIntervalSince1970: TimeInterval(api.createTimeSeconds))
+        let isClanContext = api.clanID != 0
         let displayName: String = {
-            let cn = api.clanNick.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !cn.isEmpty { return cn }
+            if isClanContext {
+                let cn = api.clanNick.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !cn.isEmpty { return cn }
+            }
             let dn = api.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
             if !dn.isEmpty { return dn }
             let un = api.username.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -85,8 +88,10 @@ extension MessageRecord {
             return "\(api.senderID)"
         }()
         let avatarURL: String? = {
-            let ca = api.clanAvatar.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !ca.isEmpty { return ca }
+            if isClanContext {
+                let ca = api.clanAvatar.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !ca.isEmpty { return ca }
+            }
             let av = api.avatar.trimmingCharacters(in: .whitespacesAndNewlines)
             if !av.isEmpty { return av }
             return nil
@@ -153,9 +158,12 @@ extension MessageRecord {
                 mentionsJSON: fresh.mentionsJSON
             )
         }
-        let nick = api.clanNick.trimmingCharacters(in: .whitespacesAndNewlines)
-        let clanAv = api.clanAvatar.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !nick.isEmpty || !clanAv.isEmpty { return fresh }
+        let isClanContext = api.clanID != 0
+        if isClanContext {
+            let nick = api.clanNick.trimmingCharacters(in: .whitespacesAndNewlines)
+            let clanAv = api.clanAvatar.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !nick.isEmpty || !clanAv.isEmpty { return fresh }
+        }
         let dn = api.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
         let un = api.username.trimmingCharacters(in: .whitespacesAndNewlines)
         let av = api.avatar.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/MezonChat/Core/Postbox/Messages/MessageTable.swift
+++ b/MezonChat/Core/Postbox/Messages/MessageTable.swift
@@ -179,8 +179,9 @@ final class MessageTable: Table {
 
             if !msg.id.hasPrefix("pending-") {
                 if let pidx = current.firstIndex(where: { serverEchoMatchesPending(server: msg, pending: $0) }) {
-                    let pid = current[pidx].id
-                    current[pidx] = msg
+                    let pending = current[pidx]
+                    let pid = pending.id
+                    current[pidx] = Self.mergePendingIdentityIntoServerEcho(pending: pending, server: msg)
                     pendingDeletes.insert(pid)
                 } else if let idx = current.firstIndex(where: { $0.id == msg.id }) {
                     current[idx] = msg
@@ -196,6 +197,40 @@ final class MessageTable: Table {
             cache[msg.channelId] = current
             pendingWrites.insert(msg.channelId)
         }
+    }
+
+    private static func mergePendingIdentityIntoServerEcho(pending: MessageRecord, server: MessageRecord) -> MessageRecord {
+        let pendingName = pending.senderDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let serverName = server.senderDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let useName: String = {
+            if pendingName.isEmpty { return server.senderDisplayName }
+            if serverName.isEmpty { return pending.senderDisplayName }
+            if serverName == pending.senderId { return pending.senderDisplayName }
+            return pending.senderDisplayName
+        }()
+        let useAvatar: String? = {
+            let pa = pending.senderAvatarURL?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if !pa.isEmpty { return pending.senderAvatarURL }
+            return server.senderAvatarURL
+        }()
+        return MessageRecord(
+            id: server.id,
+            channelId: server.channelId,
+            clanId: server.clanId,
+            senderId: server.senderId,
+            content: server.content,
+            createdAt: server.createdAt,
+            editedAt: server.editedAt,
+            isDeleted: server.isDeleted,
+            code: server.code,
+            senderDisplayName: useName,
+            senderAvatarURL: useAvatar,
+            sendingState: server.sendingState,
+            attachmentsJSON: server.attachmentsJSON,
+            reactionsJSON: server.reactionsJSON,
+            referencesData: server.referencesData,
+            mentionsJSON: server.mentionsJSON
+        )
     }
 
     func replaceAllMessages(_ messages: [MessageRecord], channelId: String) {

--- a/MezonChat/Features/Chat/ChatViewController.swift
+++ b/MezonChat/Features/Chat/ChatViewController.swift
@@ -4009,15 +4009,23 @@ final class ChatViewController: ViewController {
     }
 
     private func presentForwardMessage(for display: ChatMessageDisplay, includeAdjacentNewer: Bool) {
+        let displays: [ChatMessageDisplay] = includeAdjacentNewer
+            ? forwardDisplaysAdjacentNewer(from: display)
+            : [display]
         let records = recordsForForward(selected: display, includeAdjacentNewer: includeAdjacentNewer)
         guard !records.isEmpty else {
             Toast.error(L(L10n.Sharing.errorTitle))
             return
         }
+        var attachmentHints: [String: [ParsedAttachment]] = [:]
+        for d in displays where !d.attachments.isEmpty {
+            attachmentHints[d.id] = d.attachments
+        }
         let vc = ForwardMessageViewController(
             context: context,
             messagesToForward: records,
-            forwardFromChannelID: channel.channelID
+            forwardFromChannelID: channel.channelID,
+            attachmentHints: attachmentHints
         )
         var presenter: UIViewController = self
         while let presented = presenter.presentedViewController {

--- a/MezonChat/Features/Chat/ForwardMessageViewController.swift
+++ b/MezonChat/Features/Chat/ForwardMessageViewController.swift
@@ -15,12 +15,252 @@ private enum ForwardOutgoing {
         return #"{"fwd":true}"#
     }
 
-    static func attachments(for record: MessageRecord) -> [Mezon_Api_MessageAttachment] {
-        guard !record.attachmentsJSON.isEmpty else { return [] }
-        if let list = try? Mezon_Api_MessageAttachmentList(serializedBytes: record.attachmentsJSON) {
-            return list.attachments
+    static func attachments(for record: MessageRecord, fallback: [ParsedAttachment] = []) -> [Mezon_Api_MessageAttachment] {
+        parsedAttachments(for: record, fallback: fallback).map { p in
+            var att = Mezon_Api_MessageAttachment()
+            att.url = p.url
+            att.filename = p.filename
+            att.filetype = p.filetype
+            if let w = p.width { att.width = Int32(w) }
+            if let h = p.height { att.height = Int32(h) }
+            if let d = p.durationSeconds { att.duration = Int32(d) }
+            return att
         }
-        return []
+    }
+
+    static func parsedAttachments(for record: MessageRecord, fallback: [ParsedAttachment] = []) -> [ParsedAttachment] {
+        var out: [ParsedAttachment] = []
+        var seen = Set<String>()
+        let append: ([ParsedAttachment]) -> Void = { items in
+            for item in items {
+                let key = attachmentDedupeKey(item)
+                guard !key.isEmpty, !seen.contains(key) else { continue }
+                seen.insert(key)
+                out.append(item)
+            }
+        }
+        append(parsedAttachments(fromColumnData: record.attachmentsJSON))
+        append(parsedAttachments(fromContentData: record.content))
+        append(fallback)
+        return out
+    }
+
+    private static func attachmentDedupeKey(_ item: ParsedAttachment) -> String {
+        let u = item.url.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !u.isEmpty { return u }
+        let name = item.filename.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !name.isEmpty { return "name:\(name)" }
+        return ""
+    }
+
+    private static func parsedAttachments(fromColumnData data: Data, didUnwrapBase64: Bool = false) -> [ParsedAttachment] {
+        guard !data.isEmpty else { return [] }
+
+        if !didUnwrapBase64, let decoded = parsedAttachmentsFromBase64Wrapped(data) {
+            return decoded
+        }
+
+        let isLikelyJson = data.first == UInt8(ascii: "[") || data.first == UInt8(ascii: "{")
+        if !isLikelyJson {
+            if let list = try? Mezon_Api_MessageAttachmentList(serializedBytes: data),
+               !list.attachments.isEmpty {
+                let parsed = list.attachments.compactMap(parsedAttachment(from:))
+                if !parsed.isEmpty { return parsed }
+            }
+            if let list = try? Mezon_Api_ChannelAttachmentList(serializedBytes: data),
+               !list.attachments.isEmpty {
+                return list.attachments.map(parsedAttachment(fromChannel:))
+            }
+            if let list = try? Mezon_Api_ListChannelTimelineAttachment(serializedBytes: data),
+               !list.attachments.isEmpty {
+                return list.attachments.map(parsedAttachment(fromTimeline:))
+            }
+        }
+
+        return parsedAttachments(fromJSONData: data)
+    }
+
+    private static func parsedAttachmentsFromBase64Wrapped(_ data: Data) -> [ParsedAttachment]? {
+        let ascii = data.reduce(true) { ok, b in ok && (b == 9 || b == 10 || b == 13 || b == 32 || (b >= 43 && b <= 122)) }
+        guard ascii,
+              let s = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              s.count >= 16,
+              let inner = Data(base64Encoded: s),
+              inner.count >= 8,
+              inner != data else {
+            return nil
+        }
+        let innerResult = parsedAttachments(fromColumnData: inner, didUnwrapBase64: true)
+        return innerResult.isEmpty ? nil : innerResult
+    }
+
+    private static func parsedAttachments(fromContentData data: Data) -> [ParsedAttachment] {
+        guard !data.isEmpty,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return []
+        }
+        var items: [[String: Any]] = []
+        for key in ["attachments", "a", "at"] {
+            if let arr = json[key] as? [[String: Any]] {
+                items.append(contentsOf: arr)
+            } else if let arr = json[key] as? [Any] {
+                items.append(contentsOf: arr.compactMap { $0 as? [String: Any] })
+            }
+        }
+        if let one = json["attachment"] as? [String: Any] {
+            items.append(one)
+        }
+        return items.compactMap(parsedAttachment(fromJSONItem:))
+    }
+
+    private static func parsedAttachments(fromJSONData data: Data) -> [ParsedAttachment] {
+        var jsonArray: [[String: Any]]?
+        if let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] {
+            jsonArray = arr
+        } else if let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            if let arr = dict["attachments"] as? [[String: Any]] {
+                jsonArray = arr
+            } else if let arr = dict["a"] as? [[String: Any]] {
+                jsonArray = arr
+            } else if jsonItemLooksLikeAttachment(dict) {
+                jsonArray = [dict]
+            }
+        } else if let str = String(data: data, encoding: .utf8),
+                  let strData = str.data(using: .utf8),
+                  let arr = try? JSONSerialization.jsonObject(with: strData) as? [[String: Any]] {
+            jsonArray = arr
+        }
+        guard let jsonArray else { return [] }
+        return jsonArray.compactMap(parsedAttachment(fromJSONItem:))
+    }
+
+    private static func jsonItemLooksLikeAttachment(_ dict: [String: Any]) -> Bool {
+        let u = jsonAttachmentURL(from: dict)
+        let name = jsonAttachmentFilename(from: dict)
+        return !u.isEmpty || !name.isEmpty
+    }
+
+    private static func jsonAttachmentURL(from dict: [String: Any]) -> String {
+        for key in ["url", "uri", "file_url", "fileUrl", "fileURL", "link"] {
+            if let s = dict[key] as? String {
+                let t = s.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !t.isEmpty { return t }
+            }
+        }
+        return (dict["thumbnail"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    }
+
+    private static func jsonAttachmentFilename(from dict: [String: Any]) -> String {
+        for key in ["filename", "file_name", "fileName"] {
+            if let s = dict[key] as? String {
+                let t = s.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !t.isEmpty { return t }
+            }
+        }
+        return ""
+    }
+
+    private static func parsedAttachment(from att: Mezon_Api_MessageAttachment) -> ParsedAttachment? {
+        let urlPrimary = att.url.trimmingCharacters(in: .whitespacesAndNewlines)
+        let thumb = att.thumbnail.trimmingCharacters(in: .whitespacesAndNewlines)
+        let urlStr = !urlPrimary.isEmpty ? urlPrimary : thumb
+        guard !urlStr.isEmpty else { return nil }
+        return ParsedAttachment(
+            url: urlStr,
+            filename: att.filename,
+            filetype: att.filetype,
+            width: att.width != 0 ? Int(att.width) : nil,
+            height: att.height != 0 ? Int(att.height) : nil,
+            durationSeconds: att.duration > 0 ? Int(att.duration) : nil
+        )
+    }
+
+    private static func parsedAttachment(fromChannel att: Mezon_Api_ChannelAttachment) -> ParsedAttachment {
+        ParsedAttachment(
+            url: att.url,
+            filename: att.filename,
+            filetype: att.filetype,
+            width: att.width == 0 ? nil : Int(att.width),
+            height: att.height == 0 ? nil : Int(att.height),
+            durationSeconds: nil
+        )
+    }
+
+    private static func parsedAttachment(fromTimeline att: Mezon_Api_ChannelTimelineAttachment) -> ParsedAttachment {
+        let urlStr = att.fileURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let thumb = att.thumbnail.trimmingCharacters(in: .whitespacesAndNewlines)
+        return ParsedAttachment(
+            url: !urlStr.isEmpty ? urlStr : thumb,
+            filename: att.fileName,
+            filetype: att.fileType,
+            width: att.width == 0 ? nil : Int(att.width),
+            height: att.height == 0 ? nil : Int(att.height),
+            durationSeconds: att.duration > 0 ? Int(att.duration) : nil
+        )
+    }
+
+    private static func parsedAttachment(fromJSONItem item: [String: Any]) -> ParsedAttachment? {
+        let urlStr = jsonAttachmentURL(from: item)
+        let filename = jsonAttachmentFilename(from: item)
+        guard !urlStr.isEmpty || !filename.isEmpty else { return nil }
+        let w = item["width"] as? Int ?? (item["width"] as? String).flatMap { Int($0) }
+        let h = item["height"] as? Int ?? (item["height"] as? String).flatMap { Int($0) }
+        let d: Int? = {
+            if let n = item["duration"] as? Int { return n > 0 ? n : nil }
+            if let n = item["duration"] as? Int64 { return n > 0 ? Int(n) : nil }
+            if let s = item["duration"] as? String, let n = Int(s) { return n > 0 ? n : nil }
+            return nil
+        }()
+        let ftRaw = (item["filetype"] as? String
+            ?? item["file_type"] as? String
+            ?? item["fileType"] as? String
+            ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        return ParsedAttachment(
+            url: !urlStr.isEmpty ? urlStr : filename,
+            filename: filename,
+            filetype: ftRaw,
+            width: w,
+            height: h,
+            durationSeconds: d
+        )
+    }
+
+    static func attachmentPreviewLine(for record: MessageRecord, fallback: [ParsedAttachment] = []) -> String? {
+        let parsed = parsedAttachments(for: record, fallback: fallback)
+        guard !parsed.isEmpty else { return nil }
+
+        let mediaCount = parsed.filter(\.isMedia).count
+        let audioCount = parsed.filter { $0.isAudio && !$0.isMedia }.count
+        let fileCount = parsed.filter { !$0.isMedia && !$0.isAudio }.count
+
+        var segments: [String] = []
+        if mediaCount > 0 {
+            segments.append(countPhrase(
+                mediaCount,
+                singular: L10n.Forward.attachmentsSingular,
+                plural: L10n.Forward.attachmentsPlural
+            ))
+        }
+        if fileCount > 0 {
+            segments.append(countPhrase(
+                fileCount,
+                singular: L10n.Forward.filesSingular,
+                plural: L10n.Forward.filesPlural
+            ))
+        }
+        if audioCount > 0 {
+            segments.append(countPhrase(
+                audioCount,
+                singular: L10n.Forward.audioSingular,
+                plural: L10n.Forward.audioPlural
+            ))
+        }
+        return segments.isEmpty ? nil : segments.joined(separator: ", ")
+    }
+
+    private static func countPhrase(_ count: Int, singular: String, plural: String) -> String {
+        let label = count == 1 ? L(singular) : L(plural)
+        return "\(count) \(label)"
     }
 
     static func mentions(
@@ -81,6 +321,7 @@ final class ForwardMessageViewController: UIViewController {
 
     private let context: AccountContext
     private let messagesToForward: [MessageRecord]
+    private let attachmentHints: [String: [ParsedAttachment]]
     private let forwardFromChannelID: Int64
 
     private var suggestions: [SharingSuggestionItem] = []
@@ -88,6 +329,8 @@ final class ForwardMessageViewController: UIViewController {
     private var channelMap: [Int64: Mezon_Api_ChannelDescription] = [:]
     private var clanNames: [Int64: String] = [:]
     private var clanLogos: [Int64: String] = [:]
+    private var blockedByMeUserIds: Set<Int64> = []
+    private var forwardBlockNoteByChannelId: [Int64: String] = [:]
 
     private var selectedIDs: Set<Int64> = []
     private var searchText = ""
@@ -99,12 +342,24 @@ final class ForwardMessageViewController: UIViewController {
     private lazy var searchIcon = UIImageView()
     private lazy var searchField = UITextField()
     private lazy var previewCard = UIView()
+    private lazy var previewAttLbl = UILabel()
     private lazy var previewLbl = UILabel()
+    private var previewTextTopToAttConstraint: NSLayoutConstraint?
+    private var previewTextTopToCardConstraint: NSLayoutConstraint?
     private lazy var tableView: UITableView = {
         let t = UITableView(frame: .zero, style: .plain)
         t.separatorStyle = .none
         t.keyboardDismissMode = .interactive
         return t
+    }()
+    private let emptyResultsLabel: UILabel = {
+        let l = UILabel()
+        l.translatesAutoresizingMaskIntoConstraints = false
+        l.font = .systemFont(ofSize: 14, weight: .regular)
+        l.textAlignment = .center
+        l.numberOfLines = 0
+        l.isHidden = true
+        return l
     }()
     private lazy var inputBg = UIView()
     private lazy var commentField = UITextField()
@@ -118,10 +373,12 @@ final class ForwardMessageViewController: UIViewController {
     init(
         context: AccountContext,
         messagesToForward: [MessageRecord],
-        forwardFromChannelID: Int64
+        forwardFromChannelID: Int64,
+        attachmentHints: [String: [ParsedAttachment]] = [:]
     ) {
         self.context = context
         self.messagesToForward = messagesToForward
+        self.attachmentHints = attachmentHints
         self.forwardFromChannelID = forwardFromChannelID
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .fullScreen
@@ -153,6 +410,7 @@ final class ForwardMessageViewController: UIViewController {
             attributes: [.foregroundColor: UIColor.theme.textDisabled.withAlphaComponent(0.85)]
         )
         updatePreviewLabel()
+        updateEmptyResultsVisibility()
         tableView.reloadData()
     }
 
@@ -175,7 +433,9 @@ final class ForwardMessageViewController: UIViewController {
         searchIcon.tintColor = t.textDisabled
         searchField.textColor = t.textStrong
         previewCard.backgroundColor = t.secondary
+        previewAttLbl.textColor = t.textStrong
         previewLbl.textColor = t.textStrong
+        emptyResultsLabel.textColor = t.textDisabled
         inputBg.backgroundColor = t.secondary
         commentField.textColor = t.textStrong
         refreshSendButtonVisual()
@@ -198,6 +458,9 @@ final class ForwardMessageViewController: UIViewController {
         searchField.addTarget(self, action: #selector(searchChanged(_:)), for: .editingChanged)
 
         previewCard.layer.cornerRadius = 12
+        previewAttLbl.font = .systemFont(ofSize: 14, weight: .medium)
+        previewAttLbl.numberOfLines = 2
+        previewAttLbl.isHidden = true
         previewLbl.font = .systemFont(ofSize: 14)
         previewLbl.numberOfLines = 4
 
@@ -229,6 +492,7 @@ final class ForwardMessageViewController: UIViewController {
         searchIcon.translatesAutoresizingMaskIntoConstraints = false
         searchField.translatesAutoresizingMaskIntoConstraints = false
         previewCard.translatesAutoresizingMaskIntoConstraints = false
+        previewAttLbl.translatesAutoresizingMaskIntoConstraints = false
         previewLbl.translatesAutoresizingMaskIntoConstraints = false
         tableView.translatesAutoresizingMaskIntoConstraints = false
         inputBg.translatesAutoresizingMaskIntoConstraints = false
@@ -244,8 +508,10 @@ final class ForwardMessageViewController: UIViewController {
         searchWrap.addSubview(searchIcon)
         searchWrap.addSubview(searchField)
         view.addSubview(previewCard)
+        previewCard.addSubview(previewAttLbl)
         previewCard.addSubview(previewLbl)
         view.addSubview(tableView)
+        view.addSubview(emptyResultsLabel)
         view.addSubview(bottomBar)
         bottomBar.addSubview(inputBg)
         bottomBar.addSubview(sendBtn)
@@ -283,15 +549,21 @@ final class ForwardMessageViewController: UIViewController {
             previewCard.topAnchor.constraint(equalTo: searchWrap.bottomAnchor, constant: 14),
             previewCard.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
             previewCard.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
-            previewLbl.topAnchor.constraint(equalTo: previewCard.topAnchor, constant: 10),
-            previewLbl.bottomAnchor.constraint(equalTo: previewCard.bottomAnchor, constant: -10),
+            previewAttLbl.topAnchor.constraint(equalTo: previewCard.topAnchor, constant: 10),
+            previewAttLbl.leadingAnchor.constraint(equalTo: previewCard.leadingAnchor, constant: 12),
+            previewAttLbl.trailingAnchor.constraint(equalTo: previewCard.trailingAnchor, constant: -12),
             previewLbl.leadingAnchor.constraint(equalTo: previewCard.leadingAnchor, constant: 12),
             previewLbl.trailingAnchor.constraint(equalTo: previewCard.trailingAnchor, constant: -12),
+            previewLbl.bottomAnchor.constraint(equalTo: previewCard.bottomAnchor, constant: -10),
 
             tableView.topAnchor.constraint(equalTo: previewCard.bottomAnchor, constant: 14),
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: bottomBar.topAnchor, constant: -12),
+
+            emptyResultsLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
+            emptyResultsLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
+            emptyResultsLabel.centerYAnchor.constraint(equalTo: tableView.centerYAnchor),
 
             bottomBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             bottomBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
@@ -313,6 +585,10 @@ final class ForwardMessageViewController: UIViewController {
 
             composerPad,
         ])
+
+        previewTextTopToAttConstraint = previewLbl.topAnchor.constraint(equalTo: previewAttLbl.bottomAnchor, constant: 6)
+        previewTextTopToCardConstraint = previewLbl.topAnchor.constraint(equalTo: previewCard.topAnchor, constant: 10)
+        previewTextTopToCardConstraint?.isActive = true
 
         applyTheme()
 
@@ -371,6 +647,68 @@ final class ForwardMessageViewController: UIViewController {
         return 0
     }
 
+    private func isUserFacingDMType(_ type: Int32) -> Bool {
+        type == MezonConstants.ChannelType.dm.rawValue || type == MezonConstants.ChannelType.group.rawValue
+    }
+
+    private func isSharableClanChannelType(_ type: Int32) -> Bool {
+        type == MezonConstants.ChannelType.channel.rawValue
+            || type == MezonConstants.ChannelType.thread.rawValue
+            || type == MezonConstants.ChannelType.announcement.rawValue
+    }
+
+    private func currentUserId() -> Int64? {
+        guard let id = context.currentUser?.id, let v = Int64(id) else { return nil }
+        return v
+    }
+
+    private func peerUserIds(in channel: Mezon_Api_ChannelDescription) -> [Int64] {
+        guard let myId = currentUserId() else {
+            return channel.userIds.filter { $0 != 0 }
+        }
+        return channel.userIds.filter { $0 != 0 && $0 != myId }
+    }
+
+    private func rebuildForwardBlockNotes() {
+        forwardBlockNoteByChannelId.removeAll(keepingCapacity: true)
+        guard !blockedByMeUserIds.isEmpty else { return }
+        for (_, ch) in channelMap {
+            guard isUserFacingDMType(ch.type) else { continue }
+            let peers = peerUserIds(in: ch)
+            guard peers.contains(where: { blockedByMeUserIds.contains($0) }) else { continue }
+            let note: String
+            if ch.type == MezonConstants.ChannelType.dm.rawValue, peers.count == 1 {
+                note = L(L10n.Forward.blockedByYou)
+            } else {
+                note = L(L10n.Forward.cannotMessage)
+            }
+            forwardBlockNoteByChannelId[ch.channelID] = note
+        }
+    }
+
+    private func isForwardBlocked(channelId: Int64) -> Bool {
+        forwardBlockNoteByChannelId[channelId] != nil
+    }
+
+    private func forwardBlockNote(channelId: Int64) -> String? {
+        forwardBlockNoteByChannelId[channelId]
+    }
+
+    private func recencyTimestamp(for item: SharingSuggestionItem) -> UInt32 {
+        guard let ch = channelMap[item.channelID] else { return 0 }
+        return sharingRecencyTimestamp(ch)
+    }
+
+    private func sortSuggestionsByRecency(_ items: [SharingSuggestionItem]) -> [SharingSuggestionItem] {
+        let users = items.filter { isUserFacingDMType($0.type) }
+            .sorted { recencyTimestamp(for: $0) > recencyTimestamp(for: $1) }
+        let channels = items.filter { isSharableClanChannelType($0.type) }
+            .sorted { recencyTimestamp(for: $0) > recencyTimestamp(for: $1) }
+        let other = items.filter { !isUserFacingDMType($0.type) && !isSharableClanChannelType($0.type) }
+            .sorted { recencyTimestamp(for: $0) > recencyTimestamp(for: $1) }
+        return users + channels + other
+    }
+
     private func resolvedClanInfo(for ch: Mezon_Api_ChannelDescription) -> (clanID: Int64, channelClanName: String) {
         var clanID = ch.clanID
         var channelClanName = ch.clanName
@@ -391,6 +729,9 @@ final class ForwardMessageViewController: UIViewController {
             guard let self else { return }
             guard let token = await context.getToken() else { return }
 
+            await context.engine.friendsData.refreshFromNetwork(token: token)
+            blockedByMeUserIds = context.engine.friendsData.blockedUserIds()
+
             var dmList: [Mezon_Api_ChannelDescription] = []
             var clanList: [Mezon_Api_ChannelDescription] = []
 
@@ -408,7 +749,7 @@ final class ForwardMessageViewController: UIViewController {
                     if ch.usernames.contains(where: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) { return true }
                     return false
                 }
-                dmList.sort { self.sharingRecencyTimestamp($0) > self.sharingRecencyTimestamp($1) }
+                dmList = dmList.sorted { self.sharingRecencyTimestamp($0) > self.sharingRecencyTimestamp($1) }
             } catch {}
 
             if let allChannelsList = context.engine.clanData.getAllChannelsByUser() {
@@ -418,7 +759,7 @@ final class ForwardMessageViewController: UIViewController {
                         || t == MezonConstants.ChannelType.thread.rawValue
                         || t == MezonConstants.ChannelType.announcement.rawValue
                 }
-                clanList.sort { self.sharingRecencyTimestamp($0) > self.sharingRecencyTimestamp($1) }
+                clanList = clanList.sorted { self.sharingRecencyTimestamp($0) > self.sharingRecencyTimestamp($1) }
             }
 
             do {
@@ -443,7 +784,7 @@ final class ForwardMessageViewController: UIViewController {
                             || t == MezonConstants.ChannelType.thread.rawValue
                             || t == MezonConstants.ChannelType.announcement.rawValue
                     }
-                    clanList.sort { self.sharingRecencyTimestamp($0) > self.sharingRecencyTimestamp($1) }
+                    clanList = clanList.sorted { self.sharingRecencyTimestamp($0) > self.sharingRecencyTimestamp($1) }
                 } catch {}
             }
 
@@ -451,6 +792,7 @@ final class ForwardMessageViewController: UIViewController {
             for ch in dmList + clanList {
                 channelMap[ch.channelID] = ch
             }
+            rebuildForwardBlockNotes()
 
             var built: [SharingSuggestionItem] = []
             built.reserveCapacity(dmList.count + clanList.count)
@@ -495,6 +837,7 @@ final class ForwardMessageViewController: UIViewController {
             suggestions = built
             applyFilter(resetSelection: false)
             tableView.reloadData()
+            updateEmptyResultsVisibility()
         }
     }
 
@@ -517,8 +860,11 @@ final class ForwardMessageViewController: UIViewController {
             guard !q.isEmpty else { return true }
             if fold(item.displayName).contains(q) { return true }
             if let cn = item.clanName, fold(cn).contains(q) { return true }
-            if let ch,
-               fold(SharingChannelCell.displayName(for: ch)).contains(q) { return true }
+            guard let ch else { return false }
+            if !ch.channelLabel.isEmpty, fold(ch.channelLabel).contains(q) { return true }
+            if fold(SharingChannelCell.displayName(for: ch)).contains(q) { return true }
+            for u in ch.usernames where fold(u).contains(q) { return true }
+            for d in ch.displayNames where fold(d).contains(q) { return true }
             return false
         }
 
@@ -529,23 +875,19 @@ final class ForwardMessageViewController: UIViewController {
             filteredItems.sort {
                 forwardingDisplayName(for: $0).localizedCaseInsensitiveCompare(forwardingDisplayName(for: $1)) == .orderedAscending
             }
+        } else {
+            filteredItems = sortSuggestionsByRecency(filteredItems)
         }
+        updateEmptyResultsVisibility()
     }
 
-    private func foldingMatchSort(_ trimmed: String) -> [SharingSuggestionItem] {
-        let qFold = trimmed.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
-        guard !qFold.isEmpty else { return filteredItems }
-        return filteredItems.sorted { a, b in
-            let na = forwardingDisplayName(for: a).folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
-            let nb = forwardingDisplayName(for: b).folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
-            let xa = na == qFold
-            let xb = nb == qFold
-            if xa != xb { return xa && !xb }
-            let pa = na.hasPrefix(qFold)
-            let pb = nb.hasPrefix(qFold)
-            if pa != pb { return pa && !pb }
-            return na < nb
-        }
+    private func updateEmptyResultsVisibility() {
+        let trimmed = ForwardOutgoing.sanitizedComment(searchText)
+        let isSearching = !trimmed.isEmpty
+        let showEmpty = isSearching && displaySuggestions.isEmpty
+        emptyResultsLabel.text = L(L10n.Forward.noResults)
+        emptyResultsLabel.isHidden = !showEmpty
+        tableView.isScrollEnabled = !showEmpty
     }
 
     private func forwardingDisplayName(for item: SharingSuggestionItem) -> String {
@@ -556,37 +898,54 @@ final class ForwardMessageViewController: UIViewController {
     }
 
     private var displaySuggestions: [SharingSuggestionItem] {
-        let trimmed = ForwardOutgoing.sanitizedComment(searchText)
-        guard !trimmed.hasPrefix("#") else { return filteredItems }
-        return foldingMatchSort(trimmed)
+        filteredItems
     }
 
     private func updatePreviewLabel() {
         guard let first = messagesToForward.first else {
+            previewAttLbl.text = ""
             previewLbl.text = ""
+            setPreviewAttachmentVisible(false)
             return
         }
-        var parts: [String] = []
-        let text = Self.previewPlainText(for: first)
+        let hints = attachmentHints[first.id] ?? []
+        let attLine = ForwardOutgoing.attachmentPreviewLine(for: first, fallback: hints)
+        if let attLine {
+            previewAttLbl.text = attLine
+            setPreviewAttachmentVisible(true)
+        } else {
+            previewAttLbl.text = ""
+            setPreviewAttachmentVisible(false)
+        }
+
+        var textParts: [String] = []
+        let text = Self.previewPlainText(for: first, maxLength: attLine == nil ? 500 : 200)
         if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            parts.append(text)
+            textParts.append(text)
         }
-        let attcount = ForwardOutgoing.attachments(for: first).count
         let extra = messagesToForward.count - 1
-        if attcount > 0 {
-            parts.append(attcount > 1 ? "\(attcount) \(L(L10n.Forward.attachmentsPlural))" : "\(attcount) \(L(L10n.Forward.attachmentsSingular))")
-        }
         if extra > 0 {
-            parts.append("+\(extra) \(L(L10n.Forward.moreBundledMessages))")
+            textParts.append("+\(extra) \(L(L10n.Forward.moreBundledMessages))")
         }
-        previewLbl.text = parts.isEmpty ? L(L10n.Forward.previewPlaceholder) : parts.joined(separator: "\n")
+        if textParts.isEmpty, attLine == nil {
+            previewLbl.text = L(L10n.Forward.previewPlaceholder)
+        } else {
+            previewLbl.text = textParts.joined(separator: "\n")
+        }
     }
 
-    private static func previewPlainText(for record: MessageRecord) -> String {
+    private func setPreviewAttachmentVisible(_ visible: Bool) {
+        previewAttLbl.isHidden = !visible
+        previewTextTopToAttConstraint?.isActive = visible
+        previewTextTopToCardConstraint?.isActive = !visible
+    }
+
+    private static func previewPlainText(for record: MessageRecord, maxLength: Int = 500) -> String {
         let parsed = MessageContentParser.parse(data: record.content, mentionsData: record.mentionsJSON)
         let t = parsed.text.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !t.isEmpty { return String(t.prefix(500)) }
-        return ""
+        guard !t.isEmpty else { return "" }
+        if t.count <= maxLength { return t }
+        return String(t.prefix(maxLength)).trimmingCharacters(in: .whitespacesAndNewlines) + "…"
     }
 
     @objc private func searchChanged(_ field: UITextField) {
@@ -643,8 +1002,14 @@ final class ForwardMessageViewController: UIViewController {
                 Toast.error(L(L10n.Sharing.sessionExpired))
                 return
             }
-            let targets = selectedIDs.compactMap { self.channelMap[$0] }
-            guard !targets.isEmpty else { return }
+            let selectedChannels = selectedIDs.compactMap { self.channelMap[$0] }
+            let targets = selectedChannels.filter { !self.isForwardBlocked(channelId: $0.channelID) }
+            if targets.isEmpty {
+                if selectedChannels.contains(where: { self.isForwardBlocked(channelId: $0.channelID) }) {
+                    Toast.error(L(L10n.Forward.toastCannotForward))
+                }
+                return
+            }
             let extraRaw = ForwardOutgoing.sanitizedComment(commentField.text ?? "")
             if ForwardOutgoing.commentContentJSON(trimmed: extraRaw) == nil, !extraRaw.isEmpty {
                 Toast.error(L(L10n.Forward.commentTooLong))
@@ -665,7 +1030,7 @@ final class ForwardMessageViewController: UIViewController {
                             destinationChannelID: dest.channelID,
                             forwardFromChannelID: forwardFromChannelID
                         )
-                        let atts = ForwardOutgoing.attachments(for: msg)
+                        let atts = ForwardOutgoing.attachments(for: msg, fallback: attachmentHints[msg.id] ?? [])
                         _ = try await context.account.network.sendChannelMessage(
                             clanId: cid,
                             channelId: dest.channelID,
@@ -720,12 +1085,24 @@ extension ForwardMessageViewController: UITableViewDelegate, UITableViewDataSour
         let cell = tableView.dequeueReusableCell(withIdentifier: SharingChannelCell.reuseId, for: indexPath) as! SharingChannelCell
         let item = displaySuggestions[indexPath.row]
         let ch = channelMap[item.channelID]
-        cell.configure(item: item, channel: ch, isSelected: selectedIDs.contains(item.channelID))
+        let blockNote = forwardBlockNote(channelId: item.channelID)
+        let blocked = blockNote != nil
+        cell.configure(
+            item: item,
+            channel: ch,
+            isSelected: selectedIDs.contains(item.channelID),
+            statusNote: blockNote,
+            isForwardingBlocked: blocked
+        )
         return cell
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let item = displaySuggestions[indexPath.row]
+        if isForwardBlocked(channelId: item.channelID) {
+            Toast.error(forwardBlockNote(channelId: item.channelID) ?? L(L10n.Forward.toastCannotForward))
+            return
+        }
         if selectedIDs.contains(item.channelID) {
             selectedIDs.remove(item.channelID)
         } else {
@@ -738,6 +1115,7 @@ extension ForwardMessageViewController: UITableViewDelegate, UITableViewDataSour
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        56
+        let item = displaySuggestions[indexPath.row]
+        return isForwardBlocked(channelId: item.channelID) ? 72 : 56
     }
 }

--- a/MezonChat/Features/Profile/ProfileSettingViewController.swift
+++ b/MezonChat/Features/Profile/ProfileSettingViewController.swift
@@ -1107,6 +1107,7 @@ final class ProfileSettingViewController: BaseViewController {
                     token: token
                 )
                 await context.refreshUserProfile()
+                applyLocalUserProfileChange(displayName: displayNameForSave, avatarUrl: userAvatarUrl)
                 setLoading(false)
                 Toast.success(L(L10n.ProfileSetting.updateSuccess))
                 navigationController?.popViewController(animated: true)
@@ -1160,6 +1161,11 @@ final class ProfileSettingViewController: BaseViewController {
                     token: token
                 )
                 await context.refreshUserProfile()
+                applyLocalClanProfileChange(
+                    clanId: clan.clanID,
+                    nickName: nicknameForSave,
+                    clanAvatar: avatarChanged ? clanAvatarUrl : nil
+                )
                 setLoading(false)
                 Toast.success(L(L10n.ProfileSetting.clanUpdateSuccess))
                 navigationController?.popViewController(animated: true)
@@ -1167,6 +1173,72 @@ final class ProfileSettingViewController: BaseViewController {
                 setLoading(false)
                 Toast.error(L(L10n.ProfileSetting.updateError))
             }
+        }
+    }
+
+    private func applyLocalUserProfileChange(displayName: String, avatarUrl: String) {
+        guard let userIdStr = context.currentUser?.id, let userId = Int64(userIdStr) else { return }
+        let trimmedAvatar = avatarUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+        context.account.postbox.write { tx in
+            let clans = tx.getClans()
+            for clan in clans {
+                let members = tx.getClanMembers(clanId: clan.id)
+                guard let idx = members.firstIndex(where: { $0.userId == userId }) else { continue }
+                let old = members[idx]
+                let updated = ClanMemberRecord(
+                    userId: old.userId,
+                    roleIds: old.roleIds,
+                    clanNick: old.clanNick,
+                    clanAvatar: old.clanAvatar,
+                    userAvatarURL: trimmedAvatar.isEmpty ? old.userAvatarURL : trimmedAvatar,
+                    clanId: old.clanId,
+                    isOnline: old.isOnline,
+                    displayName: displayName,
+                    username: old.username
+                )
+                var newMembers = members
+                newMembers[idx] = updated
+                tx.updateClanMembers(newMembers, clanId: clan.id)
+            }
+        }
+        for clan in (context.account.postbox.read { tx in tx.getClans() }) {
+            refreshClanUsersPreferenceCache(clanId: clan.id)
+        }
+    }
+
+    private func applyLocalClanProfileChange(clanId: Int64, nickName: String, clanAvatar: String?) {
+        guard clanId != 0, let userIdStr = context.currentUser?.id, let userId = Int64(userIdStr) else { return }
+        let avatarToWrite: String? = clanAvatar.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        context.account.postbox.write { tx in
+            let members = tx.getClanMembers(clanId: clanId)
+            guard let idx = members.firstIndex(where: { $0.userId == userId }) else { return }
+            let old = members[idx]
+            let updated = ClanMemberRecord(
+                userId: old.userId,
+                roleIds: old.roleIds,
+                clanNick: nickName,
+                clanAvatar: avatarToWrite ?? old.clanAvatar,
+                userAvatarURL: old.userAvatarURL,
+                clanId: old.clanId,
+                isOnline: old.isOnline,
+                displayName: old.displayName,
+                username: old.username
+            )
+            var newMembers = members
+            newMembers[idx] = updated
+            tx.updateClanMembers(newMembers, clanId: clanId)
+        }
+        refreshClanUsersPreferenceCache(clanId: clanId)
+    }
+
+    private func refreshClanUsersPreferenceCache(clanId: Int64) {
+        let members = context.account.postbox.read { tx in tx.getClanMembers(clanId: clanId) }
+        guard !members.isEmpty else { return }
+        var list = Mezon_Api_ClanUserList()
+        list.clanID = clanId
+        list.clanUsers = members.map { $0.toClanUserListClanUser() }
+        if let data = try? list.serializedData() {
+            context.account.postbox.setPreferenceData(key: PreferencesKeys.clanUsers(clanId: clanId), value: data)
         }
     }
 

--- a/MezonChat/Features/ScanQR/QRScannerViewController.swift
+++ b/MezonChat/Features/ScanQR/QRScannerViewController.swift
@@ -12,6 +12,7 @@ final class QRScannerViewController: ViewController {
     private var clanInviteNode: QRClanInviteNode?
     private var userProfileNode: QRUserProfileNode?
     private var externalLinkSheetController: QRExternalLinkSheetController?
+    private var scannedTextPayloadSheetController: QRScannedTextPayloadSheetController?
     private let captureSessionQueue = DispatchQueue(label: "mezon.qrScanner.captureSession")
     private var shouldResumeCaptureWhenApplicationBecomesActive = false
     private var exclusiveScanHandlingActive = false
@@ -198,7 +199,7 @@ final class QRScannerViewController: ViewController {
     private func shouldOfferExclusiveScanHandlingResetAfterAppear() -> Bool {
         guard navigationController?.topViewController === self else { return false }
         guard loginConfirmNode == nil, clanInviteNode == nil, userProfileNode == nil else { return false }
-        guard externalLinkSheetController == nil else { return false }
+        guard externalLinkSheetController == nil, scannedTextPayloadSheetController == nil else { return false }
         return true
     }
 
@@ -249,7 +250,7 @@ final class QRScannerViewController: ViewController {
     }
     
     private func handleScannedData(_ data: String) {
-        guard externalLinkSheetController == nil else { return }
+        guard externalLinkSheetController == nil, scannedTextPayloadSheetController == nil else { return }
 
         if data.allSatisfy({ $0.isNumber }) && data.count >= 15 {
             showLoginConfirm(userId: data)
@@ -322,9 +323,7 @@ final class QRScannerViewController: ViewController {
             return
         }
 
-        showAlert(title: L(L10n.QRScanner.invalidQR), message: data) { [weak self] in
-            self?.startCaptureSessionIfNeeded()
-        }
+        presentScannedTextPayloadSheet(with: data)
     }
 
     private static func externalLinkURL(from value: String) -> URL? {
@@ -369,6 +368,22 @@ final class QRScannerViewController: ViewController {
             }
         }
         externalLinkSheetController = sheet
+        present(sheet, animated: false)
+    }
+
+    private func presentScannedTextPayloadSheet(with payload: String) {
+        guard beginExclusiveScanHandling() else { return }
+        stopCaptureSessionIfNeeded()
+        let sheet = QRScannedTextPayloadSheetController(payload: payload)
+        sheet.onDismiss = { [weak self, weak sheet] in
+            guard let self else { return }
+            if self.scannedTextPayloadSheetController === sheet {
+                self.scannedTextPayloadSheetController = nil
+            }
+            self.endExclusiveScanHandling()
+            self.startCaptureSessionIfNeeded()
+        }
+        scannedTextPayloadSheetController = sheet
         present(sheet, animated: false)
     }
 
@@ -848,6 +863,149 @@ private final class QRExternalLinkSheetController: UIViewController {
         } completion: { _ in
             self.dismiss(animated: false) {
                 self.onDismiss?(didOpen)
+            }
+        }
+    }
+}
+
+private final class QRScannedTextPayloadSheetController: UIViewController {
+    private let payload: String
+    var onDismiss: (() -> Void)?
+
+    private let dimView = UIView()
+    private let contentView = UIView()
+    private let handleView = UIView()
+    private let titleLabel = UILabel()
+    private let textView = UITextView()
+    private let copyButton = UIButton(type: .system)
+
+    private var didAnimateIn = false
+    private var isDismissing = false
+
+    init(payload: String) {
+        self.payload = payload
+        super.init(nibName: nil, bundle: nil)
+        modalPresentationStyle = .overFullScreen
+        modalTransitionStyle = .crossDissolve
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .clear
+
+        dimView.backgroundColor = UIColor.black.withAlphaComponent(0.32)
+        dimView.alpha = 0
+        dimView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(dimTapped)))
+        view.addSubview(dimView)
+
+        contentView.backgroundColor = UIColor(red: 0.10, green: 0.11, blue: 0.12, alpha: 1.0)
+        contentView.layer.cornerRadius = 14
+        contentView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        contentView.clipsToBounds = true
+        view.addSubview(contentView)
+
+        handleView.backgroundColor = UIColor.white.withAlphaComponent(0.16)
+        handleView.layer.cornerRadius = 2.5
+        contentView.addSubview(handleView)
+
+        titleLabel.text = L(L10n.QRScanner.scannedPayloadTitle)
+        titleLabel.font = .systemFont(ofSize: 17, weight: .semibold)
+        titleLabel.textColor = .white
+        titleLabel.numberOfLines = 1
+        contentView.addSubview(titleLabel)
+
+        textView.text = payload
+        textView.font = .systemFont(ofSize: 15, weight: .regular)
+        textView.textColor = .white
+        textView.backgroundColor = UIColor.white.withAlphaComponent(0.08)
+        textView.layer.cornerRadius = 10
+        textView.clipsToBounds = true
+        textView.textContainerInset = UIEdgeInsets(top: 12, left: 10, bottom: 12, right: 10)
+        textView.textContainer.lineFragmentPadding = 0
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.isScrollEnabled = true
+        textView.indicatorStyle = .white
+        contentView.addSubview(textView)
+
+        copyButton.backgroundColor = UIColor(red: 0.02, green: 0.43, blue: 1.0, alpha: 1.0)
+        copyButton.layer.cornerRadius = 22
+        copyButton.tintColor = .white
+        copyButton.setTitle(L(L10n.QRScanner.copyContent), for: .normal)
+        copyButton.setTitleColor(.white, for: .normal)
+        copyButton.titleLabel?.font = .systemFont(ofSize: 16, weight: .semibold)
+        copyButton.setImage(UIImage(systemName: "doc.on.doc"), for: .normal)
+        copyButton.imageEdgeInsets = UIEdgeInsets(top: 0, left: -6, bottom: 0, right: 6)
+        copyButton.titleEdgeInsets = UIEdgeInsets(top: 0, left: 6, bottom: 0, right: -6)
+        copyButton.addTarget(self, action: #selector(copyTapped), for: .touchUpInside)
+        contentView.addSubview(copyButton)
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        dimView.frame = view.bounds
+        let safeBottom = view.safeAreaInsets.bottom
+        let width = view.bounds.width
+        let horizontal: CGFloat = 16
+        let insetH = textView.textContainerInset.left + textView.textContainerInset.right
+        let innerTextWidth = max(1, width - horizontal * 2 - insetH)
+
+        let bodyFont = textView.font ?? UIFont.systemFont(ofSize: 15)
+        let bounded = (payload as NSString).boundingRect(
+            with: CGSize(width: innerTextWidth, height: CGFloat.greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: [.font: bodyFont],
+            context: nil)
+        let intrinsicText = ceil(bounded.height) + textView.textContainerInset.top + textView.textContainerInset.bottom
+        let textBlockH = min(320, max(120, intrinsicText))
+
+        let titleY: CGFloat = 38
+        titleLabel.frame = CGRect(x: horizontal, y: titleY, width: width - horizontal * 2, height: 24)
+
+        let textY = titleY + 24 + 12
+        textView.frame = CGRect(x: horizontal, y: textY, width: width - horizontal * 2, height: textBlockH)
+
+        let buttonY = textY + textBlockH + 20
+        copyButton.frame = CGRect(x: horizontal, y: buttonY, width: width - horizontal * 2, height: 44)
+
+        let sheetHeight = buttonY + 44 + 18 + safeBottom
+        contentView.frame = CGRect(x: 0, y: view.bounds.height - sheetHeight, width: width, height: sheetHeight)
+        handleView.frame = CGRect(x: (width - 56) / 2, y: 10, width: 56, height: 5)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        guard !didAnimateIn else { return }
+        didAnimateIn = true
+        contentView.transform = CGAffineTransform(translationX: 0, y: contentView.bounds.height)
+        UIView.animate(withDuration: 0.24, delay: 0, options: [.curveEaseOut]) {
+            self.dimView.alpha = 1
+            self.contentView.transform = .identity
+        }
+    }
+
+    @objc private func dimTapped() {
+        dismissSheet()
+    }
+
+    @objc private func copyTapped() {
+        UIPasteboard.general.string = payload
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+    }
+
+    private func dismissSheet() {
+        guard !isDismissing else { return }
+        isDismissing = true
+        let height = contentView.bounds.height
+        UIView.animate(withDuration: 0.2, delay: 0, options: [.curveEaseIn]) {
+            self.dimView.alpha = 0
+            self.contentView.transform = CGAffineTransform(translationX: 0, y: height)
+        } completion: { _ in
+            self.dismiss(animated: false) {
+                self.onDismiss?()
             }
         }
     }

--- a/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
+++ b/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
@@ -3952,6 +3952,20 @@ final class SendMessageInputViewController: UIViewController {
         }
         let channelIds = mentionLookupChannelIds
         let mentionSnapshot = allMentionMembers
+        let cachedClanNick: String? = {
+            guard clanId != 0,
+                  let clanUsers = context.engine.clanData.getClanUsers(clanId: clanId),
+                  let found = clanUsers.clanUsers.first(where: { $0.user.id == senderId }) else { return nil }
+            let cn = found.clanNick.trimmingCharacters(in: .whitespacesAndNewlines)
+            return cn.isEmpty ? nil : cn
+        }()
+        let cachedClanAvatar: String? = {
+            guard clanId != 0,
+                  let clanUsers = context.engine.clanData.getClanUsers(clanId: clanId),
+                  let found = clanUsers.clanUsers.first(where: { $0.user.id == senderId }) else { return nil }
+            let ca = found.clanAvatar.trimmingCharacters(in: .whitespacesAndNewlines)
+            return ca.isEmpty ? nil : ca
+        }()
         return context.account.postbox.read { tx -> (String, String?) in
             if clanId != 0,
                 let m = tx.getClanMembers(clanId: clanId).first(where: {
@@ -3983,8 +3997,13 @@ final class SendMessageInputViewController: UIViewController {
                 guard let r = members.first(where: {
                     Self.memberMatchesSender($0.userId, senderId: senderId, sender: sender)
                 }) else { continue }
+                let resolvedClanNick: String = {
+                    let rn = r.clanNick.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !rn.isEmpty { return rn }
+                    return cachedClanNick ?? ""
+                }()
                 let name = Self.layeredClanVisibleName(
-                    clanNick: r.clanNick,
+                    clanNick: resolvedClanNick,
                     displayName: r.displayName,
                     username: r.username,
                     userId: r.userId,
@@ -3995,6 +4014,8 @@ final class SendMessageInputViewController: UIViewController {
                 let ca = r.clanAvatar.trimmingCharacters(in: .whitespacesAndNewlines)
                 if !ca.isEmpty {
                     av = ca
+                } else if let cca = cachedClanAvatar {
+                    av = cca
                 } else if let p = tx.getProfile(userId: sender.id), let u = p.avatarUrl {
                     let t = u.trimmingCharacters(in: .whitespacesAndNewlines)
                     av = t.isEmpty ? sender.avatarURL?.absoluteString : t
@@ -4007,7 +4028,7 @@ final class SendMessageInputViewController: UIViewController {
                 Self.memberMatchesSender($0.userId, senderId: senderId, sender: sender)
             }) {
                 let name = Self.layeredClanVisibleName(
-                    clanNick: "",
+                    clanNick: cachedClanNick ?? "",
                     displayName: mm.displayName,
                     username: mm.username,
                     userId: mm.userId,
@@ -4016,7 +4037,9 @@ final class SendMessageInputViewController: UIViewController {
                 )
                 let mav = mm.avatarURL?.trimmingCharacters(in: .whitespacesAndNewlines)
                 let av: String?
-                if let mav, !mav.isEmpty {
+                if let cca = cachedClanAvatar {
+                    av = cca
+                } else if let mav, !mav.isEmpty {
                     av = mav
                 } else {
                     av = sender.avatarURL?.absoluteString
@@ -4024,14 +4047,15 @@ final class SendMessageInputViewController: UIViewController {
                 return (name, av)
             }
             let name = Self.layeredClanVisibleName(
-                clanNick: "",
+                clanNick: cachedClanNick ?? "",
                 displayName: sender.displayName,
                 username: sender.username,
                 userId: 0,
                 profile: tx.getProfile(userId: sender.id),
                 sender: sender
             )
-            return (name, sender.avatarURL?.absoluteString)
+            let av: String? = cachedClanAvatar ?? sender.avatarURL?.absoluteString
+            return (name, av)
         }
     }
 

--- a/MezonChat/Features/Sharing/SharingChannelCell.swift
+++ b/MezonChat/Features/Sharing/SharingChannelCell.swift
@@ -44,6 +44,16 @@ final class SharingChannelCell: UITableViewCell {
         return l
     }()
 
+    private let statusLabel: UILabel = {
+        let l = UILabel()
+        l.translatesAutoresizingMaskIntoConstraints = false
+        l.font = .systemFont(ofSize: 12, weight: .regular)
+        l.textColor = UIColor.white.withAlphaComponent(0.55)
+        l.numberOfLines = 2
+        l.isHidden = true
+        return l
+    }()
+
     private let clanAvatarView: UIImageView = {
         let iv = UIImageView()
         iv.translatesAutoresizingMaskIntoConstraints = false
@@ -119,6 +129,9 @@ final class SharingChannelCell: UITableViewCell {
         clanAvatarView.isHidden = true
         clanNameLabel.isHidden = true
         clanNameLabel.text = nil
+        statusLabel.isHidden = true
+        statusLabel.text = nil
+        contentView.alpha = 1
     }
 
     private func setupLayout() {
@@ -130,6 +143,7 @@ final class SharingChannelCell: UITableViewCell {
         avatarView.addSubview(channelIconView)
         contentView.addSubview(textColumnStack)
         textColumnStack.addArrangedSubview(nameLabel)
+        textColumnStack.addArrangedSubview(statusLabel)
         textColumnStack.addArrangedSubview(clanRowStack)
         clanRowStack.addArrangedSubview(clanAvatarView)
         clanRowStack.addArrangedSubview(clanNameLabel)
@@ -164,10 +178,25 @@ final class SharingChannelCell: UITableViewCell {
         ])
     }
 
-    func configure(item: SharingSuggestionItem, channel: Mezon_Api_ChannelDescription?, isSelected: Bool) {
+    func configure(
+        item: SharingSuggestionItem,
+        channel: Mezon_Api_ChannelDescription?,
+        isSelected: Bool,
+        statusNote: String? = nil,
+        isForwardingBlocked: Bool = false
+    ) {
         let theme = UIColor.theme
         nameLabel.textColor = theme.textStrong
         clanNameLabel.textColor = theme.textDisabled
+        if let note = statusNote?.trimmingCharacters(in: .whitespacesAndNewlines), !note.isEmpty {
+            statusLabel.isHidden = false
+            statusLabel.text = note
+            statusLabel.textColor = theme.textDisabled
+        } else {
+            statusLabel.isHidden = true
+            statusLabel.text = nil
+        }
+        contentView.alpha = isForwardingBlocked ? 0.5 : 1
 
         let ch = channel
         let isDM = item.type == MezonConstants.ChannelType.dm.rawValue
@@ -256,7 +285,7 @@ final class SharingChannelCell: UITableViewCell {
             avatarView.backgroundColor = theme.tertiary
         }
 
-        checkmarkView.isHidden = !isSelected
+        checkmarkView.isHidden = isForwardingBlocked || !isSelected
     }
 
     private func loadMainAvatar(raw: String) {


### PR DESCRIPTION
Ticket: https://github.com/mezonai/mezon/issues/12794
## Summary

Improve the forward message destination picker (preview, search, sorting, empty state, blocked users).

## 1. Root Cause

- **Attachment preview**: Forward screen only parsed protobuf `attachmentsJSON` and showed a single total count; long text filled the 4-line preview and hid attachment info. Desktop messages may store attachments as JSON or inside `content`.
- **Search**: Filter matched only UI `displayName`, not `usernames` / `displayNames` on the channel.
- **Sort**: Search results were sorted alphabetically (`foldingMatchSort`), breaking recency order used in Share.
- **Empty search**: No empty state when search returned zero results.
- **Blocked users**: Block list was fetched via `ListFriends(state: block)` in `FriendsData` but not used in forward; users could still select blocked DMs.

## 2. Solution

- Parse attachments from protobuf, JSON, and `content`; show breakdown (e.g. `2 attachments, 1 file`); truncate text when attachments exist; pass `attachmentHints` from `ChatMessageDisplay`.
- Search across `channelLabel`, `usernames`, and `displayNames` (aligned with `SharingViewController`).
- Sort by recency (DMs then channels); preserve order when filtering; remove alphabetical search sort.
- Show localized **No results found** empty state.
- Refresh `friendsData`, map `blockedUserIds()`, show status label on row, disable selection/send, toast on blocked tap.

## 3. Self-test

- [ ] Forward message with image + file (incl. from desktop): preview shows text + attachment breakdown (`N attachments, M file`).
- [ ] Forward long text + attachments: attachment line remains visible (separate label / truncated text).
- [ ] Search by `username` (not only display name): matching DM/group appears.
- [ ] Default list order: recently messaged users/channels near top.
- [ ] Search nonsense query (e.g. `pppppp`): **No results found** / **Không tìm thấy kết quả**.
- [ ] DM with user you blocked: subtitle *You blocked this user*, dimmed row, cannot select or forward; toast on tap.
- [ ] Group containing a blocked member: *You can't message each other* (or equivalent VI).
- [ ] Forward to normal DM/channel still works; success toast + message delivered.
- [ ] EN / VI strings for new `forward.*` keys.