### PR TITLE
Fix notification avatars (Topic/For you) and voice member row layout in channel list

### DIFF
--- a/MezonChat/Core/MezonEngine/MezonEngine+Notifications.swift
+++ b/MezonChat/Core/MezonEngine/MezonEngine+Notifications.swift
@@ -22,12 +22,20 @@ extension MezonEngine {
             )
 
             let mappedNotifications = apiNotifications.map { NotificationRecord(from: $0) }
+            let friends = engine.friendsData.allFriends()
 
             postbox.write { tx in
+                let enriched = mappedNotifications.map { record in
+                    let friendAvatar =
+                        friends.first(where: { $0.user.id == record.senderID })?.user.avatarURL
+                        ?? ""
+                    return record.enrichedSenderAvatar(
+                        transaction: tx, fallbackAvatarURL: friendAvatar)
+                }
                 if notificationId > 0 {
-                    tx.appendNotifications(mappedNotifications, clanId: clanId, category: category)
+                    tx.appendNotifications(enriched, clanId: clanId, category: category)
                 } else {
-                    tx.updateNotifications(mappedNotifications, clanId: clanId, category: category)
+                    tx.updateNotifications(enriched, clanId: clanId, category: category)
                 }
             }
         }

--- a/MezonChat/Core/MezonEngine/MezonEngine+TopicDiscussion.swift
+++ b/MezonChat/Core/MezonEngine/MezonEngine+TopicDiscussion.swift
@@ -14,8 +14,43 @@ extension MezonEngine {
             let apiTopics = try await network.listSdTopics(clanID: clanId, token: token)
             let mapped = apiTopics.map { TopicRecord(from: $0) }
             postbox.write { tx in
-                tx.updateTopics(mapped, clanId: clanId)
+                let enriched = mapped.map { Self.enrichSenderAvatar($0, tx: tx) }
+                tx.updateTopics(enriched, clanId: clanId)
             }
+        }
+
+        private static func enrichSenderAvatar(_ topic: TopicRecord, tx: PostboxTransaction) -> TopicRecord {
+            let senderId = topic.lastSenderID
+            guard senderId != 0 else { return topic }
+            var avatar = topic.senderAvatarURL
+            var displayName = topic.senderDisplayName
+            if let profile = tx.getProfile(userId: String(senderId)) {
+                if avatar.isEmpty, let url = profile.avatarUrl, !url.isEmpty {
+                    avatar = url
+                }
+                if displayName.isEmpty {
+                    if let dn = profile.displayName, !dn.isEmpty {
+                        displayName = dn
+                    } else if !profile.username.isEmpty {
+                        displayName = profile.username
+                    }
+                }
+            }
+            guard avatar != topic.senderAvatarURL || displayName != topic.senderDisplayName else {
+                return topic
+            }
+            return TopicRecord(
+                id: topic.id,
+                channelID: topic.channelID,
+                clanID: topic.clanID,
+                creatorID: topic.creatorID,
+                lastSenderID: topic.lastSenderID,
+                senderAvatarURL: avatar,
+                senderDisplayName: displayName,
+                content: topic.content,
+                updateTimeSeconds: topic.updateTimeSeconds,
+                lastSentMessageContent: topic.lastSentMessageContent
+            )
         }
     }
 }

--- a/MezonChat/Core/Postbox/Notifications/NotificationRecord.swift
+++ b/MezonChat/Core/Postbox/Notifications/NotificationRecord.swift
@@ -278,7 +278,7 @@ extension NotificationRecord {
             return (extractDisplayText(from: raw), "", 0, 0, 0)
         }
         let text = extractText(fromJSONObject: obj) ?? extractDisplayText(from: raw)
-        let avatar = (obj["avatar"] as? String) ?? ""
+        let avatar = extractAvatar(fromJSONObject: obj)
         let messageID =
             parseInt64(obj["message_id"]) ?? parseInt64(obj["messageId"]) ?? parseInt64(obj["messageID"])
             ?? 0
@@ -319,5 +319,76 @@ extension NotificationRecord {
             if clanID == 0 { clanID = rid.clanID }
         }
         return (text, avatar, messageID, clanID, channelID)
+    }
+
+    private static func extractAvatar(fromJSONObject obj: [String: Any]) -> String {
+        let keys = ["avatar_url", "avatarUrl", "avatarURL", "avatar", "sender_avatar", "senderAvatar"]
+        for key in keys {
+            if let value = obj[key] as? String {
+                let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty { return trimmed }
+            }
+        }
+        if let user = obj["user"] as? [String: Any] {
+            let nested = extractAvatar(fromJSONObject: user)
+            if !nested.isEmpty { return nested }
+        }
+        if let sender = obj["sender"] as? [String: Any] {
+            let nested = extractAvatar(fromJSONObject: sender)
+            if !nested.isEmpty { return nested }
+        }
+        return ""
+    }
+
+    static func placeholderName(from subject: String) -> String {
+        let markers = [
+            " wants to add you",
+            " wants to be your friend",
+            " sent you a friend request",
+            " sent you",
+        ]
+        let trimmed = subject.trimmingCharacters(in: .whitespacesAndNewlines)
+        for marker in markers {
+            guard let range = trimmed.range(of: marker, options: .caseInsensitive) else { continue }
+            let name = String(trimmed[..<range.lowerBound]).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !name.isEmpty { return name }
+        }
+        return ""
+    }
+
+    func enrichedSenderAvatar(transaction tx: PostboxTransaction, fallbackAvatarURL: String = "") -> NotificationRecord {
+        let existing = avatarURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !existing.isEmpty, existing != "default" { return self }
+        guard senderID != 0 else { return self }
+
+        var resolved = ""
+        if let profile = tx.getProfile(userId: String(senderID)),
+           let url = profile.avatarUrl?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !url.isEmpty
+        {
+            resolved = url
+        }
+        if resolved.isEmpty {
+            let fallback = fallbackAvatarURL.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !fallback.isEmpty { resolved = fallback }
+        }
+        guard !resolved.isEmpty else { return self }
+
+        return NotificationRecord(
+            id: id,
+            subject: subject,
+            content: content,
+            code: code,
+            senderID: senderID,
+            createTimeSeconds: createTimeSeconds,
+            persistent: persistent,
+            clanID: clanID,
+            channelID: channelID,
+            channelType: channelType,
+            avatarURL: resolved,
+            topicID: topicID,
+            category: category,
+            messageID: messageID
+        )
     }
 }

--- a/MezonChat/Core/Postbox/TopicDiscussion/TopicRecord.swift
+++ b/MezonChat/Core/Postbox/TopicDiscussion/TopicRecord.swift
@@ -6,6 +6,9 @@ public struct TopicRecord: PostboxCoding, Identifiable, Equatable {
     public let channelID: Int64
     public let clanID: Int64
     public let creatorID: Int64
+    public let lastSenderID: Int64
+    public let senderAvatarURL: String
+    public let senderDisplayName: String
     public let content: String
     public let updateTimeSeconds: UInt32
     public let lastSentMessageContent: String
@@ -15,6 +18,10 @@ public struct TopicRecord: PostboxCoding, Identifiable, Equatable {
         self.channelID = proto.channelID
         self.clanID = proto.clanID
         self.creatorID = proto.creatorID
+        let replySender = proto.hasLastSentMessage ? proto.lastSentMessage.senderID : 0
+        self.lastSenderID = replySender != 0 ? replySender : proto.creatorID
+        self.senderAvatarURL = ""
+        self.senderDisplayName = ""
         self.content = proto.content
         self.updateTimeSeconds = proto.createTimeSeconds
         self.lastSentMessageContent = proto.hasLastSentMessage ? proto.lastSentMessage.content : ""
@@ -25,6 +32,9 @@ public struct TopicRecord: PostboxCoding, Identifiable, Equatable {
         channelID: Int64,
         clanID: Int64,
         creatorID: Int64,
+        lastSenderID: Int64 = 0,
+        senderAvatarURL: String = "",
+        senderDisplayName: String = "",
         content: String,
         updateTimeSeconds: UInt32,
         lastSentMessageContent: String
@@ -33,6 +43,9 @@ public struct TopicRecord: PostboxCoding, Identifiable, Equatable {
         self.channelID = channelID
         self.clanID = clanID
         self.creatorID = creatorID
+        self.lastSenderID = lastSenderID != 0 ? lastSenderID : creatorID
+        self.senderAvatarURL = senderAvatarURL
+        self.senderDisplayName = senderDisplayName
         self.content = content
         self.updateTimeSeconds = updateTimeSeconds
         self.lastSentMessageContent = lastSentMessageContent

--- a/MezonChat/Core/Postbox/TopicDiscussion/TopicTable.swift
+++ b/MezonChat/Core/Postbox/TopicDiscussion/TopicTable.swift
@@ -15,12 +15,14 @@ public final class TopicTable: Table {
                 creator_id           INTEGER NOT NULL,
                 content              TEXT NOT NULL,
                 update_time_seconds  INTEGER NOT NULL,
-                last_sent_message    TEXT NOT NULL
+                last_sent_message    TEXT NOT NULL,
+                last_sender_id       INTEGER NOT NULL DEFAULT 0
             )
         """)
         db.rawExecute(
             "CREATE INDEX IF NOT EXISTS idx_topics_clan ON topics(clan_id, update_time_seconds DESC)"
         )
+        addColumnIfNeeded("topics", column: "last_sender_id", definition: "INTEGER NOT NULL DEFAULT 0")
     }
 
     public override func beforeCommit() {
@@ -36,7 +38,7 @@ public final class TopicTable: Table {
 
         let rows = db.query(
             """
-            SELECT id, channel_id, clan_id, creator_id, content, update_time_seconds, last_sent_message
+            SELECT id, channel_id, clan_id, creator_id, content, update_time_seconds, last_sent_message, last_sender_id
             FROM topics
             WHERE clan_id = ?
             ORDER BY update_time_seconds DESC
@@ -52,6 +54,7 @@ public final class TopicTable: Table {
                 channelID: sqlite3_column_int64(stmt, 1),
                 clanID: sqlite3_column_int64(stmt, 2),
                 creatorID: sqlite3_column_int64(stmt, 3),
+                lastSenderID: sqlite3_column_int64(stmt, 7),
                 content: String(cString: sqlite3_column_text(stmt, 4)),
                 updateTimeSeconds: UInt32(sqlite3_column_int64(stmt, 5)),
                 lastSentMessageContent: String(cString: sqlite3_column_text(stmt, 6))
@@ -69,8 +72,8 @@ public final class TopicTable: Table {
         for t in topics {
             db.run(
                 """
-                INSERT INTO topics (id, channel_id, clan_id, creator_id, content, update_time_seconds, last_sent_message)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                INSERT INTO topics (id, channel_id, clan_id, creator_id, content, update_time_seconds, last_sent_message, last_sender_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 { s in
                     sqlite3_bind_int64(s, 1, t.id)
@@ -80,6 +83,7 @@ public final class TopicTable: Table {
                     sqlite3_bind_text(s, 5, (t.content as NSString).utf8String, -1, nil)
                     sqlite3_bind_int64(s, 6, Int64(t.updateTimeSeconds))
                     sqlite3_bind_text(s, 7, (t.lastSentMessageContent as NSString).utf8String, -1, nil)
+                    sqlite3_bind_int64(s, 8, t.lastSenderID)
                 }
             )
         }

--- a/MezonChat/Features/ChannelList/ChannelItemCellNode.swift
+++ b/MezonChat/Features/ChannelList/ChannelItemCellNode.swift
@@ -247,7 +247,7 @@ private func makeVoiceAvatarNodes(member m: VoiceMemberDisplay, size s: CGFloat)
         wrapper.backgroundColor = UIColor.avatarColor(for: m.username)
         imgNode.isHidden = true
         let initial = String(m.username.prefix(1)).uppercased()
-        let fontSize: CGFloat = s < 20 ? 8 : 10
+        let fontSize: CGFloat = s < 22 ? 9 : 11
         initNode.attributedText = NSAttributedString(
             string: initial,
             attributes: [
@@ -266,7 +266,7 @@ private func makeVoiceAvatarNodes(member m: VoiceMemberDisplay, size s: CGFloat)
 
 final class VoiceMemberExpandedCellNode: ASCellNode {
 
-    private static let avatarSize: CGFloat = 18
+    private static let avatarSize: CGFloat = 22
 
     private let avatarWrapper: ASDisplayNode
     private let avatarImg: ASNetworkImageNode
@@ -288,7 +288,7 @@ final class VoiceMemberExpandedCellNode: ASCellNode {
         nameNode.attributedText = NSAttributedString(
             string: member.name,
             attributes: [
-                .font: UIFont.systemFont(ofSize: 12.sf, weight: .regular),
+                .font: UIFont.systemFont(ofSize: 13.sf, weight: .regular),
                 .foregroundColor: UIColor.theme.channelNormal,
             ])
     }
@@ -301,13 +301,13 @@ final class VoiceMemberExpandedCellNode: ASCellNode {
         nameNode.style.flexShrink = 1
         let row = ASStackLayoutSpec(
             direction: .horizontal,
-            spacing: 8,
+            spacing: 10,
             justifyContent: .start,
             alignItems: .center,
             children: [avatarWrapper, nameNode]
         )
         return ASInsetLayoutSpec(
-            insets: UIEdgeInsets(top: 3, left: 40, bottom: 3, right: 12),
+            insets: UIEdgeInsets(top: 2, left: 40, bottom: 2, right: 12),
             child: row
         )
     }
@@ -315,7 +315,7 @@ final class VoiceMemberExpandedCellNode: ASCellNode {
 
 final class VoiceChannelMembersCollapsedCellNode: ASCellNode {
 
-    private static let avatarSize: CGFloat = 16
+    private static let avatarSize: CGFloat = 20
     private static let maxVisible = 5
 
     private var avatarNodes: [ASDisplayNode] = []
@@ -336,7 +336,7 @@ final class VoiceChannelMembersCollapsedCellNode: ASCellNode {
 
         if totalCount > Self.maxVisible {
             let text = "+\(totalCount - Self.maxVisible)"
-            let font = UIFont.systemFont(ofSize: 9, weight: .bold)
+            let font = UIFont.systemFont(ofSize: 10, weight: .bold)
             let textWidth = (text as NSString).size(withAttributes: [.font: font]).width
             let badgeWidth = max(Self.avatarSize, ceil(textWidth) + 8)
 
@@ -380,13 +380,13 @@ final class VoiceChannelMembersCollapsedCellNode: ASCellNode {
         }
         let row = ASStackLayoutSpec(
             direction: .horizontal,
-            spacing: -4,
+            spacing: -3,
             justifyContent: .start,
             alignItems: .center,
             children: children
         )
         return ASInsetLayoutSpec(
-            insets: UIEdgeInsets(top: 2, left: 38, bottom: 3, right: 12),
+            insets: UIEdgeInsets(top: 2, left: 38, bottom: 2, right: 12),
             child: row
         )
     }

--- a/MezonChat/Features/Notifications/NotificationsContainerNode.swift
+++ b/MezonChat/Features/Notifications/NotificationsContainerNode.swift
@@ -74,7 +74,19 @@ enum NotificationItem {
     var avatarURL: String {
         switch self {
         case .notification(let n): return n.avatarURL
-        case .topic(let t): return "default"
+        case .topic(let t): return t.senderAvatarURL
+        }
+    }
+
+    var avatarPlaceholderSeed: String {
+        switch self {
+        case .notification(let n):
+            let name = NotificationRecord.placeholderName(from: n.subject)
+            if !name.isEmpty { return name }
+            return n.subject
+        case .topic(let t):
+            if !t.senderDisplayName.isEmpty { return t.senderDisplayName }
+            return String(t.lastSenderID)
         }
     }
 
@@ -297,9 +309,10 @@ final class NotificationItemCell: UITableViewCell {
         imageTask = nil
         stopAvatarSkeleton()
 
-        avatarView.backgroundColor = UIColor.avatarColor(for: item.subject)
+        let avatarSeed = item.avatarPlaceholderSeed
+        avatarView.backgroundColor = UIColor.avatarColor(for: avatarSeed)
         avatarPlaceholder.text =
-            item.subject.first.map { String($0).uppercased() } ?? "N"
+            avatarSeed.first.map { String($0).uppercased() } ?? "N"
 
         if !avatarURLStr.isEmpty, avatarURLStr != "default",
            let url = URL(string: avatarURLStr) {
@@ -321,7 +334,7 @@ final class NotificationItemCell: UITableViewCell {
                         self.avatarView.backgroundColor = .clear
                         self.avatarPlaceholder.isHidden = true
                     } else {
-                        self.avatarView.backgroundColor = UIColor.avatarColor(for: item.subject)
+                        self.avatarView.backgroundColor = UIColor.avatarColor(for: avatarSeed)
                         self.avatarPlaceholder.isHidden = false
                     }
                 }

--- a/MezonChat/Features/Notifications/NotificationsViewController.swift
+++ b/MezonChat/Features/Notifications/NotificationsViewController.swift
@@ -114,7 +114,8 @@ final class NotificationsViewController: ViewController {
                 (context.engine.data.subscribe(
                     MezonEngine.EngineData.Item.TopicList(clanId: clanId)
                 ) |> deliverOnMainQueue).start(next: { [weak self] topics in
-                    self?.setItems(topics.map { .topic($0) })
+                    guard let self else { return }
+                    self.setItems(self.enrichTopicItems(topics))
                 })
             return
         }
@@ -160,13 +161,66 @@ final class NotificationsViewController: ViewController {
     }
 
     private func setNotifications(_ v: [NotificationRecord]) {
-        self.items = v.map { .notification($0) }
+        self.items = enrichNotificationItems(v)
         needsReloadPipe.putNext(())
+    }
+
+    private func enrichNotificationItems(_ records: [NotificationRecord]) -> [NotificationItem] {
+        let friends = context.engine.friendsData.allFriends()
+        return context.account.postbox.read { tx in
+            records.map { record in
+                let friendAvatar =
+                    friends.first(where: { $0.user.id == record.senderID })?.user.avatarURL
+                    ?? ""
+                let enriched = record.enrichedSenderAvatar(
+                    transaction: tx, fallbackAvatarURL: friendAvatar)
+                return .notification(enriched)
+            }
+        }
     }
 
     private func setItems(_ v: [NotificationItem]) {
         self.items = v
         needsReloadPipe.putNext(())
+    }
+
+    private func enrichTopicItems(_ topics: [TopicRecord]) -> [NotificationItem] {
+        context.account.postbox.read { tx in
+            topics.map { topic in
+                var avatar = topic.senderAvatarURL
+                var displayName = topic.senderDisplayName
+                let senderId = topic.lastSenderID != 0 ? topic.lastSenderID : topic.creatorID
+                if senderId != 0, let profile = tx.getProfile(userId: String(senderId)) {
+                    if avatar.isEmpty, let url = profile.avatarUrl, !url.isEmpty {
+                        avatar = url
+                    }
+                    if displayName.isEmpty {
+                        if let dn = profile.displayName, !dn.isEmpty {
+                            displayName = dn
+                        } else if !profile.username.isEmpty {
+                            displayName = profile.username
+                        }
+                    }
+                }
+                if avatar == topic.senderAvatarURL, displayName == topic.senderDisplayName {
+                    return .topic(topic)
+                }
+                return .topic(
+                    TopicRecord(
+                        id: topic.id,
+                        channelID: topic.channelID,
+                        clanID: topic.clanID,
+                        creatorID: topic.creatorID,
+                        lastSenderID: topic.lastSenderID,
+                        senderAvatarURL: avatar,
+                        senderDisplayName: displayName,
+                        content: topic.content,
+                        updateTimeSeconds: topic.updateTimeSeconds,
+                        lastSentMessageContent: topic.lastSentMessageContent
+                    )
+                )
+            }
+        }
     }
 
     private func processItemDetail(_ item: NotificationItem) {


### PR DESCRIPTION
## Summary
Fix missing avatars in Notifications (Topic & For you) and adjust voice-channel member rows in the channel list.

## 1. Root Cause
- **Topic tab:** `NotificationItem.avatarURL` was effectively always `"default"`; topic rows did not carry last-sender identity/avatar from the API or local cache.
- **For you tab:** Friend-request and similar notifications often arrive with empty `avatarURL` in JSON; only a single `avatar` key was parsed, and UI fell back to placeholder initials (e.g. "R" from "Replied to:").
- **Channel list (voice):** Voice member sub-rows used smaller avatars/fonts and vertical spacing that felt cramped or inconsistent with the rest of the list.

## 2. Solution
- Extend `TopicRecord` / `TopicTable` with `lastSenderID`, `senderAvatarURL`, `senderDisplayName`; enrich on sync via `MezonEngine+TopicDiscussion` and again in `NotificationsViewController` when building Topic items.
- Broaden avatar extraction in `NotificationRecord` (multiple JSON keys + nested `user`/`sender`); add `enrichedSenderAvatar` using postbox profile and friends list fallback; enrich on fetch in `MezonEngine+Notifications` and on display in `NotificationsViewController` / `NotificationsContainerNode`.
- Parse display name from friend-request subject lines for placeholder seed when avatar is still missing.
- Tune `ChannelItemCellNode` voice member cells: larger avatars/fonts, adjusted horizontal/vertical insets.

## 3. Selftest
- [ ] **Notifications → Topic:** Open a clan with topic/reply activity; confirm sender avatars (not generic "default" / wrong initial).
- [ ] **Notifications → For you:** Friend requests and similar items show correct avatar when user exists in friends/postbox; placeholder initial uses sender name, not "R" from subject prefix.
- [ ] Pull-to-refresh / re-open tab: avatars still correct after cold start.
- [ ] **Channel list:** Expand a voice channel with multiple members; avatars and names readable, vertical spacing acceptable (not too loose).
- [ ] Regression: other notification categories and non-voice channel rows unchanged.