### PR TITLE
feat: allow create DM group and optimize group DM

### DIFF
--- a/MezonChat/Core/Localization/L10n.swift
+++ b/MezonChat/Core/Localization/L10n.swift
@@ -733,6 +733,13 @@ enum L10n {
     enum DirectMessage {
         static let you        = "directMessage.you"
         static let addFriend = "directMessage.addFriend"
+        static let newGroup = "directMessage.newGroup"
+        static let create = "directMessage.create"
+        static let searchFriends = "directMessage.searchFriends"
+        static let memberCount = "directMessage.memberCount"
+        static let noFriends = "directMessage.noFriends"
+        static let memberLimitReached = "directMessage.memberLimitReached"
+        static let createFailed = "directMessage.createFailed"
 
         static let groupCreated   = "directMessage.groupCreated"
         static let previewAttachment = "directMessage.previewAttachment"
@@ -828,6 +835,21 @@ enum L10n {
         static let unpinConfirmTitle = "channelDetail.unpinConfirmTitle"
         static let unpinConfirmBody = "channelDetail.unpinConfirmBody"
         static let unpinConfirmAction = "channelDetail.unpinConfirmAction"
+        static let customizeGroup = "channelDetail.customizeGroup"
+        static let leaveGroup = "channelDetail.leaveGroup"
+        static let deleteGroup = "channelDetail.deleteGroup"
+        static let leaveGroupConfirmTitle = "channelDetail.leaveGroupConfirmTitle"
+        static let leaveGroupConfirmBody = "channelDetail.leaveGroupConfirmBody"
+        static let deleteGroupConfirmTitle = "channelDetail.deleteGroupConfirmTitle"
+        static let deleteGroupConfirmBody = "channelDetail.deleteGroupConfirmBody"
+        static let groupName = "channelDetail.groupName"
+        static let removeGroupLogo = "channelDetail.removeGroupLogo"
+        static let groupNameRequired = "channelDetail.groupNameRequired"
+        static let groupUpdated = "channelDetail.groupUpdated"
+        static let groupLeft = "channelDetail.groupLeft"
+        static let groupDeleted = "channelDetail.groupDeleted"
+        static let updateGroupFailed = "channelDetail.updateGroupFailed"
+        static let leaveGroupFailed = "channelDetail.leaveGroupFailed"
     }
 
     enum FriendRequest {
@@ -1481,6 +1503,13 @@ extension L10n {
 
         "directMessage.addFriend": "Add Friend",
         "directMessage.you": "You",
+        "directMessage.newGroup": "New Group",
+        "directMessage.create": "Create",
+        "directMessage.searchFriends": "Search friends",
+        "directMessage.memberCount": "%d of %d members",
+        "directMessage.noFriends": "No friends available",
+        "directMessage.memberLimitReached": "Group chats can have up to 20 members.",
+        "directMessage.createFailed": "Could not create group.",
         "directMessage.groupCreated": "Group created",
         "directMessage.previewAttachment": "Attachment",
         "directMessage.previewLink": "Link",
@@ -1709,6 +1738,21 @@ extension L10n {
         "channelDetail.unpinConfirmTitle": "Unpin this message?",
         "channelDetail.unpinConfirmBody": "It will be removed from pinned for everyone in this channel.",
         "channelDetail.unpinConfirmAction": "Unpin",
+        "channelDetail.customizeGroup": "Customize Group",
+        "channelDetail.leaveGroup": "Leave Group",
+        "channelDetail.deleteGroup": "Delete Group",
+        "channelDetail.leaveGroupConfirmTitle": "Leave this group?",
+        "channelDetail.leaveGroupConfirmBody": "You will stop receiving messages from this group.",
+        "channelDetail.deleteGroupConfirmTitle": "Delete this group?",
+        "channelDetail.deleteGroupConfirmBody": "This group will be deleted for everyone.",
+        "channelDetail.groupName": "Group Name",
+        "channelDetail.removeGroupLogo": "Remove Group Logo",
+        "channelDetail.groupNameRequired": "Group name is required.",
+        "channelDetail.groupUpdated": "Group updated",
+        "channelDetail.groupLeft": "You left the group",
+        "channelDetail.groupDeleted": "Group deleted",
+        "channelDetail.updateGroupFailed": "Could not update group.",
+        "channelDetail.leaveGroupFailed": "Could not leave group.",
 
         "embed.onlyVisibleToRecipient": "Only visible to recipient",
 
@@ -2301,6 +2345,13 @@ extension L10n {
 
         "directMessage.addFriend": "Thêm bạn",
         "directMessage.you": "Bạn",
+        "directMessage.newGroup": "Nhóm mới",
+        "directMessage.create": "Tạo",
+        "directMessage.searchFriends": "Tìm bạn bè",
+        "directMessage.memberCount": "%d trên %d thành viên",
+        "directMessage.noFriends": "Chưa có bạn bè để chọn",
+        "directMessage.memberLimitReached": "Nhóm chat chỉ có tối đa 20 thành viên.",
+        "directMessage.createFailed": "Không thể tạo nhóm.",
         "directMessage.groupCreated": "Nhóm đã được tạo",
         "directMessage.previewAttachment": "Đính kèm",
         "directMessage.previewLink": "Liên kết",
@@ -2530,6 +2581,21 @@ extension L10n {
         "channelDetail.unpinConfirmTitle": "Bỏ ghim tin nhắn này?",
         "channelDetail.unpinConfirmBody": "Tin sẽ được gỡ khỏi mục ghim với mọi người trong kênh.",
         "channelDetail.unpinConfirmAction": "Bỏ ghim",
+        "channelDetail.customizeGroup": "Tùy chỉnh nhóm",
+        "channelDetail.leaveGroup": "Rời nhóm",
+        "channelDetail.deleteGroup": "Xóa nhóm",
+        "channelDetail.leaveGroupConfirmTitle": "Rời nhóm này?",
+        "channelDetail.leaveGroupConfirmBody": "Bạn sẽ không nhận tin nhắn từ nhóm này nữa.",
+        "channelDetail.deleteGroupConfirmTitle": "Xóa nhóm này?",
+        "channelDetail.deleteGroupConfirmBody": "Nhóm này sẽ bị xóa với mọi người.",
+        "channelDetail.groupName": "Tên nhóm",
+        "channelDetail.removeGroupLogo": "Xóa logo nhóm",
+        "channelDetail.groupNameRequired": "Vui lòng nhập tên nhóm.",
+        "channelDetail.groupUpdated": "Đã cập nhật nhóm",
+        "channelDetail.groupLeft": "Bạn đã rời nhóm",
+        "channelDetail.groupDeleted": "Đã xóa nhóm",
+        "channelDetail.updateGroupFailed": "Không thể cập nhật nhóm.",
+        "channelDetail.leaveGroupFailed": "Không thể rời nhóm.",
 
         "embed.onlyVisibleToRecipient": "Chỉ người nhận mới thấy được",
 

--- a/MezonChat/Core/MezonEngine/MezonEngine+Channels.swift
+++ b/MezonChat/Core/MezonEngine/MezonEngine+Channels.swift
@@ -23,18 +23,33 @@ extension MezonEngine {
             postbox.channelListView(clanId: clanId)
         }
 
-        func updateChannelDescription(clanId: Int64, channelId: Int64, name: String?, topic: String?, categoryId: Int64?, token: String) async throws {
+        func updateChannelDescription(
+            clanId: Int64,
+            channelId: Int64,
+            name: String?,
+            topic: String?,
+            categoryId: Int64?,
+            channelAvatar: String? = nil,
+            token: String
+        ) async throws {
             let result = try await network.updateChannelDesc(
                 clanId: clanId,
                 channelId: channelId,
                 channelLabel: name,
+                channelAvatar: channelAvatar,
                 topic: topic,
                 categoryId: categoryId,
                 token: token
             )
 
             self.postbox.write { tx in
-                tx.updateChannelDescription(clanId: clanId, channelId: channelId, name: name, topic: topic)
+                tx.updateChannelDescription(
+                    clanId: clanId,
+                    channelId: channelId,
+                    name: name,
+                    topic: topic,
+                    channelAvatar: channelAvatar
+                )
             }
         }
     }

--- a/MezonChat/Core/Postbox/Channel/ChannelRecord.swift
+++ b/MezonChat/Core/Postbox/Channel/ChannelRecord.swift
@@ -61,7 +61,7 @@ struct ChannelRecord: PostboxCoding, Equatable {
         return proto
     }
 
-    func updating(label: String? = nil, topic: String? = nil) -> ChannelRecord {
+    func updating(label: String? = nil, topic: String? = nil, channelAvatar: String? = nil) -> ChannelRecord {
         let newLabel = label ?? self.label
         let newTopic = topic ?? self.topic
 
@@ -71,6 +71,9 @@ struct ChannelRecord: PostboxCoding, Equatable {
         {
             proto.channelLabel = newLabel
             proto.topic = newTopic
+            if let channelAvatar {
+                proto.channelAvatar = channelAvatar
+            }
             updatedProtoData = try? proto.serializedData()
         }
 
@@ -95,6 +98,7 @@ struct ChannelRecord: PostboxCoding, Equatable {
         var updatedCategoryName = self.categoryName
         var updatedParentId = self.parentId
         var updatedType = self.type
+        var updatedChannelAvatar: String?
 
         if !proto.channelLabel.isEmpty { updatedLabel = proto.channelLabel }
         if !proto.topic.isEmpty { updatedTopic = proto.topic }
@@ -102,6 +106,7 @@ struct ChannelRecord: PostboxCoding, Equatable {
         if !proto.categoryName.isEmpty { updatedCategoryName = proto.categoryName }
         if proto.parentID != 0 { updatedParentId = proto.parentID }
         if proto.type != 0 { updatedType = Int32(proto.type) }
+        updatedChannelAvatar = proto.channelAvatar
 
         var updatedProto = self.toProto()
         if !proto.channelLabel.isEmpty { updatedProto.channelLabel = proto.channelLabel }
@@ -110,6 +115,9 @@ struct ChannelRecord: PostboxCoding, Equatable {
         if !proto.categoryName.isEmpty { updatedProto.categoryName = proto.categoryName }
         if proto.parentID != 0 { updatedProto.parentID = proto.parentID }
         if proto.type != 0 { updatedProto.type = proto.type }
+        if let updatedChannelAvatar {
+            updatedProto.channelAvatar = updatedChannelAvatar
+        }
 
         return ChannelRecord(
             id: self.id,

--- a/MezonChat/Core/Postbox/Core/Postbox.swift
+++ b/MezonChat/Core/Postbox/Core/Postbox.swift
@@ -461,6 +461,24 @@ final class Postbox {
         return decodeChannelList(data)
     }
 
+    func updateCachedDMChannelDescription(_ channel: Mezon_Api_ChannelDescription) {
+        var channels = getCachedDMChannelList()
+        if let index = channels.firstIndex(where: { $0.channelID == channel.channelID }) {
+            channels[index] = channel
+        } else {
+            channels.insert(channel, at: 0)
+        }
+        setPreferenceDataSync(key: PreferencesKeys.dmChannelList, value: encodeChannelList(channels))
+        updateCachedAllChannelsByUser(channel)
+    }
+
+    func removeCachedDMChannelDescription(channelId: Int64) {
+        var channels = getCachedDMChannelList()
+        channels.removeAll { $0.channelID == channelId }
+        setPreferenceDataSync(key: PreferencesKeys.dmChannelList, value: encodeChannelList(channels))
+        removeCachedAllChannelsByUser(channelId: channelId)
+    }
+
     private func decodeChannelList(_ data: Data) -> [Mezon_Api_ChannelDescription] {
         guard data.count >= 4 else { return [] }
         let count = data.withUnsafeBytes { $0.load(as: UInt32.self) }
@@ -477,6 +495,43 @@ final class Postbox {
             offset += Int(len)
         }
         return result
+    }
+
+    private func encodeChannelList(_ channels: [Mezon_Api_ChannelDescription]) -> Data {
+        var result = Data()
+        var count = UInt32(channels.count)
+        result.append(contentsOf: withUnsafeBytes(of: &count) { Array($0) })
+        for channel in channels {
+            guard let data = try? channel.serializedData() else { continue }
+            var length = UInt32(data.count)
+            result.append(contentsOf: withUnsafeBytes(of: &length) { Array($0) })
+            result.append(data)
+        }
+        return result
+    }
+
+    private func updateCachedAllChannelsByUser(_ channel: Mezon_Api_ChannelDescription) {
+        guard let data = getPreferenceData(key: PreferencesKeys.allChannelsByUser),
+              var list = try? Mezon_Api_ChannelDescList(serializedBytes: data)
+        else {
+            return
+        }
+        if let index = list.channeldesc.firstIndex(where: { $0.channelID == channel.channelID }) {
+            list.channeldesc[index] = channel
+        } else {
+            list.channeldesc.append(channel)
+        }
+        setPreferenceDataSync(key: PreferencesKeys.allChannelsByUser, value: try? list.serializedData())
+    }
+
+    private func removeCachedAllChannelsByUser(channelId: Int64) {
+        guard let data = getPreferenceData(key: PreferencesKeys.allChannelsByUser),
+              var list = try? Mezon_Api_ChannelDescList(serializedBytes: data)
+        else {
+            return
+        }
+        list.channeldesc.removeAll { $0.channelID == channelId }
+        setPreferenceDataSync(key: PreferencesKeys.allChannelsByUser, value: try? list.serializedData())
     }
 
     func clearAll() {

--- a/MezonChat/Core/Postbox/Core/PostboxTransaction.swift
+++ b/MezonChat/Core/Postbox/Core/PostboxTransaction.swift
@@ -193,11 +193,17 @@ final class PostboxTransaction {
         clanMemberTable.getMembers(clanId: clanId)
     }
 
-    func updateChannelDescription(clanId: Int64, channelId: Int64, name: String?, topic: String?) {
+    func updateChannelDescription(
+        clanId: Int64,
+        channelId: Int64,
+        name: String?,
+        topic: String?,
+        channelAvatar: String? = nil
+    ) {
         let channels = channelTable.getChannels(clanId: clanId)
         if let index = channels.firstIndex(where: { $0.id == channelId }) {
             let existing = channels[index]
-            let updated = existing.updating(label: name, topic: topic)
+            let updated = existing.updating(label: name, topic: topic, channelAvatar: channelAvatar)
             channelTable.updateSingleChannelRecord(updated)
             updatedChannelClanIds.insert(clanId)
         }

--- a/MezonChat/Features/ChannelDetail/ChannelDetailContainerNode.swift
+++ b/MezonChat/Features/ChannelDetail/ChannelDetailContainerNode.swift
@@ -16,8 +16,10 @@ final class ChannelDetailContainerNode: ASDisplayNode {
     private let onSearchTapped: () -> Void
     private let onThreadsTapped: () -> Void
     private let onMuteTapped: () -> Void
+    private let onGroupOptionsTapped: () -> Void
 
     private let backButtonNode = ASButtonNode()
+    private let moreButtonNode = ASButtonNode()
     private let headerTrailingSpacerNode = ASDisplayNode()
     private let titleNode = ASTextNode2()
     private let channelIconNode = ASImageNode()
@@ -41,7 +43,7 @@ final class ChannelDetailContainerNode: ASDisplayNode {
         context: AccountContext, clanId: Int64, channel: Mezon_Api_ChannelDescription,
         onClose: @escaping () -> Void, onSettingsTapped: @escaping () -> Void,
         onSearchTapped: @escaping () -> Void, onThreadsTapped: @escaping () -> Void,
-        onMuteTapped: @escaping () -> Void
+        onMuteTapped: @escaping () -> Void, onGroupOptionsTapped: @escaping () -> Void
     ) {
         self.context = context
         self.clanId = clanId
@@ -51,6 +53,7 @@ final class ChannelDetailContainerNode: ASDisplayNode {
         self.onSearchTapped = onSearchTapped
         self.onThreadsTapped = onThreadsTapped
         self.onMuteTapped = onMuteTapped
+        self.onGroupOptionsTapped = onGroupOptionsTapped
 
         let myId = context.currentUser.flatMap { Int64($0.id) }
         self.visibleTabs = Self.visibleTabsList(channel: channel, currentUserId: myId)
@@ -158,9 +161,21 @@ final class ChannelDetailContainerNode: ASDisplayNode {
         backButtonNode.contentHorizontalAlignment = .middle
         backButtonNode.contentVerticalAlignment = .center
 
-        configureChannelHeaderVisuals()
+        moreButtonNode.setImage(
+            UIImage(systemName: "ellipsis")?.withTintColor(
+                UIColor.theme.textStrong, renderingMode: .alwaysOriginal), for: .normal)
+        moreButtonNode.addTarget(
+            self, action: #selector(groupOptionsPressed), forControlEvents: .touchUpInside)
+        moreButtonNode.style.preferredSize = CGSize(width: 52.sf, height: 44.sf)
+        moreButtonNode.contentHorizontalAlignment = .middle
+        moreButtonNode.contentVerticalAlignment = .center
 
-        headerTrailingSpacerNode.style.preferredSize = CGSize(width: 44.sf, height: 44.sf)
+        configureChannelHeaderVisuals()
+        titleNode.maximumNumberOfLines = 1
+        titleNode.truncationMode = .byTruncatingTail
+        titleNode.style.flexShrink = 1
+
+        headerTrailingSpacerNode.style.preferredSize = CGSize(width: 52.sf, height: 44.sf)
         headerTrailingSpacerNode.isUserInteractionEnabled = false
         headerTrailingSpacerNode.backgroundColor = .clear
     }
@@ -259,6 +274,11 @@ final class ChannelDetailContainerNode: ASDisplayNode {
 
     @objc private func backPressed() { onClose() }
     @objc private func settingsPressed() { onSettingsTapped() }
+    @objc private func groupOptionsPressed() { onGroupOptionsTapped() }
+
+    private var isGroupDirectMessage: Bool {
+        clanId == 0 && channel.type == MezonConstants.ChannelType.group.rawValue
+    }
 
     private func activeContentNode() -> ASDisplayNode {
         guard activeTabIndex < visibleTabs.count else { return membersListNode }
@@ -280,6 +300,13 @@ final class ChannelDetailContainerNode: ASDisplayNode {
             alignItems: .center,
             children: [channelIconNode, titleNode]
         )
+        let headerHorizontalControlsWidth = 44.sf + 52.sf
+        let headerTitlePadding: CGFloat = 20.sw
+        let maxHeaderContentWidth = max(
+            0,
+            constrainedSize.max.width - 32.sw - headerHorizontalControlsWidth - headerTitlePadding
+        )
+        titleNode.style.maxWidth = ASDimension(unit: .points, value: maxHeaderContentWidth)
         headerContent.style.flexShrink = 1
 
         let titleCentered = ASCenterLayoutSpec(
@@ -294,7 +321,7 @@ final class ChannelDetailContainerNode: ASDisplayNode {
             spacing: 0,
             justifyContent: .start,
             alignItems: .center,
-            children: [backButtonNode, titleCentered, headerTrailingSpacerNode]
+            children: [backButtonNode, titleCentered, isGroupDirectMessage ? moreButtonNode : headerTrailingSpacerNode]
         )
         topBar.style.height = ASDimensionMake(56.sf)
         topBar.style.alignSelf = .stretch
@@ -364,6 +391,9 @@ final class ChannelDetailContainerNode: ASDisplayNode {
         configureChannelHeaderVisuals()
         backButtonNode.setImage(
             UIImage(systemName: "chevron.left")?.withTintColor(
+                t.textStrong, renderingMode: .alwaysOriginal), for: .normal)
+        moreButtonNode.setImage(
+            UIImage(systemName: "ellipsis")?.withTintColor(
                 t.textStrong, renderingMode: .alwaysOriginal), for: .normal)
         for i in 0..<visibleTabs.count {
             updateTabAppearance(index: i, title: title(for: visibleTabs[i]))

--- a/MezonChat/Features/ChannelDetail/ChannelDetailViewController.swift
+++ b/MezonChat/Features/ChannelDetail/ChannelDetailViewController.swift
@@ -46,6 +46,9 @@ final class ChannelDetailViewController: ViewController {
             },
             onMuteTapped: { [weak self] in
                 self?.handleMuteButtonTapped()
+            },
+            onGroupOptionsTapped: { [weak self] in
+                self?.showGroupDMOptions()
             }
         )
     }
@@ -202,6 +205,696 @@ final class ChannelDetailViewController: ViewController {
             clanId: channel.clanID,
             muteTimeSeconds: muteTimeSeconds
         )
+    }
+
+    private var isGroupDirectMessage: Bool {
+        clanId == 0 && resolvedChannelTypeForDetail() == MezonConstants.ChannelType.group.rawValue
+    }
+
+    private var currentUserNumericId: Int64? {
+        context.currentUser.flatMap { Int64($0.id) }
+    }
+
+    private func estimatedGroupMemberCount() -> Int {
+        if channel.memberCount > 0 {
+            return Int(channel.memberCount)
+        }
+        var ids = Set(channel.userIds)
+        if let myId = currentUserNumericId {
+            ids.insert(myId)
+        }
+        return max(ids.count, 1)
+    }
+
+    private func showGroupDMOptions() {
+        guard isGroupDirectMessage else { return }
+
+        let deleteByEstimate = estimatedGroupMemberCount() <= 1
+        let leaveTitle = deleteByEstimate ? L(L10n.ChannelDetail.deleteGroup) : L(L10n.ChannelDetail.leaveGroup)
+        let sheet = GroupDMOptionsSheetViewController(
+            customizeTitle: L(L10n.ChannelDetail.customizeGroup),
+            leaveTitle: leaveTitle,
+            isDeleteAction: deleteByEstimate,
+            onCustomize: { [weak self] in
+                self?.presentCustomizeGroup()
+            },
+            onLeaveOrDelete: { [weak self] in
+                self?.confirmLeaveOrDeleteGroup()
+            }
+        )
+        sheet.modalPresentationStyle = .overFullScreen
+        sheet.modalTransitionStyle = .crossDissolve
+        present(sheet, animated: false)
+    }
+
+    private func presentCustomizeGroup() {
+        let vc = GroupDMCustomizeViewController(context: context, channel: channel) { [weak self] updated in
+            self?.applyUpdatedGroupDM(updated)
+        }
+        vc.modalPresentationStyle = .pageSheet
+        if #available(iOS 15.0, *) {
+            vc.sheetPresentationController?.detents = [.medium()]
+            vc.sheetPresentationController?.prefersGrabberVisible = true
+        }
+        present(vc, animated: true)
+    }
+
+    private func applyUpdatedGroupDM(_ updated: Mezon_Api_ChannelDescription) {
+        channel = updated
+        context.account.postbox.updateCachedDMChannelDescription(updated)
+        detailNode.applyUpdatedChannel(updated)
+        NotificationCenter.default.post(
+            name: .mezonChannelDescriptionDidUpdate,
+            object: nil,
+            userInfo: ["clanId": Int64(0), "channelId": updated.channelID]
+        )
+    }
+
+    private func confirmLeaveOrDeleteGroup() {
+        let deleteByEstimate = estimatedGroupMemberCount() <= 1
+        let title = deleteByEstimate
+            ? L(L10n.ChannelDetail.deleteGroupConfirmTitle)
+            : L(L10n.ChannelDetail.leaveGroupConfirmTitle)
+        let message = deleteByEstimate
+            ? L(L10n.ChannelDetail.deleteGroupConfirmBody)
+            : L(L10n.ChannelDetail.leaveGroupConfirmBody)
+        let actionTitle = deleteByEstimate ? L(L10n.ChannelDetail.deleteGroup) : L(L10n.ChannelDetail.leaveGroup)
+
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: L(L10n.Common.cancel), style: .cancel))
+        alert.addAction(UIAlertAction(title: actionTitle, style: .destructive) { [weak self] _ in
+            self?.performLeaveOrDeleteGroup()
+        })
+        present(alert, animated: true)
+    }
+
+    private func shouldDeleteGroup(token: String) async -> Bool {
+        do {
+            let response = try await context.account.network.listChannelUsersUC(
+                channelId: channel.channelID,
+                limit: 500,
+                token: token
+            )
+            if !response.userIds.isEmpty {
+                return Set(response.userIds).count <= 1
+            }
+        } catch {
+        }
+        return estimatedGroupMemberCount() <= 1
+    }
+
+    private func performLeaveOrDeleteGroup() {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard let token = await self.context.getToken() else {
+                Toast.error(L(L10n.ClanInviteSheet.sessionNotFound))
+                return
+            }
+            guard let myId = self.currentUserNumericId else {
+                Toast.error(L(L10n.ChannelDetail.leaveGroupFailed))
+                return
+            }
+
+            do {
+                let deleteGroup = await self.shouldDeleteGroup(token: token)
+                if deleteGroup {
+                    try await self.context.account.network.deleteChannelDesc(
+                        channelId: self.channel.channelID,
+                        clanId: 0,
+                        token: token
+                    )
+                } else {
+                    try await self.context.account.network.removeChannelUsers(
+                        channelId: self.channel.channelID,
+                        userIds: [myId],
+                        token: token
+                    )
+                }
+                self.context.account.postbox.removeCachedDMChannelDescription(channelId: self.channel.channelID)
+                NotificationCenter.default.post(
+                    name: .mezonChannelDescriptionDidUpdate,
+                    object: nil,
+                    userInfo: ["clanId": Int64(0), "channelId": self.channel.channelID, "removed": true]
+                )
+                Toast.success(deleteGroup ? L(L10n.ChannelDetail.groupDeleted) : L(L10n.ChannelDetail.groupLeft))
+                self.exitRemovedGroupDM()
+            } catch {
+                Toast.error(L(L10n.ChannelDetail.leaveGroupFailed))
+            }
+        }
+    }
+
+    private func exitRemovedGroupDM() {
+        guard let navigationController else {
+            dismiss(animated: true)
+            return
+        }
+        guard let mezonNavigation = navigationController as? NavigationController else {
+            navigationController.popViewController(animated: true)
+            return
+        }
+
+        var stack = mezonNavigation.viewControllers
+        if let detailIndex = stack.firstIndex(where: { $0 === self }) {
+            stack.remove(at: detailIndex)
+            let previousIndex = detailIndex - 1
+            if previousIndex >= 0, previousIndex < stack.count, stack[previousIndex] is ChatViewController {
+                stack.remove(at: previousIndex)
+            }
+        } else if !stack.isEmpty {
+            stack.removeLast()
+        }
+
+        if stack.isEmpty {
+            mezonNavigation.popToRoot(animated: true)
+        } else {
+            mezonNavigation.setViewControllers(stack, animated: true)
+        }
+    }
+}
+
+private final class GroupDMOptionsSheetViewController: UIViewController {
+
+    private let customizeTitle: String
+    private let leaveTitle: String
+    private let isDeleteAction: Bool
+    private let onCustomize: () -> Void
+    private let onLeaveOrDelete: () -> Void
+
+    private let dimView = UIView()
+    private let containerView = UIView()
+    private var didAnimateIn = false
+
+    init(
+        customizeTitle: String,
+        leaveTitle: String,
+        isDeleteAction: Bool,
+        onCustomize: @escaping () -> Void,
+        onLeaveOrDelete: @escaping () -> Void
+    ) {
+        self.customizeTitle = customizeTitle
+        self.leaveTitle = leaveTitle
+        self.isDeleteAction = isDeleteAction
+        self.onCustomize = onCustomize
+        self.onLeaveOrDelete = onLeaveOrDelete
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        guard !didAnimateIn else { return }
+        didAnimateIn = true
+        animateIn()
+    }
+
+    private func setupUI() {
+        view.backgroundColor = .clear
+
+        dimView.translatesAutoresizingMaskIntoConstraints = false
+        dimView.backgroundColor = UIColor.black.withAlphaComponent(0.36)
+        dimView.alpha = 0
+        dimView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(backgroundTapped)))
+
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        containerView.backgroundColor = UIColor.theme.primary
+        containerView.layer.cornerRadius = 24.sf
+        containerView.layer.masksToBounds = true
+
+        let customizeButton = makeActionButton(
+            title: customizeTitle,
+            symbolName: "pencil",
+            titleColor: UIColor.theme.textStrong
+        )
+        customizeButton.addTarget(self, action: #selector(customizePressed), for: .touchUpInside)
+
+        let leaveButton = makeActionButton(
+            title: leaveTitle,
+            symbolName: isDeleteAction ? "trash.fill" : "rectangle.and.arrow.right",
+            titleColor: UIColor.systemRed
+        )
+        leaveButton.addTarget(self, action: #selector(leavePressed), for: .touchUpInside)
+
+        let stack = UIStackView(arrangedSubviews: [customizeButton, leaveButton])
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.alignment = .fill
+        stack.spacing = 10.sh
+
+        view.addSubview(dimView)
+        view.addSubview(containerView)
+        containerView.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            dimView.topAnchor.constraint(equalTo: view.topAnchor),
+            dimView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            dimView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            dimView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            containerView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16.sw),
+            containerView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16.sw),
+            containerView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -10.sh),
+
+            stack.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 16.sh),
+            stack.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 14.sw),
+            stack.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -14.sw),
+            stack.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -16.sh),
+
+            customizeButton.heightAnchor.constraint(equalToConstant: 52.sh),
+            leaveButton.heightAnchor.constraint(equalToConstant: 52.sh)
+        ])
+    }
+
+    private func makeActionButton(title: String, symbolName: String, titleColor: UIColor) -> UIButton {
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.backgroundColor = UIColor.theme.secondary
+        button.layer.cornerRadius = 16.sf
+        button.setTitle(title, for: .normal)
+        button.setTitleColor(titleColor, for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 16.sf, weight: .semibold)
+        button.contentHorizontalAlignment = .leading
+        button.contentEdgeInsets = UIEdgeInsets(top: 0, left: 18.sw, bottom: 0, right: 18.sw)
+        button.imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 10.sw)
+        button.titleEdgeInsets = UIEdgeInsets(top: 0, left: 10.sw, bottom: 0, right: -10.sw)
+        button.tintColor = titleColor
+        button.setImage(UIImage(systemName: symbolName), for: .normal)
+        return button
+    }
+
+    private func animateIn() {
+        view.layoutIfNeeded()
+        containerView.transform = CGAffineTransform(translationX: 0, y: containerView.bounds.height + 40.sh)
+        UIView.animate(withDuration: 0.24, delay: 0, options: [.curveEaseOut]) {
+            self.dimView.alpha = 1
+            self.containerView.transform = .identity
+        }
+    }
+
+    private func dismissSheet(completion: (() -> Void)? = nil) {
+        UIView.animate(withDuration: 0.18, delay: 0, options: [.curveEaseIn]) {
+            self.dimView.alpha = 0
+            self.containerView.transform = CGAffineTransform(translationX: 0, y: self.containerView.bounds.height + 40.sh)
+        } completion: { _ in
+            self.dismiss(animated: false, completion: completion)
+        }
+    }
+
+    @objc private func backgroundTapped() {
+        dismissSheet()
+    }
+
+    @objc private func customizePressed() {
+        dismissSheet(completion: onCustomize)
+    }
+
+    @objc private func leavePressed() {
+        dismissSheet(completion: onLeaveOrDelete)
+    }
+}
+
+private final class GroupDMCustomizeViewController: UIViewController, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+
+    private static let maxAvatarBytes = 10 * 1024 * 1024
+
+    private let context: AccountContext
+    private let originalChannel: Mezon_Api_ChannelDescription
+    private let onSaved: (Mezon_Api_ChannelDescription) -> Void
+
+    private var avatarURL: String
+    private var selectedImage: UIImage?
+    private var selectedImageData: Data?
+    private var avatarLoadTask: URLSessionDataTask?
+    private var isSaving = false
+
+    private let titleLabel = UILabel()
+    private let avatarButton = UIButton(type: .system)
+    private let avatarImageView = UIImageView()
+    private let avatarPlaceholderImageView = UIImageView()
+    private let removeAvatarButton = UIButton(type: .system)
+    private let nameLabel = UILabel()
+    private let nameField = UITextField()
+    private let cancelButton = UIButton(type: .system)
+    private let saveButton = UIButton(type: .system)
+    private let activityIndicator = UIActivityIndicatorView(style: .medium)
+
+    init(
+        context: AccountContext,
+        channel: Mezon_Api_ChannelDescription,
+        onSaved: @escaping (Mezon_Api_ChannelDescription) -> Void
+    ) {
+        self.context = context
+        self.originalChannel = channel
+        self.avatarURL = channel.channelAvatar
+        self.onSaved = onSaved
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    deinit {
+        avatarLoadTask?.cancel()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        updateAvatarPreview()
+    }
+
+    private func setupUI() {
+        view.backgroundColor = UIColor.theme.primary
+
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.text = L(L10n.ChannelDetail.customizeGroup)
+        titleLabel.textColor = UIColor.theme.textStrong
+        titleLabel.font = .systemFont(ofSize: 20.sf, weight: .bold)
+
+        avatarButton.translatesAutoresizingMaskIntoConstraints = false
+        avatarButton.backgroundColor = UIColor.theme.secondary
+        avatarButton.layer.cornerRadius = 44.swh
+        avatarButton.clipsToBounds = true
+        avatarButton.addTarget(self, action: #selector(pickAvatarTapped), for: .touchUpInside)
+
+        avatarImageView.translatesAutoresizingMaskIntoConstraints = false
+        avatarImageView.contentMode = .scaleAspectFill
+        avatarImageView.clipsToBounds = true
+
+        avatarPlaceholderImageView.translatesAutoresizingMaskIntoConstraints = false
+        avatarPlaceholderImageView.image = UIImage(systemName: "person.2.fill")
+        avatarPlaceholderImageView.tintColor = .white
+        avatarPlaceholderImageView.contentMode = .scaleAspectFit
+
+        let avatarOverlay = UIView()
+        avatarOverlay.translatesAutoresizingMaskIntoConstraints = false
+        avatarOverlay.backgroundColor = UIColor.black.withAlphaComponent(0.18)
+        avatarOverlay.isUserInteractionEnabled = false
+
+        let cameraImageView = UIImageView(image: UIImage(systemName: "camera.fill"))
+        cameraImageView.translatesAutoresizingMaskIntoConstraints = false
+        cameraImageView.tintColor = .white
+        cameraImageView.contentMode = .scaleAspectFit
+
+        avatarButton.addSubview(avatarImageView)
+        avatarButton.addSubview(avatarPlaceholderImageView)
+        avatarButton.addSubview(avatarOverlay)
+        avatarButton.addSubview(cameraImageView)
+
+        removeAvatarButton.translatesAutoresizingMaskIntoConstraints = false
+        removeAvatarButton.setTitle(L(L10n.ChannelDetail.removeGroupLogo), for: .normal)
+        removeAvatarButton.setTitleColor(UIColor.systemRed, for: .normal)
+        removeAvatarButton.titleLabel?.font = .systemFont(ofSize: 14.sf, weight: .medium)
+        removeAvatarButton.addTarget(self, action: #selector(removeAvatarTapped), for: .touchUpInside)
+
+        nameLabel.translatesAutoresizingMaskIntoConstraints = false
+        nameLabel.text = L(L10n.ChannelDetail.groupName)
+        nameLabel.textColor = UIColor.theme.text
+        nameLabel.font = .systemFont(ofSize: 13.sf, weight: .semibold)
+
+        nameField.translatesAutoresizingMaskIntoConstraints = false
+        nameField.text = originalChannel.channelLabel
+        nameField.placeholder = L(L10n.ChannelDetail.groupName)
+        nameField.textColor = UIColor.theme.textStrong
+        nameField.font = .systemFont(ofSize: 16.sf, weight: .regular)
+        nameField.backgroundColor = UIColor.theme.secondary
+        nameField.layer.cornerRadius = 10.sf
+        nameField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 12.sw, height: 1))
+        nameField.leftViewMode = .always
+        nameField.rightView = UIView(frame: CGRect(x: 0, y: 0, width: 12.sw, height: 1))
+        nameField.rightViewMode = .always
+        nameField.clearButtonMode = .whileEditing
+        nameField.returnKeyType = .done
+        nameField.addTarget(self, action: #selector(nameFieldDidReturn), for: .editingDidEndOnExit)
+
+        cancelButton.translatesAutoresizingMaskIntoConstraints = false
+        cancelButton.setTitle(L(L10n.Common.cancel), for: .normal)
+        cancelButton.setTitleColor(UIColor.theme.textStrong, for: .normal)
+        cancelButton.titleLabel?.font = .systemFont(ofSize: 16.sf, weight: .semibold)
+        cancelButton.backgroundColor = UIColor.theme.secondary
+        cancelButton.layer.cornerRadius = 10.sf
+        cancelButton.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
+
+        saveButton.translatesAutoresizingMaskIntoConstraints = false
+        saveButton.setTitle(L(L10n.Common.save), for: .normal)
+        saveButton.setTitleColor(.white, for: .normal)
+        saveButton.titleLabel?.font = .systemFont(ofSize: 16.sf, weight: .semibold)
+        saveButton.backgroundColor = UIColor.theme.bgViolet
+        saveButton.layer.cornerRadius = 10.sf
+        saveButton.addTarget(self, action: #selector(saveTapped), for: .touchUpInside)
+
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+        activityIndicator.hidesWhenStopped = true
+        activityIndicator.color = .white
+
+        let avatarStack = UIStackView(arrangedSubviews: [avatarButton, removeAvatarButton])
+        avatarStack.translatesAutoresizingMaskIntoConstraints = false
+        avatarStack.axis = .vertical
+        avatarStack.alignment = .center
+        avatarStack.spacing = 8.sh
+
+        let buttonStack = UIStackView(arrangedSubviews: [cancelButton, saveButton])
+        buttonStack.translatesAutoresizingMaskIntoConstraints = false
+        buttonStack.axis = .horizontal
+        buttonStack.spacing = 12.sw
+        buttonStack.distribution = .fillEqually
+
+        let contentStack = UIStackView(arrangedSubviews: [
+            titleLabel,
+            avatarStack,
+            nameLabel,
+            nameField,
+            buttonStack
+        ])
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
+        contentStack.axis = .vertical
+        contentStack.spacing = 14.sh
+        contentStack.setCustomSpacing(18.sh, after: titleLabel)
+        contentStack.setCustomSpacing(8.sh, after: nameLabel)
+
+        view.addSubview(contentStack)
+        saveButton.addSubview(activityIndicator)
+
+        NSLayoutConstraint.activate([
+            contentStack.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 24.sh),
+            contentStack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24.sw),
+            contentStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24.sw),
+            contentStack.bottomAnchor.constraint(lessThanOrEqualTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20.sh),
+
+            avatarButton.widthAnchor.constraint(equalToConstant: 88.swh),
+            avatarButton.heightAnchor.constraint(equalToConstant: 88.swh),
+
+            avatarImageView.topAnchor.constraint(equalTo: avatarButton.topAnchor),
+            avatarImageView.leadingAnchor.constraint(equalTo: avatarButton.leadingAnchor),
+            avatarImageView.trailingAnchor.constraint(equalTo: avatarButton.trailingAnchor),
+            avatarImageView.bottomAnchor.constraint(equalTo: avatarButton.bottomAnchor),
+
+            avatarPlaceholderImageView.centerXAnchor.constraint(equalTo: avatarButton.centerXAnchor),
+            avatarPlaceholderImageView.centerYAnchor.constraint(equalTo: avatarButton.centerYAnchor),
+            avatarPlaceholderImageView.widthAnchor.constraint(equalToConstant: 38.swh),
+            avatarPlaceholderImageView.heightAnchor.constraint(equalToConstant: 38.swh),
+
+            avatarOverlay.leadingAnchor.constraint(equalTo: avatarButton.leadingAnchor),
+            avatarOverlay.trailingAnchor.constraint(equalTo: avatarButton.trailingAnchor),
+            avatarOverlay.bottomAnchor.constraint(equalTo: avatarButton.bottomAnchor),
+            avatarOverlay.heightAnchor.constraint(equalToConstant: 30.sh),
+
+            cameraImageView.centerXAnchor.constraint(equalTo: avatarOverlay.centerXAnchor),
+            cameraImageView.centerYAnchor.constraint(equalTo: avatarOverlay.centerYAnchor),
+            cameraImageView.widthAnchor.constraint(equalToConstant: 17.swh),
+            cameraImageView.heightAnchor.constraint(equalToConstant: 17.swh),
+
+            nameField.heightAnchor.constraint(equalToConstant: 46.sh),
+            cancelButton.heightAnchor.constraint(equalToConstant: 46.sh),
+            saveButton.heightAnchor.constraint(equalToConstant: 46.sh),
+
+            activityIndicator.centerXAnchor.constraint(equalTo: saveButton.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: saveButton.centerYAnchor),
+        ])
+    }
+
+    private func updateAvatarPreview() {
+        avatarLoadTask?.cancel()
+        avatarLoadTask = nil
+
+        if let selectedImage {
+            avatarImageView.image = selectedImage
+            avatarImageView.isHidden = false
+            avatarPlaceholderImageView.isHidden = true
+            removeAvatarButton.isHidden = false
+            return
+        }
+
+        let trimmed = avatarURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        removeAvatarButton.isHidden = trimmed.isEmpty
+        guard !trimmed.isEmpty, !trimmed.contains("avatar-group.png") else {
+            avatarImageView.image = nil
+            avatarImageView.isHidden = true
+            avatarPlaceholderImageView.isHidden = false
+            avatarButton.backgroundColor = UIColor.theme.bgViolet
+            return
+        }
+
+        let proxied = ImgproxyURL.avatarProxyURL(from: trimmed, width: 180, height: 180)
+        if let cached = ImageCache.shared.cachedImage(forURL: proxied) {
+            avatarImageView.image = cached
+            avatarImageView.isHidden = false
+            avatarPlaceholderImageView.isHidden = true
+            return
+        }
+
+        avatarImageView.image = nil
+        avatarImageView.isHidden = true
+        avatarPlaceholderImageView.isHidden = false
+        avatarButton.backgroundColor = UIColor.theme.bgViolet
+        avatarLoadTask = ImageCache.shared.loadImage(urlString: proxied) { [weak self] image in
+            guard let self, let image else { return }
+            self.avatarImageView.image = image
+            self.avatarImageView.isHidden = false
+            self.avatarPlaceholderImageView.isHidden = true
+        }
+    }
+
+    @objc private func pickAvatarTapped() {
+        guard UIImagePickerController.isSourceTypeAvailable(.photoLibrary) else { return }
+        let picker = UIImagePickerController()
+        picker.sourceType = .photoLibrary
+        picker.allowsEditing = true
+        picker.delegate = self
+        present(picker, animated: true)
+    }
+
+    @objc private func removeAvatarTapped() {
+        avatarURL = ""
+        selectedImage = nil
+        selectedImageData = nil
+        updateAvatarPreview()
+    }
+
+    @objc private func nameFieldDidReturn() {
+        view.endEditing(true)
+    }
+
+    @objc private func cancelTapped() {
+        dismiss(animated: true)
+    }
+
+    @objc private func saveTapped() {
+        guard !isSaving else { return }
+        let name = (nameField.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else {
+            Toast.error(L(L10n.ChannelDetail.groupNameRequired))
+            return
+        }
+
+        setSaving(true)
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer { self.setSaving(false) }
+            guard let token = await self.context.getToken() else {
+                Toast.error(L(L10n.ClanInviteSheet.sessionNotFound))
+                return
+            }
+            do {
+                let uploadedAvatarURL = try await self.uploadSelectedAvatarIfNeeded(token: token)
+                let response = try await self.context.account.network.updateChannelDesc(
+                    clanId: 0,
+                    channelId: self.originalChannel.channelID,
+                    channelLabel: name,
+                    channelAvatar: uploadedAvatarURL,
+                    token: token
+                )
+
+                var updated = self.originalChannel
+                updated.channelLabel = response.channelLabel.isEmpty ? name : response.channelLabel
+                updated.channelAvatar = uploadedAvatarURL
+                if response.type != 0 {
+                    updated.type = response.type
+                } else if updated.type == 0 {
+                    updated.type = MezonConstants.ChannelType.group.rawValue
+                }
+                updated.clanID = 0
+                if response.updateTimeSeconds != 0 {
+                    updated.updateTimeSeconds = response.updateTimeSeconds
+                }
+
+                self.onSaved(updated)
+                Toast.success(L(L10n.ChannelDetail.groupUpdated))
+                self.dismiss(animated: true)
+            } catch {
+                Toast.error(L(L10n.ChannelDetail.updateGroupFailed))
+            }
+        }
+    }
+
+    private func setSaving(_ saving: Bool) {
+        isSaving = saving
+        nameField.isEnabled = !saving
+        cancelButton.isEnabled = !saving
+        saveButton.isEnabled = !saving
+        avatarButton.isEnabled = !saving
+        removeAvatarButton.isEnabled = !saving
+        saveButton.setTitle(saving ? nil : L(L10n.Common.save), for: .normal)
+        if saving {
+            activityIndicator.startAnimating()
+        } else {
+            activityIndicator.stopAnimating()
+        }
+    }
+
+    private func uploadSelectedAvatarIfNeeded(token: String) async throws -> String {
+        guard let selectedImage, let selectedImageData else {
+            return avatarURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        guard selectedImageData.count <= Self.maxAvatarBytes else {
+            throw MezonError.httpError(statusCode: 0, message: "File size exceeds 10MB limit")
+        }
+
+        let filename = "group_dm_\(originalChannel.channelID)_\(Int(Date().timeIntervalSince1970)).jpg"
+        let filetype = "image/jpeg"
+        let uploadInfo = try await context.account.network.uploadAttachmentFile(
+            filename: filename,
+            filetype: filetype,
+            size: selectedImageData.count,
+            width: Int(selectedImage.size.width),
+            height: Int(selectedImage.size.height),
+            token: token
+        )
+        try await context.account.network.uploadToMinIO(
+            url: uploadInfo.url,
+            data: selectedImageData,
+            contentType: filetype
+        )
+        let cdnURL = "\(MezonConfig.baseImgURL)/\(uploadInfo.filename)"
+        ImageCache.shared.setImage(selectedImage, data: selectedImageData, forKey: cdnURL)
+        return cdnURL
+    }
+
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        picker.dismiss(animated: true)
+    }
+
+    func imagePickerController(
+        _ picker: UIImagePickerController,
+        didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+    ) {
+        let image = (info[.editedImage] as? UIImage) ?? (info[.originalImage] as? UIImage)
+        picker.dismiss(animated: true) { [weak self] in
+            guard let self, let image else { return }
+            guard let data = image.jpegData(compressionQuality: 0.85) else { return }
+            if data.count > Self.maxAvatarBytes {
+                Toast.error("File size exceeds 10MB limit")
+                return
+            }
+            self.selectedImage = image
+            self.selectedImageData = data
+            self.updateAvatarPreview()
+        }
     }
 }
 

--- a/MezonChat/Features/Chat/ChatViewController.swift
+++ b/MezonChat/Features/Chat/ChatViewController.swift
@@ -775,15 +775,29 @@ final class ChatViewController: ViewController {
 
     @objc private func handleChannelMetadataChanged(_ notification: Notification) {
         guard let cid = Self.userInfoInt64(notification.userInfo?["channelId"]), cid == channel.channelID else { return }
+        let typeWasUnknown = channel.type == 0
+        var updatedChannel: Mezon_Api_ChannelDescription?
         if clanId != 0 {
             if let notifyClan = Self.userInfoInt64(notification.userInfo?["clanId"]), notifyClan != clanId {
                 return
             }
             if let cached = context.account.postbox.resolvedChannelDescription(clanId: clanId, channelId: channel.channelID) {
-                channel = cached
+                updatedChannel = cached
             }
         } else if let cached = context.account.postbox.getDMChannelDescription(channelId: channel.channelID) {
-            channel = cached
+            updatedChannel = cached
+        }
+
+        if let updatedChannel {
+            channel = updatedChannel
+            if !updatedChannel.channelLabel.isEmpty {
+                setChannelLabel(updatedChannel.channelLabel)
+            }
+            sendInputViewController.channel = updatedChannel
+            syncChannelToComposer()
+            if typeWasUnknown && updatedChannel.type != 0 {
+                rejoinChatIfChannelMetadataChanged()
+            }
         }
         metadataOnlyPipe.putNext(())
     }

--- a/MezonChat/Features/DirectMessages/DirectMessagesContainerNode.swift
+++ b/MezonChat/Features/DirectMessages/DirectMessagesContainerNode.swift
@@ -4,6 +4,7 @@ import AsyncDisplayKit
 struct DirectMessagesInteraction {
     let onSelectDirectMessage: (Mezon_Api_ChannelDescription) -> Void
     let onAddFriendTapped: () -> Void
+    let onCreateGroupTapped: () -> Void
     let onSearchTapped: () -> Void
     let onBackTapped: () -> Void
     let onRefresh: () -> Void
@@ -17,6 +18,7 @@ final class DirectMessagesContainerNode: ASDisplayNode {
     private let addFriendButton = UIButton(type: .system)
     private let badgeLabel = UILabel()
     private let searchButton = UIButton(type: .system)
+    private let createGroupButton = UIButton(type: .system)
     private let tableView: UITableView
     private let activityStrip = DmMessageActivityStripView()
     private let activityTableHeaderWrapper = UIView()
@@ -140,6 +142,20 @@ final class DirectMessagesContainerNode: ASDisplayNode {
         }
         searchButton.addTarget(self, action: #selector(searchTapped), for: .touchUpInside)
 
+        createGroupButton.backgroundColor = UIColor(red: 88/255, green: 101/255, blue: 242/255, alpha: 1.0)
+        createGroupButton.tintColor = .white
+        createGroupButton.layer.cornerRadius = 25.swh
+        createGroupButton.layer.shadowColor = UIColor.black.cgColor
+        createGroupButton.layer.shadowOpacity = 0.22
+        createGroupButton.layer.shadowRadius = 10
+        createGroupButton.layer.shadowOffset = CGSize(width: 0, height: 4)
+        createGroupButton.setImage(
+            UIImage(systemName: "plus", withConfiguration: UIImage.SymbolConfiguration(pointSize: 18.sf, weight: .semibold)),
+            for: .normal
+        )
+        createGroupButton.accessibilityLabel = L(L10n.DirectMessage.newGroup)
+        createGroupButton.addTarget(self, action: #selector(createGroupTapped), for: .touchUpInside)
+
         activityStrip.onSelect = { [weak self] item in
             self?.interaction.onSelectMessageActivity(item)
         }
@@ -149,6 +165,7 @@ final class DirectMessagesContainerNode: ASDisplayNode {
         view.addSubview(badgeLabel)
         view.addSubview(searchButton)
         view.addSubview(tableView)
+        view.addSubview(createGroupButton)
 
         activityTableHeaderWrapper.backgroundColor = .clear
         activityStrip.autoresizingMask = [.flexibleWidth, .flexibleHeight]
@@ -208,6 +225,17 @@ final class DirectMessagesContainerNode: ASDisplayNode {
         let tvHeight = size.height - tvTop - bottomInset
 
         transition.updateFrame(view: tableView, frame: CGRect(x: 0, y: tvTop, width: size.width, height: tvHeight))
+        tableView.contentInset.bottom = 76.sh
+        tableView.scrollIndicatorInsets.bottom = 76.sh
+
+        let createButtonSize: CGFloat = 50.swh
+        let createButtonX = size.width - sideInset - createButtonSize
+        let createButtonY = size.height - bottomInset - createButtonSize - 18.sh
+        transition.updateFrame(
+            view: createGroupButton,
+            frame: CGRect(x: createButtonX, y: createButtonY, width: createButtonSize, height: createButtonSize)
+        )
+        createGroupButton.layer.cornerRadius = createButtonSize / 2
         syncActivityTableHeader(width: size.width)
     }
 
@@ -262,11 +290,20 @@ final class DirectMessagesContainerNode: ASDisplayNode {
             searchButton.backgroundColor = UIColor.theme.primary
         }
 
+        createGroupButton.backgroundColor = UIColor(red: 88/255, green: 101/255, blue: 242/255, alpha: 1.0)
+        createGroupButton.tintColor = .white
+        createGroupButton.setImage(
+            UIImage(systemName: "plus", withConfiguration: UIImage.SymbolConfiguration(pointSize: 18.sf, weight: .semibold)),
+            for: .normal
+        )
+        createGroupButton.accessibilityLabel = L(L10n.DirectMessage.newGroup)
+
         tableView.reloadData()
         activityStrip.applyTheme()
     }
 
     @objc private func addFriendTapped() { interaction.onAddFriendTapped() }
+    @objc private func createGroupTapped() { interaction.onCreateGroupTapped() }
     @objc private func searchTapped() { interaction.onSearchTapped() }
     @objc private func handleRefresh() { interaction.onRefresh() }
 

--- a/MezonChat/Features/DirectMessages/DirectMessagesViewController.swift
+++ b/MezonChat/Features/DirectMessages/DirectMessagesViewController.swift
@@ -51,6 +51,9 @@ final class DirectMessagesViewController: ViewController {
                 let vc = FriendRequestViewController(context: self.context)
                 self.navigationController?.pushViewController(vc, animated: true)
             },
+            onCreateGroupTapped: { [weak self] in
+                self?.openNewGroupDMComposer()
+            },
             onSearchTapped: { [weak self] in
                 guard let self else { return }
                 let vc = SearchViewController(clanId: self.resolvedClanIdForSearch(), context: self.context)
@@ -92,6 +95,7 @@ final class DirectMessagesViewController: ViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(handleChannelMarkedAsRead(_:)), name: Notification.Name("MezonChannelMarkedAsRead"), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleNewMessageReceived(_:)), name: Notification.Name("MezonNewMessageReceived"), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleSocketReconnectForDMBadges(_:)), name: .mezonSocketStatusChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleChannelDescriptionDidUpdate(_:)), name: .mezonChannelDescriptionDidUpdate, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleDirectMessagesThemeChange), name: ThemeManager.didChangeNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleNetworkStatusChanged(_:)), name: NetworkMonitor.statusDidChangeNotification, object: nil)
         
@@ -120,6 +124,33 @@ final class DirectMessagesViewController: ViewController {
         guard isNodeLoaded else { return }
         view.backgroundColor = UIColor.theme.secondary
         directMessagesNode.applyTheme()
+    }
+
+    @objc private func handleChannelDescriptionDidUpdate(_ notification: Notification) {
+        let notifyClanId = Self.int64UserInfo(notification.userInfo?["clanId"]) ?? 0
+        guard notifyClanId == 0 else { return }
+        guard let channelId = Self.int64UserInfo(notification.userInfo?["channelId"]) else { return }
+
+        if (notification.userInfo?["removed"] as? Bool) == true {
+            let oldCount = directMessages.count
+            directMessages.removeAll { $0.channelID == channelId }
+            guard oldCount != directMessages.count else { return }
+            directMessagesPipe.putNext(directMessages)
+            setIsEmpty(directMessages.isEmpty)
+            needsReloadPipe.putNext(())
+            persistDmChannelListToPostbox()
+            return
+        }
+
+        guard let updated = context.account.postbox.getDMChannelDescription(channelId: channelId),
+              let index = directMessages.firstIndex(where: { $0.channelID == channelId })
+        else {
+            return
+        }
+        directMessages[index] = Self.mergeDmApiRowPreservingCachedPreview(updated, cached: directMessages[index])
+        directMessagesPipe.putNext(directMessages)
+        needsReloadPipe.putNext(())
+        persistDmChannelListToPostbox()
     }
 
     @objc private func handleSocketReconnectForDMBadges(_ notification: Notification) {
@@ -344,6 +375,30 @@ final class DirectMessagesViewController: ViewController {
         if changed {
             needsReloadPipe.putNext(())
         }
+    }
+
+    private func openNewGroupDMComposer() {
+        let vc = NewGroupDMViewController(context: context) { [weak self] channel in
+            self?.upsertCreatedDirectMessageChannel(channel)
+        }
+        if let navigationController = navigationController as? NavigationController {
+            navigationController.pushViewController(vc, animated: true)
+        } else {
+            navigationController?.pushViewController(vc, animated: true)
+        }
+    }
+
+    private func upsertCreatedDirectMessageChannel(_ channel: Mezon_Api_ChannelDescription) {
+        var next = directMessages
+        if let idx = next.firstIndex(where: { $0.channelID == channel.channelID }) {
+            next[idx] = Self.mergeDmApiRowPreservingCachedPreview(channel, cached: next[idx])
+        } else {
+            next.insert(channel, at: 0)
+        }
+        let sorted = Self.sortDmChannels(next)
+        setDirectMessages(sorted)
+        setIsEmpty(sorted.isEmpty)
+        persistDmChannelListToPostbox()
     }
 
     private var prefetchFriendListTask: Task<Void, Never>?
@@ -603,6 +658,20 @@ final class DirectMessagesViewController: ViewController {
     private var lastFetchDirectMessagesAt: Date?
     private let fetchDirectMessagesCooldown: TimeInterval = 2.0
 
+    private func listDirectAndGroupMessageChannels(token: String) async throws -> [Mezon_Api_ChannelDescription] {
+        var channels = try await context.account.network.listDirectMessageChannels(token: token)
+        do {
+            let groupChannels = try await context.account.network.listGroupMessageChannels(token: token)
+            var existingIds = Set(channels.map(\.channelID))
+            for channel in groupChannels where !existingIds.contains(channel.channelID) {
+                channels.append(channel)
+                existingIds.insert(channel.channelID)
+            }
+        } catch {
+        }
+        return channels
+    }
+
     func fetchDirectMessages() {
         if fetchDirectMessagesTask != nil { return }
         if let last = lastFetchDirectMessagesAt, Date().timeIntervalSince(last) < fetchDirectMessagesCooldown {
@@ -630,7 +699,7 @@ final class DirectMessagesViewController: ViewController {
             await self.fetchUserActivities(token: token)
             do {
                 let cachedRows = self.directMessages
-                var channels = try await self.context.account.network.listDirectMessageChannels(token: token)
+                var channels = try await self.listDirectAndGroupMessageChannels(token: token)
                 channels = Self.mergeDmApiRowsPreservingCachedPreview(channels, cached: cachedRows)
                 do {
                     let badgeResponse = try await self.context.account.network.listChannelBadgeCount(
@@ -665,7 +734,7 @@ final class DirectMessagesViewController: ViewController {
             }
             do {
                 let cachedRows = self.directMessages
-                var channels = try await self.context.account.network.listDirectMessageChannels(token: token)
+                var channels = try await self.listDirectAndGroupMessageChannels(token: token)
                 channels = Self.mergeDmApiRowsPreservingCachedPreview(channels, cached: cachedRows)
                 do {
                     let badgeResponse = try await self.context.account.network.listChannelBadgeCount(
@@ -728,6 +797,694 @@ final class DirectMessagesViewController: ViewController {
                 |> map { [weak self] _ in self?.currentState ?? .empty }
                 |> deliverOnMainQueue
             ).start(next: { subscriber.putNext($0) })
+        }
+    }
+}
+
+private struct NewGroupDMFriendGroup {
+    let character: String
+    let friends: [Mezon_Api_Friend]
+}
+
+private let newGroupDMActionColor = UIColor(red: 88/255, green: 101/255, blue: 242/255, alpha: 1.0)
+
+private final class NewGroupDMViewController: ViewController, UITableViewDataSource, UITableViewDelegate {
+
+    private static let maximumMembers = 20
+
+    private let context: AccountContext
+    private let onChannelCreated: (Mezon_Api_ChannelDescription) -> Void
+
+    private let headerView = UIView()
+    private let backButton = UIButton(type: .system)
+    private let titleLabel = UILabel()
+    private let subtitleLabel = UILabel()
+    private let createButton = UIButton(type: .system)
+    private let activityIndicator = UIActivityIndicatorView(style: .medium)
+
+    private let contentView = UIView()
+    private let searchContainerView = UIView()
+    private let searchIconView = UIImageView()
+    private let searchTextField = UITextField()
+    private let tableView = UITableView(frame: .zero, style: .plain)
+    private let emptyLabel = UILabel()
+
+    private var allFriends: [Mezon_Api_Friend] = []
+    private var filteredFriends: [Mezon_Api_Friend] = []
+    private var groups: [NewGroupDMFriendGroup] = []
+    private var selectedFriendIds: Set<Int64> = []
+    private var searchText = ""
+    private var isCreating = false
+    private var refreshTask: Task<Void, Never>?
+    private var friendsUpdatedDisposable: Disposable?
+
+    init(context: AccountContext, onChannelCreated: @escaping (Mezon_Api_ChannelDescription) -> Void) {
+        self.context = context
+        self.onChannelCreated = onChannelCreated
+        super.init(navigationBarPresentationData: nil)
+    }
+
+    required init(coder aDecoder: NSCoder) { fatalError() }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+        refreshTask?.cancel()
+        friendsUpdatedDisposable?.dispose()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setupViews()
+        setupLayout()
+        applyTheme()
+        syncFriendsFromStore()
+
+        NotificationCenter.default.addObserver(self, selector: #selector(handleThemeChanged), name: ThemeManager.didChangeNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleLanguageChanged), name: LanguageManager.didChangeNotification, object: nil)
+
+        friendsUpdatedDisposable = (context.engine.friendsData.friendsUpdated.signal()
+            |> deliverOnMainQueue).start(next: { [weak self] _ in
+                self?.syncFriendsFromStore()
+            })
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        refreshFriends()
+    }
+
+    private func setupViews() {
+        view.addSubview(headerView)
+        view.addSubview(contentView)
+        headerView.addSubview(backButton)
+
+        let titleStack = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel])
+        titleStack.axis = .vertical
+        titleStack.alignment = .center
+        titleStack.spacing = 2.sh
+        titleStack.translatesAutoresizingMaskIntoConstraints = false
+        titleStack.tag = 901
+        headerView.addSubview(titleStack)
+
+        headerView.addSubview(createButton)
+        headerView.addSubview(activityIndicator)
+
+        contentView.addSubview(searchContainerView)
+        contentView.addSubview(tableView)
+
+        searchContainerView.addSubview(searchIconView)
+        searchContainerView.addSubview(searchTextField)
+
+        backButton.setImage(
+            UIImage(systemName: "chevron.left", withConfiguration: UIImage.SymbolConfiguration(pointSize: 18.sf, weight: .semibold)),
+            for: .normal
+        )
+        backButton.contentHorizontalAlignment = .left
+        backButton.addTarget(self, action: #selector(backTapped), for: .touchUpInside)
+
+        titleLabel.font = .systemFont(ofSize: 16.sf, weight: .semibold)
+        titleLabel.textAlignment = .center
+        titleLabel.numberOfLines = 1
+
+        subtitleLabel.font = .systemFont(ofSize: 12.sf, weight: .semibold)
+        subtitleLabel.textAlignment = .center
+        subtitleLabel.numberOfLines = 1
+
+        createButton.titleLabel?.font = .systemFont(ofSize: 15.sf, weight: .medium)
+        createButton.contentHorizontalAlignment = .right
+        createButton.addTarget(self, action: #selector(createTapped), for: .touchUpInside)
+
+        activityIndicator.hidesWhenStopped = true
+
+        searchContainerView.layer.cornerRadius = 20.sh
+        searchContainerView.clipsToBounds = true
+
+        searchIconView.image = UIImage(systemName: "magnifyingglass", withConfiguration: UIImage.SymbolConfiguration(pointSize: 15.sf))
+        searchIconView.contentMode = .scaleAspectFit
+
+        searchTextField.font = .systemFont(ofSize: 14.sf)
+        searchTextField.returnKeyType = .search
+        searchTextField.autocorrectionType = .no
+        searchTextField.autocapitalizationType = .none
+        searchTextField.clearButtonMode = .whileEditing
+        searchTextField.addTarget(self, action: #selector(searchTextChanged), for: .editingChanged)
+
+        tableView.register(NewGroupDMFriendCell.self, forCellReuseIdentifier: NewGroupDMFriendCell.reuseId)
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.separatorStyle = .none
+        tableView.keyboardDismissMode = .onDrag
+        tableView.rowHeight = 60.sh
+        tableView.estimatedRowHeight = 60.sh
+        if #available(iOS 15.0, *) {
+            tableView.sectionHeaderTopPadding = 0
+        }
+
+        emptyLabel.font = .systemFont(ofSize: 14.sf)
+        emptyLabel.textAlignment = .center
+        emptyLabel.numberOfLines = 0
+    }
+
+    private func setupLayout() {
+        [headerView, contentView, backButton, createButton, activityIndicator, searchContainerView, searchIconView, searchTextField, tableView]
+            .forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
+
+        let titleStack = headerView.viewWithTag(901)!
+        let sideWidth: CGFloat = 78.sw
+        let headerHeight: CGFloat = 58.sh
+
+        NSLayoutConstraint.activate([
+            headerView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            headerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            headerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            headerView.heightAnchor.constraint(equalToConstant: headerHeight),
+
+            backButton.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: 18.sw),
+            backButton.centerYAnchor.constraint(equalTo: headerView.centerYAnchor),
+            backButton.widthAnchor.constraint(equalToConstant: sideWidth),
+            backButton.heightAnchor.constraint(equalToConstant: 44.sh),
+
+            createButton.trailingAnchor.constraint(equalTo: headerView.trailingAnchor, constant: -18.sw),
+            createButton.centerYAnchor.constraint(equalTo: headerView.centerYAnchor),
+            createButton.widthAnchor.constraint(equalToConstant: sideWidth),
+            createButton.heightAnchor.constraint(equalToConstant: 44.sh),
+
+            activityIndicator.centerXAnchor.constraint(equalTo: createButton.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: createButton.centerYAnchor),
+
+            titleStack.leadingAnchor.constraint(equalTo: backButton.trailingAnchor, constant: 4.sw),
+            titleStack.trailingAnchor.constraint(equalTo: createButton.leadingAnchor, constant: -4.sw),
+            titleStack.centerYAnchor.constraint(equalTo: headerView.centerYAnchor),
+
+            contentView.topAnchor.constraint(equalTo: headerView.bottomAnchor),
+            contentView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            contentView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            searchContainerView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 14.sh),
+            searchContainerView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 18.sw),
+            searchContainerView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -18.sw),
+            searchContainerView.heightAnchor.constraint(equalToConstant: 40.sh),
+
+            searchIconView.leadingAnchor.constraint(equalTo: searchContainerView.leadingAnchor, constant: 12.sw),
+            searchIconView.centerYAnchor.constraint(equalTo: searchContainerView.centerYAnchor),
+            searchIconView.widthAnchor.constraint(equalToConstant: 18.swh),
+            searchIconView.heightAnchor.constraint(equalToConstant: 18.swh),
+
+            searchTextField.leadingAnchor.constraint(equalTo: searchIconView.trailingAnchor, constant: 8.sw),
+            searchTextField.trailingAnchor.constraint(equalTo: searchContainerView.trailingAnchor, constant: -12.sw),
+            searchTextField.topAnchor.constraint(equalTo: searchContainerView.topAnchor),
+            searchTextField.bottomAnchor.constraint(equalTo: searchContainerView.bottomAnchor),
+
+            tableView.topAnchor.constraint(equalTo: searchContainerView.bottomAnchor, constant: 10.sh),
+            tableView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+        ])
+    }
+
+    @objc private func handleThemeChanged() {
+        applyTheme()
+    }
+
+    @objc private func handleLanguageChanged() {
+        applyLocalizedText()
+    }
+
+    private func applyTheme() {
+        let t = UIColor.theme
+        view.backgroundColor = t.primary
+        headerView.backgroundColor = t.primary
+        contentView.backgroundColor = t.primary
+        searchContainerView.backgroundColor = t.secondary
+        tableView.backgroundColor = t.primary
+
+        backButton.tintColor = t.text
+        titleLabel.textColor = t.text
+        subtitleLabel.textColor = t.textDisabled
+        createButton.setTitleColor(newGroupDMActionColor, for: .normal)
+        createButton.setTitleColor(t.textDisabled, for: .disabled)
+        activityIndicator.color = newGroupDMActionColor
+        searchIconView.tintColor = t.text
+        searchTextField.textColor = t.textStrong
+        searchTextField.tintColor = t.textStrong
+        emptyLabel.textColor = t.textDisabled
+
+        applyLocalizedText()
+        tableView.reloadData()
+    }
+
+    private func applyLocalizedText() {
+        titleLabel.text = L(L10n.DirectMessage.newGroup)
+        createButton.setTitle(L(L10n.DirectMessage.create), for: .normal)
+        searchTextField.attributedPlaceholder = NSAttributedString(
+            string: L(L10n.DirectMessage.searchFriends),
+            attributes: [.foregroundColor: UIColor.theme.textDisabled]
+        )
+        updateMemberCount()
+        updateEmptyState()
+    }
+
+    private func updateMemberCount() {
+        subtitleLabel.text = L(
+            L10n.DirectMessage.memberCount,
+            selectedFriendIds.count + 1,
+            Self.maximumMembers
+        )
+    }
+
+    private func updateCreateButtonState() {
+        createButton.isEnabled = !selectedFriendIds.isEmpty && !isCreating
+        createButton.isHidden = isCreating
+        if isCreating {
+            activityIndicator.startAnimating()
+        } else {
+            activityIndicator.stopAnimating()
+        }
+    }
+
+    private func updateEmptyState() {
+        let hasQuery = !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        emptyLabel.text = hasQuery ? L(L10n.FriendList.noResults) : L(L10n.DirectMessage.noFriends)
+        tableView.backgroundView = groups.isEmpty ? emptyLabel : nil
+    }
+
+    private func syncFriendsFromStore() {
+        allFriends = context.engine.friendsData.allFriends()
+            .filter { $0.state == EStateFriend.friend.rawValue && $0.hasUser && $0.user.id != 0 }
+            .sorted { lhs, rhs in
+                displayName(for: lhs).localizedCaseInsensitiveCompare(displayName(for: rhs)) == .orderedAscending
+            }
+        applyFilter()
+    }
+
+    private func refreshFriends() {
+        refreshTask?.cancel()
+        refreshTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard let token = await self.context.getTokenPreferringCachedSkipSessionReadyWait() else { return }
+            await self.context.engine.friendsData.refreshFromNetwork(token: token)
+        }
+    }
+
+    private func applyFilter() {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if query.isEmpty {
+            filteredFriends = allFriends
+        } else {
+            let normalized = normalizeString(query)
+            filteredFriends = allFriends.filter { friend in
+                normalizeString(friend.user.username).contains(normalized)
+                    || normalizeString(friend.user.displayName).contains(normalized)
+            }
+        }
+        groups = groupByAlphabet(filteredFriends)
+        updateEmptyState()
+        tableView.reloadData()
+    }
+
+    private func groupByAlphabet(_ friends: [Mezon_Api_Friend]) -> [NewGroupDMFriendGroup] {
+        var dict: [String: [Mezon_Api_Friend]] = [:]
+        for friend in friends {
+            let name = displayName(for: friend).trimmingCharacters(in: .whitespacesAndNewlines)
+            let key: String
+            if let first = name.first, first.isLetter {
+                key = String(first).uppercased()
+            } else {
+                key = "#"
+            }
+            dict[key, default: []].append(friend)
+        }
+        return dict.map { NewGroupDMFriendGroup(character: $0.key, friends: $0.value) }
+            .sorted { $0.character < $1.character }
+    }
+
+    private func normalizeString(_ str: String) -> String {
+        str.lowercased()
+            .folding(options: .diacriticInsensitive, locale: .current)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func displayName(for friend: Mezon_Api_Friend) -> String {
+        let display = friend.user.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !display.isEmpty { return display }
+        let username = friend.user.username.trimmingCharacters(in: .whitespacesAndNewlines)
+        return username.isEmpty ? L(L10n.Common.detail) : username
+    }
+
+    private func canSelectAdditionalFriend() -> Bool {
+        selectedFriendIds.count + 1 < Self.maximumMembers
+    }
+
+    private func toggleSelection(for friend: Mezon_Api_Friend) {
+        let userId = friend.user.id
+        if selectedFriendIds.contains(userId) {
+            selectedFriendIds.remove(userId)
+        } else {
+            guard canSelectAdditionalFriend() else {
+                Toast.info(L(L10n.DirectMessage.memberLimitReached))
+                return
+            }
+            selectedFriendIds.insert(userId)
+        }
+        updateMemberCount()
+        updateCreateButtonState()
+        tableView.reloadData()
+    }
+
+    @objc private func searchTextChanged() {
+        searchText = searchTextField.text ?? ""
+        applyFilter()
+    }
+
+    @objc private func backTapped() {
+        navigationController?.popViewController(animated: true)
+    }
+
+    @objc private func createTapped() {
+        guard !selectedFriendIds.isEmpty, !isCreating else { return }
+        let selectedIds = Array(selectedFriendIds)
+        isCreating = true
+        updateCreateButtonState()
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                self.isCreating = false
+                self.updateCreateButtonState()
+            }
+            guard let token = await self.context.getToken() else {
+                Toast.error(L(L10n.DirectMessage.createFailed))
+                return
+            }
+
+            do {
+                let channel: Mezon_Api_ChannelDescription
+                if selectedIds.count == 1, let userId = selectedIds.first {
+                    if let existing = await self.existingOneToOneDirectMessage(userId: userId, token: token) {
+                        channel = existing
+                    } else {
+                        channel = try await self.context.account.network.createDirectMessage(userId: userId, token: token)
+                    }
+                } else {
+                    channel = try await self.context.account.network.createGroupDirectMessage(userIds: selectedIds, token: token)
+                }
+
+                let decorated = self.decoratedChannel(channel, selectedIds: selectedIds)
+                self.openCreatedChannel(decorated, showCreatedToast: selectedIds.count > 1)
+            } catch {
+                Toast.error(error.localizedDescription.isEmpty ? L(L10n.DirectMessage.createFailed) : error.localizedDescription)
+            }
+        }
+    }
+
+    private func existingOneToOneDirectMessage(userId: Int64, token: String) async -> Mezon_Api_ChannelDescription? {
+        guard let channels = try? await context.account.network.listDirectMessageChannels(token: token) else {
+            return nil
+        }
+        return channels.first { channel in
+            channel.type == MezonConstants.ChannelType.dm.rawValue
+                && channel.userIds.count == 1
+                && channel.userIds.contains(userId)
+        }
+    }
+
+    private func decoratedChannel(_ channel: Mezon_Api_ChannelDescription, selectedIds: [Int64]) -> Mezon_Api_ChannelDescription {
+        var result = channel
+        if result.clanID != 0 {
+            result.clanID = 0
+        }
+        if result.type == 0 {
+            result.type = selectedIds.count > 1
+                ? MezonConstants.ChannelType.group.rawValue
+                : MezonConstants.ChannelType.dm.rawValue
+        }
+        if result.userIds.isEmpty {
+            result.userIds = selectedIds
+        }
+
+        let selectedFriends = selectedIds.compactMap { id in
+            allFriends.first(where: { $0.user.id == id })?.user
+        }
+        var displayNames = selectedFriends.map { user in
+            let display = user.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+            return display.isEmpty ? user.username : display
+        }.filter { !$0.isEmpty }
+        var usernames = selectedFriends.map(\.username).filter { !$0.isEmpty }
+        var avatars = selectedFriends.map(\.avatarURL).filter { !$0.isEmpty }
+
+        if let current = context.currentUser {
+            let currentDisplay = current.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+            displayNames.append(currentDisplay.isEmpty ? current.username : currentDisplay)
+            if !current.username.isEmpty {
+                usernames.append(current.username)
+            }
+            if let avatar = current.avatarURL?.absoluteString, !avatar.isEmpty {
+                avatars.append(avatar)
+            }
+        }
+
+        if result.displayNames.isEmpty {
+            result.displayNames = displayNames
+        }
+        if result.usernames.isEmpty {
+            result.usernames = usernames
+        }
+        if result.avatars.isEmpty {
+            result.avatars = avatars
+        }
+        if result.type == MezonConstants.ChannelType.group.rawValue,
+           result.channelLabel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            result.channelLabel = displayNames.joined(separator: ", ")
+        }
+        return result
+    }
+
+    private func openCreatedChannel(_ channel: Mezon_Api_ChannelDescription, showCreatedToast: Bool) {
+        onChannelCreated(channel)
+        if showCreatedToast {
+            Toast.success(L(L10n.DirectMessage.groupCreated))
+        }
+
+        let chatVC = ChatViewController(clanId: 0, channel: channel, context: context, parentName: nil)
+        guard let navigationController else { return }
+        if let navigationController = navigationController as? NavigationController {
+            navigationController.replaceTopController(chatVC, animated: true)
+        } else {
+            var stack = navigationController.viewControllers
+            if !stack.isEmpty {
+                stack.removeLast()
+            }
+            stack.append(chatVC)
+            navigationController.setViewControllers(stack, animated: true)
+        }
+    }
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        groups.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        guard section < groups.count else { return 0 }
+        return groups[section].friends.count
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        26.sh
+    }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard section < groups.count else { return nil }
+        let view = UIView()
+        view.backgroundColor = UIColor.theme.primary
+
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = groups[section].character
+        label.font = .systemFont(ofSize: 13.sf, weight: .semibold)
+        label.textColor = UIColor.theme.textDisabled
+        view.addSubview(label)
+
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20.sw),
+            label.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -4.sh)
+        ])
+        return view
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: NewGroupDMFriendCell.reuseId, for: indexPath) as! NewGroupDMFriendCell
+        let friend = groups[indexPath.section].friends[indexPath.row]
+        let selected = selectedFriendIds.contains(friend.user.id)
+        let disabled = !selected && !canSelectAdditionalFriend()
+        cell.configure(friend: friend, selected: selected, disabled: disabled)
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        guard indexPath.section < groups.count, indexPath.row < groups[indexPath.section].friends.count else { return }
+        toggleSelection(for: groups[indexPath.section].friends[indexPath.row])
+    }
+
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        searchTextField.resignFirstResponder()
+    }
+}
+
+private final class NewGroupDMFriendCell: UITableViewCell {
+
+    static let reuseId = "NewGroupDMFriendCell"
+
+    private let avatarView = TextAvatarView(username: "", size: 40.swh, fontSize: 16.sf)
+    private let avatarImageView = UIImageView()
+    private let nameLabel = UILabel()
+    private let usernameLabel = UILabel()
+    private let checkImageView = UIImageView()
+
+    private var imageTask: URLSessionDataTask?
+    private var representedAvatarURL: String?
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setup()
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        imageTask?.cancel()
+        imageTask = nil
+        representedAvatarURL = nil
+        avatarImageView.image = nil
+        avatarImageView.isHidden = true
+        avatarView.showPlaceholder()
+    }
+
+    private func setup() {
+        selectionStyle = .none
+        backgroundColor = .clear
+        contentView.backgroundColor = .clear
+
+        let container = UIView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        container.backgroundColor = UIColor.theme.secondary
+        container.layer.cornerRadius = 10.sf
+        container.clipsToBounds = true
+        contentView.addSubview(container)
+
+        avatarView.translatesAutoresizingMaskIntoConstraints = false
+        avatarImageView.translatesAutoresizingMaskIntoConstraints = false
+        nameLabel.translatesAutoresizingMaskIntoConstraints = false
+        usernameLabel.translatesAutoresizingMaskIntoConstraints = false
+        checkImageView.translatesAutoresizingMaskIntoConstraints = false
+
+        avatarImageView.contentMode = .scaleAspectFill
+        avatarImageView.clipsToBounds = true
+        avatarImageView.layer.cornerRadius = 20.swh
+        avatarImageView.isHidden = true
+
+        nameLabel.font = .systemFont(ofSize: 14.sf, weight: .medium)
+        nameLabel.numberOfLines = 1
+        usernameLabel.font = .systemFont(ofSize: 12.sf)
+        usernameLabel.numberOfLines = 1
+
+        checkImageView.contentMode = .scaleAspectFit
+
+        container.addSubview(avatarView)
+        avatarView.addSubview(avatarImageView)
+        container.addSubview(nameLabel)
+        container.addSubview(usernameLabel)
+        container.addSubview(checkImageView)
+
+        NSLayoutConstraint.activate([
+            container.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 3.sh),
+            container.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -3.sh),
+            container.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 18.sw),
+            container.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -18.sw),
+
+            avatarView.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 12.sw),
+            avatarView.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            avatarView.widthAnchor.constraint(equalToConstant: 40.swh),
+            avatarView.heightAnchor.constraint(equalToConstant: 40.swh),
+
+            avatarImageView.topAnchor.constraint(equalTo: avatarView.topAnchor),
+            avatarImageView.leadingAnchor.constraint(equalTo: avatarView.leadingAnchor),
+            avatarImageView.trailingAnchor.constraint(equalTo: avatarView.trailingAnchor),
+            avatarImageView.bottomAnchor.constraint(equalTo: avatarView.bottomAnchor),
+
+            checkImageView.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -14.sw),
+            checkImageView.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            checkImageView.widthAnchor.constraint(equalToConstant: 22.swh),
+            checkImageView.heightAnchor.constraint(equalToConstant: 22.swh),
+
+            nameLabel.leadingAnchor.constraint(equalTo: avatarView.trailingAnchor, constant: 12.sw),
+            nameLabel.trailingAnchor.constraint(equalTo: checkImageView.leadingAnchor, constant: -12.sw),
+            nameLabel.topAnchor.constraint(equalTo: container.topAnchor, constant: 9.sh),
+
+            usernameLabel.leadingAnchor.constraint(equalTo: nameLabel.leadingAnchor),
+            usernameLabel.trailingAnchor.constraint(equalTo: nameLabel.trailingAnchor),
+            usernameLabel.topAnchor.constraint(equalTo: nameLabel.bottomAnchor, constant: 2.sh)
+        ])
+    }
+
+    func configure(friend: Mezon_Api_Friend, selected: Bool, disabled: Bool) {
+        let t = UIColor.theme
+        contentView.alpha = disabled ? 0.45 : 1.0
+        contentView.subviews.first?.backgroundColor = t.secondary
+
+        let user = friend.user
+        let display = user.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let username = user.username.trimmingCharacters(in: .whitespacesAndNewlines)
+        let name = display.isEmpty ? username : display
+        nameLabel.text = name.isEmpty ? L(L10n.Common.detail) : name
+        nameLabel.textColor = t.textStrong
+        usernameLabel.text = username.isEmpty ? "" : "@\(username)"
+        usernameLabel.textColor = t.textDisabled
+        avatarView.configure(username: username.isEmpty ? name : username, fontSize: 16.sf)
+
+        let symbol = selected ? "checkmark.circle.fill" : "circle"
+        checkImageView.image = UIImage(systemName: symbol, withConfiguration: UIImage.SymbolConfiguration(pointSize: 21.sf, weight: .semibold))
+        checkImageView.tintColor = selected ? newGroupDMActionColor : t.textDisabled
+
+        loadAvatarIfNeeded(user.avatarURL)
+    }
+
+    private func loadAvatarIfNeeded(_ rawURL: String) {
+        imageTask?.cancel()
+        imageTask = nil
+        avatarImageView.image = nil
+        avatarImageView.isHidden = true
+
+        let trimmed = rawURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, URL(string: trimmed) != nil else {
+            avatarView.showPlaceholder()
+            return
+        }
+
+        let proxied = ImgproxyURL.avatarProxyURL(from: trimmed, width: 100, height: 100)
+        representedAvatarURL = proxied
+        if let cached = ImageCache.shared.cachedImage(forURL: proxied) {
+            avatarImageView.image = cached
+            avatarImageView.isHidden = false
+            avatarView.showImageMode()
+            return
+        }
+
+        avatarView.showSkeleton()
+        imageTask = ImageCache.shared.loadImage(urlString: proxied) { [weak self] image in
+            guard let self, self.representedAvatarURL == proxied else { return }
+            if let image {
+                self.avatarImageView.image = image
+                self.avatarImageView.isHidden = false
+                self.avatarView.showImageMode()
+            } else {
+                self.avatarImageView.image = nil
+                self.avatarImageView.isHidden = true
+                self.avatarView.showPlaceholder()
+            }
         }
     }
 }

--- a/MezonChat/Networking/MezonHTTPClient.swift
+++ b/MezonChat/Networking/MezonHTTPClient.swift
@@ -553,6 +553,19 @@ final class MezonHTTPClient {
         )
     }
 
+    func createGroupDirectMessage(userIds: [Int64], token: String) async throws -> Mezon_Api_ChannelDescription {
+        var req = Mezon_Api_CreateChannelDescRequest()
+        req.clanID = 0
+        req.type = MezonConstants.ChannelType.group.rawValue
+        req.channelPrivate = 1
+        req.userIds = userIds
+        return try await postProto(
+            path: "/mezon.api.Mezon/CreateChannelDesc",
+            message: req,
+            auth: .bearer(token)
+        )
+    }
+
     func listUserActivity(token: String) async throws -> Mezon_Api_ListUserActivity {
         let empty = SwiftProtobuf.Google_Protobuf_Empty()
         return try await postProto(
@@ -881,6 +894,7 @@ final class MezonHTTPClient {
         clanId: Int64,
         channelId: Int64,
         channelLabel: String? = nil,
+        channelAvatar: String? = nil,
         topic: String? = nil,
         categoryId: Int64? = nil,
         token: String
@@ -892,6 +906,11 @@ final class MezonHTTPClient {
             var labelValue = SwiftProtobuf.Google_Protobuf_StringValue()
             labelValue.value = channelLabel
             req.channelLabel = labelValue
+        }
+        if let channelAvatar = channelAvatar {
+            var avatarValue = SwiftProtobuf.Google_Protobuf_StringValue()
+            avatarValue.value = channelAvatar
+            req.channelAvatar = avatarValue
         }
         if let topic = topic {
             req.topic = topic


### PR DESCRIPTION
Ticket: https://github.com/mezonai/mezon/issues/13112
## Description
Allow users to start a new conversation from the Messages tab: 1:1 DM or group chat.

## User flow
- From the Messages tab, tap **+** to create a new chat
- Pick one or more friends from the list (with search)
- **1 person** → create or open a 1:1 DM
- **2+ people** → create a new group chat
- On success → navigate to the corresponding chat screen

## Group chat
- Show a group avatar (member avatars composite or default group avatar)
- Group name: member names combined (or server-provided label)
- Join the channel and sync the new dialog into the Messages list

## Add members (from an existing group)
- From the current group, open the same friend-picker flow to add members to the group

## Acceptance
- Create a 1:1 DM from the friend list
- Create a group with 2+ members
- New dialog appears in Messages and opens chat immediately
- Add members to an existing group (if in scope)