### PR TITLE
update: init sentry and capture

### DIFF
--- a/MezonChat.xcodeproj/project.pbxproj
+++ b/MezonChat.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 63;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -179,6 +179,7 @@
 		53389118473783486708FB47 /* ListViewAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F37221A869B32DD40E80249 /* ListViewAnimation.swift */; };
 		535B8FC278DF434E3215DFAA /* AddFriendByUsernameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 811B1E2FBC03AED1C62BEB68 /* AddFriendByUsernameViewController.swift */; };
 		5374E7263AA43607E0D44203 /* Rectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8EDFC6DA55BA15B9F136D3 /* Rectangle.swift */; };
+		53B2AA34A915496FA1143830 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 569BB5ED0A719F403FD9DEE5 /* Sentry */; };
 		53DF5A89ED56E3F365D69CE8 /* NavigationBarTransitionContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2BF7D4BCF7054B5CFCF9A0 /* NavigationBarTransitionContainer.swift */; };
 		5559A7D9DDDAE40F7AD92961 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243F73240E9CAC19CAC0296A /* SplashViewController.swift */; };
 		55DA70E054D16536911DD3F4 /* ImageCorners.swift in Sources */ = {isa = PBXBuildFile; fileRef = A459BEA5D3BB2E577802BD86 /* ImageCorners.swift */; };
@@ -209,7 +210,6 @@
 		62623D69C2FDCE2D27CE0962 /* MessageLocationNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D5510ECC05B079EB97CDE8D /* MessageLocationNode.swift */; };
 		628F552A3F5A25BF10E0FB22 /* SSubscriber.m in Sources */ = {isa = PBXBuildFile; fileRef = 97C961A66EB3877EDD29FF80 /* SSubscriber.m */; };
 		62D4FE7D5F261A1175CC7A11 /* ChannelMemberRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F3C98DD7CD7588632AF5EA /* ChannelMemberRecord.swift */; };
-		631E24FBE4430AB85919D702 /* Pods_MezonChat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85FE52C4CBE33EA29337838A /* Pods_MezonChat.framework */; };
 		6392436A7E791CA65DE544D0 /* ListViewItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3EE8DA45D3BB7A0CACBF22 /* ListViewItem.swift */; };
 		63B9DB4C96206F1EFE41364E /* ChannelBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B23BEA15E0F21603451529E0 /* ChannelBannerView.swift */; };
 		64A7A825E83B5A28C4E0192D /* ImageUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = E322BFBEDA641EC842A02B22 /* ImageUtilities.swift */; };
@@ -275,6 +275,7 @@
 		7FC9B98EF2654DD4B0D6F88F /* MezonSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = D78559B57838DAE838F649EE /* MezonSocket.swift */; };
 		7FCD1ED8F3118CBFE60F724C /* WindowPanRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E850F413482D68E3D14AD0E2 /* WindowPanRecognizer.swift */; };
 		80D7F87D3564B030BADDCD0F /* Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE95FDCD8F967A86393A0E4 /* Accessibility.swift */; };
+		826602218CBC97D592DCEE92 /* SentryLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D011B52B18F41B062F65C0E8 /* SentryLogger.swift */; };
 		82C059C35A9E0B37947BCD2A /* SSignal+Meta.m in Sources */ = {isa = PBXBuildFile; fileRef = BD6B2D9C9519A9EEE2901FE5 /* SSignal+Meta.m */; };
 		82F0F24B9EEA6FACC2BDBEAA /* StatusBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4003598D0AD0F1E26DC319A1 /* StatusBar.swift */; };
 		832621BEDFE6409041031FC8 /* UIImage+Decode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 208C195B44CADEB924D95E84 /* UIImage+Decode.swift */; };
@@ -315,7 +316,6 @@
 		95191F33FD4CB11C6092B6BC /* CreatePollViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0132121ADA574306744E74 /* CreatePollViewController.swift */; };
 		955DDF08307DB4B692327BD6 /* FriendListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24557F6346DDE96BC1E06E22 /* FriendListViewController.swift */; };
 		95F5E6A42CC90E343563E840 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE19D465AF7DBDACFEDFDFEF /* Message.swift */; };
-		9631CCD58007C166C19FF4ED /* PollEmojiParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8532A8F165E99715FC62A20 /* PollEmojiParser.swift */; };
 		965BF9CAC5C1EA00D9597053 /* NavigationLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4A84C6D1127C00370CA4995 /* NavigationLayout.swift */; };
 		969538DEB3C57CBDDCBF47E0 /* SwiftProtobuf in Frameworks */ = {isa = PBXBuildFile; productRef = A259DAEA74BD10BB6C982FAC /* SwiftProtobuf */; };
 		97445407959986C39506D0C4 /* AppThemeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD94BB519169EBB90AFFA4AF /* AppThemeViewController.swift */; };
@@ -347,6 +347,7 @@
 		A2EEB657D15A5699A6C50AF2 /* AttachmentPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4EE1A764EA42BFB425675B6 /* AttachmentPreviewView.swift */; };
 		A3083D8AD06D571860E3BEAD /* WindowInputAccessoryHeightProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9627B4EF7C174B792855725B /* WindowInputAccessoryHeightProvider.swift */; };
 		A342776F18663F2D647A8C14 /* WebRTCSignalingDataType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6134781E821A16A7A8EABE0 /* WebRTCSignalingDataType.swift */; };
+		A34FF492506FBC572EA8C8D3 /* PollEmojiParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DE10C7198622AF5C9994C8A /* PollEmojiParser.swift */; };
 		A45DC648D1E69CA473366CDA /* RolesRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7D537B7219330E6CE1C5F6 /* RolesRepository.swift */; };
 		A585745863D22A16A52173D7 /* realtime.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F178B60FCDEA18D0A0446101 /* realtime.pb.swift */; };
 		A658C3C1A1894DB10CB19150 /* QRLoginConfirmNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20AE25A5CC6C4330DFC371DC /* QRLoginConfirmNode.swift */; };
@@ -687,7 +688,7 @@
 		380217E26784374B78348BC8 /* NotificationSettingRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingRecord.swift; sourceTree = "<group>"; };
 		386A788D50FF0B389BEB44C7 /* SSignal+Combine.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SSignal+Combine.h"; sourceTree = "<group>"; };
 		38EBD3DE736872C6AC2D4D66 /* ChatWelcomeItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatWelcomeItem.swift; sourceTree = "<group>"; };
-		3910C328DAF28A5D8A379BA3 /* mezon_callkit_silent.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = mezon_callkit_silent.caf; sourceTree = "<group>"; };
+		3910C328DAF28A5D8A379BA3 /* mezon_callkit_silent.caf */ = {isa = PBXFileReference; path = mezon_callkit_silent.caf; sourceTree = "<group>"; };
 		392D5A59E301B17B09BEF416 /* ListViewReorderingItemNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewReorderingItemNode.swift; sourceTree = "<group>"; };
 		393A7534D077AA187486557A /* UniversalMasterController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalMasterController.swift; sourceTree = "<group>"; };
 		39568002A6E6690CE6D2C9EA /* AddMemberOrRoleSheetController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMemberOrRoleSheetController.swift; sourceTree = "<group>"; };
@@ -838,12 +839,12 @@
 		79DDB9EFFDE1B6ECBFEF6F31 /* List.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = List.swift; sourceTree = "<group>"; };
 		7A1614BDC3FD9434A6F2F4A9 /* CanvasWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasWebViewController.swift; sourceTree = "<group>"; };
 		7BC05A1D70218FEF88ECD091 /* ThemeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeManager.swift; sourceTree = "<group>"; };
-		7BCEB69B2269CC9BB78458BD /* Pods-MezonChat.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MezonChat.release.xcconfig"; path = "Target Support Files/Pods-MezonChat/Pods-MezonChat.release.xcconfig"; sourceTree = "<group>"; };
 		7C9DD86C33B3394AABB6B02C /* SAtomic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SAtomic.h; sourceTree = "<group>"; };
-		7CBD0290A77BC1FAC28E6FEE /* NotificationService.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		7CBD0290A77BC1FAC28E6FEE /* NotificationService.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = NotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		7D231D0BB4770A6BAAC1ACE2 /* NSWeakReference.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSWeakReference.h; sourceTree = "<group>"; };
 		7D51F5462EB85FBDE2E8973F /* ClanListContainerNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClanListContainerNode.swift; sourceTree = "<group>"; };
 		7D5960091C540D0308F86AFE /* MezonSharing.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MezonSharing.entitlements; sourceTree = "<group>"; };
+		7DE10C7198622AF5C9994C8A /* PollEmojiParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollEmojiParser.swift; sourceTree = "<group>"; };
 		7E023816BAC27911EE47B5A1 /* HighlightTrackingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightTrackingButton.swift; sourceTree = "<group>"; };
 		7E3CBAA5EFC76EEA38E64A54 /* SSignal+Timing.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "SSignal+Timing.m"; sourceTree = "<group>"; };
 		7E7EA82091D375B56E7D3778 /* CreateClanEntryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateClanEntryViewController.swift; sourceTree = "<group>"; };
@@ -871,7 +872,6 @@
 		845C5E3AF84A8BA0BB3ED96B /* MessageContentParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageContentParser.swift; sourceTree = "<group>"; };
 		859F5D7416A27DC41E2B263B /* PortalSourceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalSourceView.swift; sourceTree = "<group>"; };
 		85A1FD53749AF15825DDD0B8 /* NavigationLayoutEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLayoutEnvironment.swift; sourceTree = "<group>"; };
-		85FE52C4CBE33EA29337838A /* Pods_MezonChat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MezonChat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		86FD4A3143D8EC7A0F470236 /* OpenURLHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OpenURLHelper.m; sourceTree = "<group>"; };
 		872B2357D03FAC002169FB75 /* PollDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollDetailViewController.swift; sourceTree = "<group>"; };
 		8742D1794B61567C6B48E0B5 /* Signal_Catch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Signal_Catch.swift; sourceTree = "<group>"; };
@@ -939,7 +939,6 @@
 		A75B9860652CFC0072D3A61A /* ClaimLuckyMoneyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaimLuckyMoneyViewController.swift; sourceTree = "<group>"; };
 		A7672B8FE0D8D114E56A3440 /* MezonChat.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MezonChat.entitlements; sourceTree = "<group>"; };
 		A7B68B53B72C3DB28761C9DA /* ASTransformLayerNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASTransformLayerNode.swift; sourceTree = "<group>"; };
-		A8532A8F165E99715FC62A20 /* PollEmojiParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PollEmojiParser.swift; sourceTree = "<group>"; };
 		A8BFDCB4B3FC719FB16890C7 /* CreateThreadFormViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateThreadFormViewController.swift; sourceTree = "<group>"; };
 		A981FBC8F4A29D5CB381A8A2 /* MessageReactionsNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReactionsNode.swift; sourceTree = "<group>"; };
 		A994BA4C4032092AFDF1AB1B /* UIBarButtonItem+Proxy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIBarButtonItem+Proxy.m"; sourceTree = "<group>"; };
@@ -969,7 +968,6 @@
 		B2D2F5ECB3CF7C64DB76F934 /* FriendRequestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendRequestViewController.swift; sourceTree = "<group>"; };
 		B2E51B5A7E4D668AC3A8ECE3 /* NavigationTransitionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationTransitionCoordinator.swift; sourceTree = "<group>"; };
 		B3FBFF6B270E3C4E4B55F1A5 /* PollData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollData.swift; sourceTree = "<group>"; };
-		B4500B3B18ABB90261B71DB0 /* Pods-MezonChat.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MezonChat.debug.xcconfig"; path = "Target Support Files/Pods-MezonChat/Pods-MezonChat.debug.xcconfig"; sourceTree = "<group>"; };
 		B48A2B7C54658E4FF8C4C4AC /* PeerCallVideoRenderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerCallVideoRenderView.swift; sourceTree = "<group>"; };
 		B4D69DC509BC57816F86328C /* UIViewController+Navigation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Navigation.h"; sourceTree = "<group>"; };
 		B4E9A9FA5EBA97181B5FBE05 /* TransformImageArguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransformImageArguments.swift; sourceTree = "<group>"; };
@@ -1021,7 +1019,7 @@
 		C5912BDE56C84777786DF134 /* SSignal+Take.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "SSignal+Take.m"; sourceTree = "<group>"; };
 		C5E07664F250504B41F2FCE0 /* ChildComponentTransitions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChildComponentTransitions.swift; sourceTree = "<group>"; };
 		C5E7CA166848AC32CD0C9935 /* VoIPAnswerAccountBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoIPAnswerAccountBridge.swift; sourceTree = "<group>"; };
-		C5F56FEE8A54000B408A70DC /* MezonSharing.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = MezonSharing.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		C5F56FEE8A54000B408A70DC /* MezonSharing.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = MezonSharing.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		C63401D42D34F16D2D657AB9 /* NotificationsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsViewController.swift; sourceTree = "<group>"; };
 		C6AF8577C7F4EDA9424052AC /* ScrollComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollComponent.swift; sourceTree = "<group>"; };
 		C6D517A910B492508C07E94F /* QRUserProfileNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRUserProfileNode.swift; sourceTree = "<group>"; };
@@ -1045,6 +1043,7 @@
 		CF66D437B6AAAFC0E142B4F8 /* SceneStatusBarHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneStatusBarHost.swift; sourceTree = "<group>"; };
 		CFB60C7265044F7F01B0A1B3 /* MezonConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MezonConstants.swift; sourceTree = "<group>"; };
 		CFDA349820A6197896CBBA08 /* AppBundle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppBundle.h; sourceTree = "<group>"; };
+		D011B52B18F41B062F65C0E8 /* SentryLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryLogger.swift; sourceTree = "<group>"; };
 		D11CFD145FA96F1DFB434452 /* NavigationTitleNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationTitleNode.swift; sourceTree = "<group>"; };
 		D14D16BA6AC7002EB342035F /* UIKitUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitUtils.swift; sourceTree = "<group>"; };
 		D164AD06553D6C407D6B7636 /* ClanInviteLinkParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClanInviteLinkParser.swift; sourceTree = "<group>"; };
@@ -1060,7 +1059,7 @@
 		D60BC4DBAC8680ECBB3998D5 /* ContextMenuAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuAction.swift; sourceTree = "<group>"; };
 		D61DC64AF09CF71E054447B8 /* MessageActionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageActionSheet.swift; sourceTree = "<group>"; };
 		D66C3D58A9E438C84EE96F22 /* ThreadPool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadPool.swift; sourceTree = "<group>"; };
-		D6770D303E39BF3CD083400D /* Mezon.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Mezon.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		D6770D303E39BF3CD083400D /* MezonChat.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = MezonChat.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D6A61559422270AEFB788549 /* TooltipController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipController.swift; sourceTree = "<group>"; };
 		D6CAB118D81CCEE9DAAC9E86 /* MezonRootController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MezonRootController.swift; sourceTree = "<group>"; };
 		D6FCBF73086932953EE28120 /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
@@ -1165,7 +1164,7 @@
 				0F1B01761353884FA4FBAAA0 /* LiveKit in Frameworks */,
 				E198763D3F940271D8AC6957 /* LiveKitWebRTC in Frameworks */,
 				969538DEB3C57CBDDCBF47E0 /* SwiftProtobuf in Frameworks */,
-				631E24FBE4430AB85919D702 /* Pods_MezonChat.framework in Frameworks */,
+				53B2AA34A915496FA1143830 /* Sentry in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1724,7 +1723,7 @@
 		5D009DF3818076C7CDE50BF0 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				D6770D303E39BF3CD083400D /* Mezon.app */,
+				D6770D303E39BF3CD083400D /* MezonChat.app */,
 				C5F56FEE8A54000B408A70DC /* MezonSharing.appex */,
 				7CBD0290A77BC1FAC28E6FEE /* NotificationService.appex */,
 			);
@@ -1741,14 +1740,6 @@
 				12D75E55562023B8AA717C57 /* PinnedMessagesNode.swift */,
 			);
 			path = Tabs;
-			sourceTree = "<group>";
-		};
-		61368490FADF9BBC394E0D2E /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				85FE52C4CBE33EA29337838A /* Pods_MezonChat.framework */,
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		6234DF10D7F5EC9259A35E98 /* Messages */ = {
@@ -1831,6 +1822,7 @@
 				CFB60C7265044F7F01B0A1B3 /* MezonConstants.swift */,
 				BD53B3B5983DA572DC1A5B57 /* NetworkMonitor.swift */,
 				4B14DAAEB6FF3F647B2BF095 /* ScreenScale.swift */,
+				D011B52B18F41B062F65C0E8 /* SentryLogger.swift */,
 				938CD478A6578D888E1A6C46 /* SharingManager.swift */,
 			);
 			path = Utils;
@@ -1844,7 +1836,6 @@
 				CD7E9FEB6B0B50ABBC05F659 /* NotificationService */,
 				EA83705E3BB7ABF26349CE36 /* Pods */,
 				5D009DF3818076C7CDE50BF0 /* Products */,
-				61368490FADF9BBC394E0D2E /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -2083,9 +2074,9 @@
 				43C8DE6DB70246F1D1E6715E /* PollCardNode.swift */,
 				B3FBFF6B270E3C4E4B55F1A5 /* PollData.swift */,
 				872B2357D03FAC002169FB75 /* PollDetailViewController.swift */,
+				7DE10C7198622AF5C9994C8A /* PollEmojiParser.swift */,
 				83B038C2252CEC38CB7C8EB2 /* PollOptionRowNode.swift */,
 				9D40D0830D8415DAC9ADCF9A /* PollVoteCache.swift */,
-				A8532A8F165E99715FC62A20 /* PollEmojiParser.swift */,
 			);
 			path = Poll;
 			sourceTree = "<group>";
@@ -2429,8 +2420,6 @@
 			isa = PBXGroup;
 			children = (
 				1813841AB9729992EC4419D3 /* Target Support Files */,
-				B4500B3B18ABB90261B71DB0 /* Pods-MezonChat.debug.xcconfig */,
-				7BCEB69B2269CC9BB78458BD /* Pods-MezonChat.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -2557,6 +2546,8 @@
 			dependencies = (
 			);
 			name = MezonSharing;
+			packageProductDependencies = (
+			);
 			productName = MezonSharing;
 			productReference = C5F56FEE8A54000B408A70DC /* MezonSharing.appex */;
 			productType = "com.apple.product-type.app-extension";
@@ -2565,14 +2556,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = EC72BD5A9A9D143AE179DBD5 /* Build configuration list for PBXNativeTarget "MezonChat" */;
 			buildPhases = (
-				5FE950E08A59AE496783A35D /* [CP] Check Pods Manifest.lock */,
 				92A6A179EF8E12E0B4022079 /* Validate Secrets.swift */,
 				19F4DA105C897E310E067B9B /* Sources */,
 				BE4910FC6D318402623B7340 /* Resources */,
 				5A295EE582C60FFCE8897D74 /* Frameworks */,
 				F43D6A2CE84BF39FC2D3BE56 /* Embed Foundation Extensions */,
 				99F43EB3C132A8A6F8012E98 /* Generate LiveKitWebRTC dSYM */,
-				A3D8613CBC06FBC32F6EAE61 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -2585,9 +2574,10 @@
 				3E5AC5BBE97A32C837DF224B /* LiveKit */,
 				F873647C85F20D5A4ADF79FB /* LiveKitWebRTC */,
 				A259DAEA74BD10BB6C982FAC /* SwiftProtobuf */,
+				569BB5ED0A719F403FD9DEE5 /* Sentry */,
 			);
 			productName = MezonChat;
-			productReference = D6770D303E39BF3CD083400D /* Mezon.app */;
+			productReference = D6770D303E39BF3CD083400D /* MezonChat.app */;
 			productType = "com.apple.product-type.application";
 		};
 		AC5A47AC852E8A9FE2245D9E /* NotificationService */ = {
@@ -2601,6 +2591,8 @@
 			dependencies = (
 			);
 			name = NotificationService;
+			packageProductDependencies = (
+			);
 			productName = NotificationService;
 			productReference = 7CBD0290A77BC1FAC28E6FEE /* NotificationService.appex */;
 			productType = "com.apple.product-type.app-extension";
@@ -2615,9 +2607,11 @@
 				LastUpgradeCheck = 1600;
 				TargetAttributes = {
 					09C2682B354953312A4C98EC = {
+						DevelopmentTeam = "";
 						ProvisioningStyle = Automatic;
 					};
 					2055A71796058B31A0F6D83C = {
+						DevelopmentTeam = "";
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.ApplicationGroups.iOS = {
@@ -2632,6 +2626,7 @@
 						};
 					};
 					AC5A47AC852E8A9FE2245D9E = {
+						DevelopmentTeam = "";
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -2649,9 +2644,10 @@
 			packageReferences = (
 				3D12BB45B3BF7A859C520F12 /* XCRemoteSwiftPackageReference "client-sdk-swift" */,
 				91D275EEE786CB4A197C75B6 /* XCRemoteSwiftPackageReference "webrtc-xcframework" */,
+				C1E4C8C615FE293BED810C78 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 				AB033BCC9ED02682CF74E65D /* XCRemoteSwiftPackageReference "swift-protobuf" */,
 			);
-			productRefGroup = 5D009DF3818076C7CDE50BF0 /* Products */;
+			preferredProjectObjectVersion = 77;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -2679,28 +2675,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		5FE950E08A59AE496783A35D /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-MezonChat-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
 		92A6A179EF8E12E0B4022079 /* Validate Secrets.swift */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -2739,27 +2713,6 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"${SRCROOT}/scripts/generate_livekit_webrtc_dsym.sh\"\n";
 		};
-		A3D8613CBC06FBC32F6EAE61 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-MezonChat/Pods-MezonChat-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-MezonChat/Pods-MezonChat-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MezonChat/Pods-MezonChat-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -2767,7 +2720,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				95191F33FD4CB11C6092B6BC /* CreatePollViewController.swift in Sources */,
 				8F86CFDCD730499F49787149 /* ASCGImageBuffer.mm in Sources */,
 				89B03906CB574F31B9373594 /* ASDisplayNode+Measure.swift in Sources */,
 				9D75DE1606BAA81A2D2A3199 /* ASTransformLayerNode.swift in Sources */,
@@ -2880,6 +2832,7 @@
 				11E2044E4515867090CE86BF /* CreateClanEntryViewController.swift in Sources */,
 				0EDB580A72650037E391D034 /* CreateClanViewController.swift in Sources */,
 				BD6841EC07DAE8F29B1A9439 /* CreateNewRoleViewController.swift in Sources */,
+				95191F33FD4CB11C6092B6BC /* CreatePollViewController.swift in Sources */,
 				AB6DC6BD6A69568C050AFCE5 /* CreateThreadFormViewController.swift in Sources */,
 				7A202E7BD0A70364775105D9 /* DeviceMetrics.swift in Sources */,
 				83297FB300A781A7EA0B8230 /* DirectMessagesContainerNode.swift in Sources */,
@@ -3083,6 +3036,7 @@
 				622EACFAA0BD25CF202C962E /* PollCardNode.swift in Sources */,
 				46AE41D0F733CC49E465CC57 /* PollData.swift in Sources */,
 				93C3DABD5576946D9C3EA629 /* PollDetailViewController.swift in Sources */,
+				A34FF492506FBC572EA8C8D3 /* PollEmojiParser.swift in Sources */,
 				EC87594FEA514F1E4315920A /* PollOptionRowNode.swift in Sources */,
 				DD0B3C4B5EE6F9106BAB83A8 /* PollVoteCache.swift in Sources */,
 				4DBCEC18203E8D21B91F9BD8 /* PortalSourceView.swift in Sources */,
@@ -3160,6 +3114,7 @@
 				4F44C15E9C148675681F134C /* SearchViewController.swift in Sources */,
 				6911295A5A03A73EF85BCFF6 /* Secrets.swift in Sources */,
 				1A74E6D6A944E2FD10F0B144 /* SendMessageInputViewController.swift in Sources */,
+				826602218CBC97D592DCEE92 /* SentryLogger.swift in Sources */,
 				E4F170A362A8085DEC132ADB /* SessionExpiredModal.swift in Sources */,
 				E043AB4EE8D03C8003BAA30B /* SessionRefreshManager.swift in Sources */,
 				E8C9F88973AF0F6CA094CE0C /* SetPasswordViewController.swift in Sources */,
@@ -3283,7 +3238,6 @@
 				1AFDA7CF41FCE5FF0BF3019E /* ZoomableContentGalleryItemNode.swift in Sources */,
 				3287AC5C18B31DD1DCF7B888 /* api.pb.swift in Sources */,
 				A585745863D22A16A52173D7 /* realtime.pb.swift in Sources */,
-				9631CCD58007C166C19FF4ED /* PollEmojiParser.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3381,7 +3335,7 @@
 		};
 		433A5251B2769A74EDD27D32 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7BCEB69B2269CC9BB78458BD /* Pods-MezonChat.release.xcconfig */;
+			baseConfigurationReference = BD20F700232CB92701B501FD /* Pods-MezonChat.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -3390,16 +3344,9 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = E9Y2J54ZH3;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/MezonChat/Core/SSignalKit/SSignalKit/Source",
-					"$(SRCROOT)/MezonChat/Core/Display",
-					"$(SRCROOT)/MezonChat/Core/Display/UIKitRuntimeUtils",
-					"$(SRCROOT)/MezonChat/Core/Display/ObjCRuntimeUtils",
-					"$(SRCROOT)/MezonChat/Core/Display/AppBundle",
-				);
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/MezonChat/Core/SSignalKit/SSignalKit/Source $(SRCROOT)/MezonChat/Core/Display $(SRCROOT)/MezonChat/Core/Display/UIKitRuntimeUtils $(SRCROOT)/MezonChat/Core/Display/ObjCRuntimeUtils $(SRCROOT)/MezonChat/Core/Display/AppBundle";
 				INFOPLIST_FILE = MezonChat/Resources/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3424,7 +3371,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = NotificationService/NotificationService.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = E9Y2J54ZH3;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = NotificationService/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3445,7 +3392,7 @@
 				CODE_SIGN_ENTITLEMENTS = MezonSharing/MezonSharing.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = E9Y2J54ZH3;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = MezonSharing/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3467,7 +3414,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = NotificationService/NotificationService.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = E9Y2J54ZH3;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = NotificationService/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3488,7 +3435,7 @@
 				CODE_SIGN_ENTITLEMENTS = MezonSharing/MezonSharing.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = E9Y2J54ZH3;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = MezonSharing/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3507,7 +3454,7 @@
 		};
 		D6110184B3C571C58191E396 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B4500B3B18ABB90261B71DB0 /* Pods-MezonChat.debug.xcconfig */;
+			baseConfigurationReference = 4DDD39BC40258F000789A998 /* Pods-MezonChat.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -3516,16 +3463,9 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = E9Y2J54ZH3;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/MezonChat/Core/SSignalKit/SSignalKit/Source",
-					"$(SRCROOT)/MezonChat/Core/Display",
-					"$(SRCROOT)/MezonChat/Core/Display/UIKitRuntimeUtils",
-					"$(SRCROOT)/MezonChat/Core/Display/ObjCRuntimeUtils",
-					"$(SRCROOT)/MezonChat/Core/Display/AppBundle",
-				);
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/MezonChat/Core/SSignalKit/SSignalKit/Source $(SRCROOT)/MezonChat/Core/Display $(SRCROOT)/MezonChat/Core/Display/UIKitRuntimeUtils $(SRCROOT)/MezonChat/Core/Display/ObjCRuntimeUtils $(SRCROOT)/MezonChat/Core/Display/AppBundle";
 				INFOPLIST_FILE = MezonChat/Resources/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3677,6 +3617,14 @@
 				minimumVersion = 1.28.0;
 			};
 		};
+		C1E4C8C615FE293BED810C78 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.40.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -3684,6 +3632,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 3D12BB45B3BF7A859C520F12 /* XCRemoteSwiftPackageReference "client-sdk-swift" */;
 			productName = LiveKit;
+		};
+		569BB5ED0A719F403FD9DEE5 /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C1E4C8C615FE293BED810C78 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
 		};
 		A259DAEA74BD10BB6C982FAC /* SwiftProtobuf */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/MezonChat/Application/AppDelegate.swift
+++ b/MezonChat/Application/AppDelegate.swift
@@ -22,6 +22,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate, UIWindowSceneDelega
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
         MezonEnvironment.current = .prod
+        SentryLogger.start()
         CallKitManager.shared.configure()
         NotificationCenter.default.addObserver(self, selector: #selector(handleVoIPTokenDidUpdate), name: .mezonVoIPTokenDidUpdate, object: nil)
         NotificationCenter.default.addObserver(

--- a/MezonChat/Core/UI/MediaLoadingSignals.swift
+++ b/MezonChat/Core/UI/MediaLoadingSignals.swift
@@ -172,7 +172,13 @@ final class ImageCache {
         key: String,
         completion: @escaping (UIImage?) -> Void
     ) -> URLSessionDataTask {
-        let task = URLSession.shared.dataTask(with: url) { [weak self] data, _, _ in
+        let task = URLSession.shared.dataTask(with: url) { [weak self] data, _, error in
+            if let error {
+                SentryLogger.capture(error, extras: [
+                    "where": "ImageCache.downloadImage",
+                    "url": url.absoluteString,
+                ])
+            }
             guard let data else {
                 DispatchQueue.main.async { completion(nil) }
                 return
@@ -405,8 +411,14 @@ func remoteImageSignal(url: String, resizeMode: ImageResizeMode = .fit) -> Signa
                 subscriber.putCompletion()
                 return
             }
-            let task = URLSession.shared.dataTask(with: imageURL) { data, _, _ in
+            let task = URLSession.shared.dataTask(with: imageURL) { data, _, error in
                 guard !cancelled.with({ $0 }) else { return }
+                if let error {
+                    SentryLogger.capture(error, extras: [
+                        "where": "remoteImageSignal",
+                        "url": url,
+                    ])
+                }
                 guard let data else {
                     subscriber.putNext(emptyDrawingTransform())
                     subscriber.putCompletion()
@@ -454,8 +466,14 @@ func remoteAttachmentImageSignal(proxyURL: String, originalURL: String, resizeMo
                 onFailure()
                 return
             }
-            let task = URLSession.shared.dataTask(with: imageURL) { data, _, _ in
+            let task = URLSession.shared.dataTask(with: imageURL) { data, _, error in
                 guard !cancelled.with({ $0 }) else { return }
+                if let error {
+                    SentryLogger.capture(error, extras: [
+                        "where": "remoteAttachmentImageSignal",
+                        "url": urlString,
+                    ])
+                }
                 guard let data, let image = UIImage.decompressedImage(from: data) else {
                     onFailure()
                     return
@@ -544,8 +562,14 @@ func remoteImageUISignal(url: String) -> Signal<UIImage?, NoError> {
                 subscriber.putCompletion()
                 return
             }
-            let task = URLSession.shared.dataTask(with: imageURL) { data, _, _ in
+            let task = URLSession.shared.dataTask(with: imageURL) { data, _, error in
                 guard !cancelled.with({ $0 }) else { return }
+                if let error {
+                    SentryLogger.capture(error, extras: [
+                        "where": "rawImageSignal",
+                        "url": url,
+                    ])
+                }
                 let image = data.flatMap { UIImage.decompressedImage(from: $0) }
                 if let image, let data {
                     cache.setImage(image, data: data, forKey: url)

--- a/MezonChat/Core/UI/ReactionEmojiImageLoader.swift
+++ b/MezonChat/Core/UI/ReactionEmojiImageLoader.swift
@@ -26,7 +26,13 @@ enum ReactionEmojiImageLoader {
             }
             return nil
         }
-        let task = URLSession.shared.dataTask(with: url) { data, _, _ in
+        let task = URLSession.shared.dataTask(with: url) { data, _, error in
+            if let error {
+                SentryLogger.capture(error, extras: [
+                    "where": "ReactionEmojiImageLoader.load",
+                    "url": url.absoluteString,
+                ])
+            }
             guard let data,
                   let image = UIImage.animatedImage(from: data) ?? UIImage.decodeImage(from: data)
             else {
@@ -121,7 +127,13 @@ enum ReactionEmojiImageLoader {
             }
             return nil
         }
-        let task = URLSession.shared.dataTask(with: url) { data, _, _ in
+        let task = URLSession.shared.dataTask(with: url) { data, _, error in
+            if let error {
+                SentryLogger.capture(error, extras: [
+                    "where": "ReactionEmojiImageLoader.loadData",
+                    "url": url.absoluteString,
+                ])
+            }
             guard let data else {
                 DispatchQueue.main.async { completion(nil) }
                 return

--- a/MezonChat/Core/Utils/SentryLogger.swift
+++ b/MezonChat/Core/Utils/SentryLogger.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Sentry
+
+enum SentryLogger {
+
+    static func start() {
+        SentrySDK.start { options in
+            options.dsn = Secrets.sentryDSN
+            options.environment = MezonEnvironment.current == .prod ? "production" : "development"
+            options.releaseName = Self.releaseName()
+
+            options.debug = false
+            options.attachStacktrace = true
+            options.enableAutoPerformanceTracing = false
+            options.enableNetworkTracking = false
+            options.enableUserInteractionTracing = false
+            options.enableNetworkBreadcrumbs = true
+            options.enableAutoBreadcrumbTracking = true
+            options.enableAppHangTracking = true
+        }
+    }
+
+    static func setUser(id: String?, username: String?) {
+        guard let id else {
+            SentrySDK.setUser(nil)
+            return
+        }
+        let user = Sentry.User(userId: id)
+        user.username = username
+        SentrySDK.setUser(user)
+    }
+
+    static func capture(_ error: Error, extras: [String: Any]? = nil) {
+        SentrySDK.capture(error: error) { scope in
+            if let extras {
+                for (key, value) in extras {
+                    scope.setExtra(value: value, key: key)
+                }
+            }
+        }
+    }
+
+    static func capture(message: String, level: SentryLevel = .info, extras: [String: Any]? = nil) {
+        SentrySDK.capture(message: message) { scope in
+            scope.setLevel(level)
+            if let extras {
+                for (key, value) in extras {
+                    scope.setExtra(value: value, key: key)
+                }
+            }
+        }
+    }
+
+    static func addBreadcrumb(category: String, message: String, level: SentryLevel = .info, data: [String: Any]? = nil) {
+        let crumb = Breadcrumb(level: level, category: category)
+        crumb.message = message
+        crumb.data = data
+        SentrySDK.addBreadcrumb(crumb)
+    }
+
+    private static func releaseName() -> String {
+        let bundle = Bundle.main
+        let version = bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+        let build = bundle.infoDictionary?["CFBundleVersion"] as? String ?? "0"
+        let identifier = bundle.bundleIdentifier ?? "mezon.ios"
+        return "\(identifier)@\(version)+\(build)"
+    }
+}

--- a/MezonChat/Features/ChannelDetail/ChannelDetailViewController.swift
+++ b/MezonChat/Features/ChannelDetail/ChannelDetailViewController.swift
@@ -827,6 +827,10 @@ private final class GroupDMCustomizeViewController: UIViewController, UIImagePic
                 Toast.success(L(L10n.ChannelDetail.groupUpdated))
                 self.dismiss(animated: true)
             } catch {
+                SentryLogger.capture(error, extras: [
+                    "where": "ChannelDetail.updateGroup",
+                    "channelId": self.originalChannel.channelID,
+                ])
                 Toast.error(L(L10n.ChannelDetail.updateGroupFailed))
             }
         }

--- a/MezonChat/Features/Chat/Cells/MessageMediaContentNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageMediaContentNode.swift
@@ -381,7 +381,13 @@ final class MessageMediaContentNode: ASDisplayNode {
             return
         }
 
-        URLSession.shared.dataTask(with: imageURL) { data, _, _ in
+        URLSession.shared.dataTask(with: imageURL) { data, _, error in
+            if let error {
+                SentryLogger.capture(error, extras: [
+                    "where": "MessageMediaContentNode.loadImage",
+                    "url": url,
+                ])
+            }
             guard let data else { return }
             let image = UIImage.animatedImage(from: data) ?? UIImage.decodeImage(from: data)
             if let image {

--- a/MezonChat/Features/Chat/ChatViewController.swift
+++ b/MezonChat/Features/Chat/ChatViewController.swift
@@ -1742,6 +1742,12 @@ final class ChatViewController: ViewController {
                     tx.replaceAllMessages(records, channelId: self.storageChannelId)
                 }
             } catch {
+                SentryLogger.capture(error, extras: [
+                    "where": "ChatViewController.fetchMessages",
+                    "channelId": channel.channelID,
+                    "clanId": clanId,
+                    "topicId": self.topicId,
+                ])
                 self.setErrorMessage(error.localizedDescription)
             }
         }
@@ -1776,6 +1782,12 @@ final class ChatViewController: ViewController {
                     }
                 }
             } catch {
+                SentryLogger.capture(error, extras: [
+                    "where": "ChatViewController.fetchOlderMessages",
+                    "channelId": channel.channelID,
+                    "clanId": clanId,
+                    "anchorMessageId": msgId,
+                ])
                 self.setHasMoreOlder(false)
             }
         }
@@ -1809,6 +1821,12 @@ final class ChatViewController: ViewController {
                 }
                 self.setIsLoadingNewer(false)
             } catch {
+                SentryLogger.capture(error, extras: [
+                    "where": "ChatViewController.fetchNewerMessages",
+                    "channelId": channel.channelID,
+                    "clanId": clanId,
+                    "anchorMessageId": msgId,
+                ])
                 self.setHasMoreNewer(false)
                 self.setIsLoadingNewer(false)
             }
@@ -1843,6 +1861,11 @@ final class ChatViewController: ViewController {
                     )
                 }
             } catch {
+                SentryLogger.capture(error, extras: [
+                    "where": "ChatViewController.jumpToPresent",
+                    "channelId": channel.channelID,
+                    "clanId": clanId,
+                ])
                 self.pendingScrollToBottom = false
                 self.setErrorMessage(error.localizedDescription)
             }
@@ -3410,6 +3433,12 @@ final class ChatViewController: ViewController {
                     )
                 }
             } catch {
+                SentryLogger.capture(error, extras: [
+                    "where": "ChatViewController.jumpToMessage",
+                    "channelId": self.channel.channelID,
+                    "clanId": self.clanId,
+                    "anchorMessageId": msgId,
+                ])
                 self.messagesNode.pendingJumpMessageId = nil
             }
         }

--- a/MezonChat/Features/Chat/ForwardMessageViewController.swift
+++ b/MezonChat/Features/Chat/ForwardMessageViewController.swift
@@ -1070,6 +1070,11 @@ final class ForwardMessageViewController: UIViewController {
                 Toast.success(L(L10n.Forward.success))
                 dismiss(animated: true)
             } catch {
+                SentryLogger.capture(error, extras: [
+                    "where": "ForwardMessage",
+                    "messageCount": messagesToForward.count,
+                    "destinationCount": targets.count,
+                ])
                 Toast.error(L(L10n.Sharing.errorTitle))
             }
         }

--- a/MezonChat/Features/ClanSettings/Roles/RoleDetailViewController.swift
+++ b/MezonChat/Features/ClanSettings/Roles/RoleDetailViewController.swift
@@ -800,6 +800,12 @@ extension RoleDetailViewController: UIImagePickerControllerDelegate, UINavigatio
                 )
                 self.applyIconURL(cdnURL)
             } catch {
+                SentryLogger.capture(error, extras: [
+                    "where": "RoleDetail.uploadIcon",
+                    "roleId": self.roleId,
+                    "clanId": self.clanId,
+                    "size": data.count,
+                ])
                 Toast.error(L(L10n.ClanRoles.iconFailed))
             }
         }

--- a/MezonChat/Features/Clans/CreateClanViewController.swift
+++ b/MezonChat/Features/Clans/CreateClanViewController.swift
@@ -522,6 +522,10 @@ final class CreateClanViewController: BaseViewController, UIImagePickerControlle
                 logoImageView.image = image
                 refreshLogoOverlay()
             } catch {
+                SentryLogger.capture(error, extras: [
+                    "where": "CreateClan.uploadLogo",
+                    "size": data.count,
+                ])
                 Toast.error(error.localizedDescription)
                 logoCenterStack.isHidden = false
             }

--- a/MezonChat/Features/Profile/ProfileSettingViewController.swift
+++ b/MezonChat/Features/Profile/ProfileSettingViewController.swift
@@ -1382,6 +1382,11 @@ final class ProfileSettingViewController: BaseViewController {
                     dmIconRemoveButton.isHidden = false
                 }
             } catch {
+                SentryLogger.capture(error, extras: [
+                    "where": "ProfileSetting.uploadImage",
+                    "target": "\(target)",
+                    "size": data.count,
+                ])
                 Toast.error(L(L10n.ProfileSetting.updateError))
             }
         }

--- a/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
+++ b/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
@@ -1037,6 +1037,11 @@ final class SendMessageInputViewController: UIViewController {
                         token: token
                     )
                 } catch {
+                    SentryLogger.capture(error, extras: [
+                        "where": "sendWaveMessage",
+                        "channelId": channel.channelID,
+                        "clanId": clanId,
+                    ])
                     self.onError?(error.localizedDescription)
             }
         }
@@ -1099,6 +1104,11 @@ final class SendMessageInputViewController: UIViewController {
                         token: token
                     )
                 } catch {
+                    SentryLogger.capture(error, extras: [
+                        "where": "sendBuzzMessage",
+                        "channelId": channel.channelID,
+                        "clanId": clanId,
+                    ])
                     self.onError?(error.localizedDescription)
             }
         }
@@ -3802,6 +3812,12 @@ final class SendMessageInputViewController: UIViewController {
                 att.duration = Int32(durationSeconds)
                 sendChannelMessageWithAttachments(text: "", attachments: [att])
             } catch {
+                SentryLogger.capture(error, extras: [
+                    "where": "sendVoiceAttachment",
+                    "channelId": self.channel.channelID,
+                    "clanId": self.clanId,
+                    "durationSeconds": durationSeconds,
+                ])
                 self.onError?(error.localizedDescription)
                 try? FileManager.default.removeItem(at: fileURL)
             }
@@ -4475,6 +4491,14 @@ final class SendMessageInputViewController: UIViewController {
                     }
                 }
             } catch {
+                SentryLogger.capture(error, extras: [
+                    "where": "sendChannelMessage",
+                    "channelId": channel.channelID,
+                    "clanId": clanId,
+                    "isEdit": isEdit,
+                    "imageCount": imagesToUpload.count,
+                    "fileCount": filesToUpload.count,
+                ])
                 if !isEdit, !sendAsAnonymous {
                     self.context.account.postbox.write { tx in tx.markMessageFailed(id: localId) }
                     ParsedAttachment.pendingImageCache.removeValue(forKey: localId)
@@ -4601,6 +4625,12 @@ final class SendMessageInputViewController: UIViewController {
                     token: token
                 )
             } catch {
+                SentryLogger.capture(error, extras: [
+                    "where": "sendChannelMessageWithAttachments",
+                    "channelId": channel.channelID,
+                    "clanId": clanId,
+                    "attachmentCount": attachments.count,
+                ])
                 self.onError?(error.localizedDescription)
             }
         }

--- a/MezonChat/Features/Sharing/SharingViewController.swift
+++ b/MezonChat/Features/Sharing/SharingViewController.swift
@@ -1444,6 +1444,10 @@ final class SharingViewController: UIViewController {
                 self.dismiss(animated: true)
 
             } catch {
+                SentryLogger.capture(error, extras: [
+                    "where": "Sharing.sendWithAttachments",
+                    "mediaCount": self.sharedMediaFiles.count,
+                ])
                 self.isUploading = false
                 self.loadingOverlay.isHidden = true
                 self.activityIndicator.stopAnimating()

--- a/project.yml
+++ b/project.yml
@@ -32,6 +32,9 @@ packages:
   SwiftProtobuf:
     url: https://github.com/apple/swift-protobuf
     from: "1.28.0"
+  Sentry:
+    url: https://github.com/getsentry/sentry-cocoa
+    from: "8.40.0"
 
 options:
   bundleIdPrefix: mezon
@@ -75,6 +78,8 @@ targets:
         product: LiveKitWebRTC
       - package: SwiftProtobuf
         product: SwiftProtobuf
+      - package: Sentry
+        product: Sentry
       - target: NotificationService
       - target: MezonSharing
     sources:


### PR DESCRIPTION
## Summary

- Add **Sentry Cocoa SDK** (`sentry-cocoa` 8.40.0) via Swift Package Manager in `project.yml`.
- Introduce `SentryLogger` wrapper for SDK init, user context, error/message capture, and breadcrumbs.
- Start Sentry early in `AppDelegate` (before other services).
- Add `Secrets.sentryDSN` for DSN configuration.
- Wire `SentryLogger.capture` at key error-handling paths (chat, upload, media, clan, profile, etc.) with `where` + contextual metadata.

## Motivation

The app currently only logs errors locally or shows UI error states — hard to monitor production failures across screens and async flows. Sentry collects crashes/errors with stack traces and context for faster debugging.

## Changes

### Dependency

| File | Change |
|------|--------|
| `project.yml` | Add `getsentry/sentry-cocoa` package and link `Sentry` product to `MezonChat` target |
| `MezonChat.xcodeproj` | Regenerated via `xcodegen generate` |

### Core

| File | Change |
|------|--------|
| `MezonChat/Core/Utils/SentryLogger.swift` | SDK wrapper: `start()`, `setUser()`, `capture(error:)`, `capture(message:)`, `addBreadcrumb()` |
| `MezonChat/Networking/Secrets.swift` | Add `sentryDSN` |
| `MezonChat/Application/AppDelegate.swift` | Call `SentryLogger.start()` in `didFinishLaunchingWithOptions` |

### Sentry config (current)

- **Environment:** `production` / `development` based on `MezonEnvironment.current`
- **Release:** `{bundleId}@{version}+{build}`
- **Enabled:** stack traces, network breadcrumbs, auto breadcrumbs, app hang tracking
- **Disabled:** auto performance tracing, network tracking, user interaction tracing (reduce overhead/noise initially)

### Error capture — covered areas

- **Chat:** fetch messages (older/newer/around), message operations
- **Send message / upload:** send message, upload attachments
- **Media:** `MediaLoadingSignals`, `MessageMediaContentNode`, `ReactionEmojiImageLoader`
- **Channel / Clan:** `ChannelDetailViewController`, `CreateClanViewController`, `RoleDetailViewController`
- **Profile / Sharing:** `ProfileSettingViewController`, `SharingViewController`, `ForwardMessageViewController`

Each capture typically includes extras:

```swift
SentryLogger.capture(error, extras: [
    "where": "Module.functionName",
    "channelId": ...,
    // relevant context
])