### PR TITLE
260521-IOS-Fix UI poll

### DIFF
--- a/MezonChat/Features/Chat/Poll/CreatePollViewController.swift
+++ b/MezonChat/Features/Chat/Poll/CreatePollViewController.swift
@@ -436,11 +436,11 @@ final class CreatePollViewController: BaseViewController {
             postButton.leadingAnchor.constraint(equalTo: bottomBar.leadingAnchor, constant: 20),
             postButton.trailingAnchor.constraint(equalTo: bottomBar.trailingAnchor, constant: -20),
             postButton.topAnchor.constraint(equalTo: bottomBar.topAnchor, constant: 12),
-            postButton.bottomAnchor.constraint(equalTo: bottomBar.bottomAnchor, constant: -12),
+            postButton.bottomAnchor.constraint(equalTo: bottomBar.safeAreaLayoutGuide.bottomAnchor, constant: -12),
             postButton.heightAnchor.constraint(equalToConstant: 50)
         ])
         
-        let bbBottom = bottomBar.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        let bbBottom = bottomBar.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         bbBottom.isActive = true
         bottomBarBottomConstraint = bbBottom
     }

--- a/MezonChat/Features/Chat/Poll/PollOptionRowNode.swift
+++ b/MezonChat/Features/Chat/Poll/PollOptionRowNode.swift
@@ -39,7 +39,6 @@ final class PollOptionRowNode: ASDisplayNode {
     private static let rowHeight: CGFloat = 40
     private static let cornerRadius: CGFloat = 8
     private static let fillAnimationDuration: CFTimeInterval = 0.6
-    private static let activeTextWhiteThreshold = 0
     private static let blurpleColor = UIColor(red: 88/255, green: 101/255, blue: 242/255, alpha: 1)
     private static let blurpleFillResult = UIColor(red: 88/255, green: 101/255, blue: 242/255, alpha: 0.35)
 
@@ -109,9 +108,7 @@ final class PollOptionRowNode: ASDisplayNode {
 
     private func updateLabelText() {
         let t = UIColor.theme
-        let shouldUseActiveColor = hasVoted && option.isSelected && shouldShowResults
-            && option.percentage >= 0
-        let color = shouldUseActiveColor ? UIColor.white : t.textStrong
+        let color = isLabelWhite == true ? UIColor.white : t.textStrong
         let font = UIFont.systemFont(ofSize: 14.sf)
         
         cachedAttributedLabelText = PollEmojiParser.parse(option.label, font: font, color: color, emojiSize: 20.sf)
@@ -119,8 +116,6 @@ final class PollOptionRowNode: ASDisplayNode {
 
     private func updateMetaText() {
         let t = UIColor.theme
-        let shouldUseActiveColor = hasVoted && option.isSelected && shouldShowResults
-            && option.percentage >= Self.activeTextWhiteThreshold
         let voteWord = option.voteCount > 1
             ? L(L10n.Poll.votes)
             : L(L10n.Poll.vote)
@@ -128,7 +123,7 @@ final class PollOptionRowNode: ASDisplayNode {
             string: "\(option.percentage)% \(option.voteCount) \(voteWord)",
             attributes: [
                 .font: UIFont.systemFont(ofSize: 12.sf),
-                .foregroundColor: shouldUseActiveColor ? UIColor.white : t.textDisabled,
+                .foregroundColor: isMetaWhite == true ? UIColor.white : t.textStrong,
             ]
         )
     }
@@ -184,6 +179,9 @@ final class PollOptionRowNode: ASDisplayNode {
 
     private var cachedLabelSize: CGSize = .zero
     private var cachedMetaSize: CGSize = .zero
+    
+    private var isLabelWhite: Bool?
+    private var isMetaWhite: Bool?
 
     func measureSize(maxWidth: CGFloat) -> CGSize {
         let hPad: CGFloat = 12
@@ -231,6 +229,33 @@ final class PollOptionRowNode: ASDisplayNode {
         }
 
         cachedSize = CGSize(width: maxWidth, height: rowHeight)
+        
+        let targetFillWidth: CGFloat = shouldShowResults ? maxWidth * CGFloat(option.percentage) / 100.0 : 0
+        let touchesLabel = targetFillWidth > hPad + (cachedLabelSize.width * 0.4)
+        
+        let rightReserved: CGFloat = option.isSelected ? (checkSize + gap) : 0
+        let metaX = maxWidth - hPad - rightReserved - cachedMetaSize.width
+        let coversMeta = targetFillWidth >= (metaX + cachedMetaSize.width - 4)
+        
+        let shouldLabelBeWhite = hasVoted && option.isSelected && shouldShowResults && touchesLabel
+        let shouldMetaBeWhite = hasVoted && option.isSelected && shouldShowResults && coversMeta
+        
+        if isLabelWhite == nil {
+            isLabelWhite = shouldLabelBeWhite
+            if shouldLabelBeWhite { updateLabelText() }
+        } else if isLabelWhite != shouldLabelBeWhite {
+            isLabelWhite = shouldLabelBeWhite
+            updateLabelText()
+        }
+        
+        if isMetaWhite == nil {
+            isMetaWhite = shouldMetaBeWhite
+            if shouldMetaBeWhite { updateMetaText() }
+        } else if isMetaWhite != shouldMetaBeWhite {
+            isMetaWhite = shouldMetaBeWhite
+            updateMetaText()
+        }
+        
         return cachedSize
     }
 


### PR DESCRIPTION
issue: https://github.com/mezonai/mezon-ios/issues/149
Test Cases
Verify the "Post" button bottom bar extends to the bottom screen edge without floating gaps on devices with a home indicator.
Verify the "Post" button remains properly padded and positioned above the keyboard when it appears.
Verify the vote count text changes to white ONLY when fully covered by the blue progress bar.
Verify the vote count text uses textStrong color when the progress bar does NOT fully overlap the text.
Verify both the poll option layout and colors adapt correctly when toggling between Light and Dark themes.

Root Cause
Create Poll Screen: The bottom bar constraint was directly pinned to view.safeAreaLayoutGuide.bottomAnchor, which left an empty visual gap at the bottom home indicator area.
Poll Card Option UI: The vote count text color was hardcoded to become white unconditionally for selected options, causing poor contrast when the progress bar width was too short to cover the text.

Solution
Create Poll Screen: Pinned the bottomBar to the absolute view.bottomAnchor to span the full screen bottom, while constraining the internal postButton to bottomBar.safeAreaLayoutGuide.bottomAnchor to respect safe area insets correctly.
Poll Card Option UI: Implemented dynamic overlap calculations within measureSize(). The vote count text now smartly determines its color based on the progress bar width, switching to white only when fully overlapped, and falling back to textStrong otherwise.