### PR TITLE
feat: add share contact

### DIFF
--- a/MezonChat/Core/UI/MediaLoadingSignals.swift
+++ b/MezonChat/Core/UI/MediaLoadingSignals.swift
@@ -174,7 +174,7 @@ final class ImageCache {
     ) -> URLSessionDataTask {
         let task = URLSession.shared.dataTask(with: url) { [weak self] data, _, error in
             if let error {
-                SentryLogger.capture(error, extras: [
+                SentryLogger.captureMediaError(error, extras: [
                     "where": "ImageCache.downloadImage",
                     "url": url.absoluteString,
                 ])
@@ -414,7 +414,7 @@ func remoteImageSignal(url: String, resizeMode: ImageResizeMode = .fit) -> Signa
             let task = URLSession.shared.dataTask(with: imageURL) { data, _, error in
                 guard !cancelled.with({ $0 }) else { return }
                 if let error {
-                    SentryLogger.capture(error, extras: [
+                    SentryLogger.captureMediaError(error, extras: [
                         "where": "remoteImageSignal",
                         "url": url,
                     ])
@@ -469,7 +469,7 @@ func remoteAttachmentImageSignal(proxyURL: String, originalURL: String, resizeMo
             let task = URLSession.shared.dataTask(with: imageURL) { data, _, error in
                 guard !cancelled.with({ $0 }) else { return }
                 if let error {
-                    SentryLogger.capture(error, extras: [
+                    SentryLogger.captureMediaError(error, extras: [
                         "where": "remoteAttachmentImageSignal",
                         "url": urlString,
                     ])
@@ -565,7 +565,7 @@ func remoteImageUISignal(url: String) -> Signal<UIImage?, NoError> {
             let task = URLSession.shared.dataTask(with: imageURL) { data, _, error in
                 guard !cancelled.with({ $0 }) else { return }
                 if let error {
-                    SentryLogger.capture(error, extras: [
+                    SentryLogger.captureMediaError(error, extras: [
                         "where": "rawImageSignal",
                         "url": url,
                     ])

--- a/MezonChat/Core/UI/ReactionEmojiImageLoader.swift
+++ b/MezonChat/Core/UI/ReactionEmojiImageLoader.swift
@@ -28,7 +28,7 @@ enum ReactionEmojiImageLoader {
         }
         let task = URLSession.shared.dataTask(with: url) { data, _, error in
             if let error {
-                SentryLogger.capture(error, extras: [
+                SentryLogger.captureMediaError(error, extras: [
                     "where": "ReactionEmojiImageLoader.load",
                     "url": url.absoluteString,
                 ])
@@ -129,7 +129,7 @@ enum ReactionEmojiImageLoader {
         }
         let task = URLSession.shared.dataTask(with: url) { data, _, error in
             if let error {
-                SentryLogger.capture(error, extras: [
+                SentryLogger.captureMediaError(error, extras: [
                     "where": "ReactionEmojiImageLoader.loadData",
                     "url": url.absoluteString,
                 ])

--- a/MezonChat/Core/Utils/MezonConstants.swift
+++ b/MezonChat/Core/Utils/MezonConstants.swift
@@ -28,6 +28,7 @@ enum MezonConstants {
         "https://cdn.mezon.ai/stickers/mezon.gif",
         "http://cdn.mezon.ai/landing-page-mezon/2021919345600368640.gif",
     ]
+    static let shareContactKey = "share_contact"
 
     enum ChannelType: Int32 {
         case channel = 1
@@ -61,6 +62,8 @@ enum MezonConstants {
         case upcomingEvent = 13
         case updateEphemeral = 14  
         case deleteEphemeral = 15  
+        case shareContact = 16
+        case location = 17
         case poll = 18
     }
 }

--- a/MezonChat/Core/Utils/SentryLogger.swift
+++ b/MezonChat/Core/Utils/SentryLogger.swift
@@ -31,13 +31,37 @@ enum SentryLogger {
     }
 
     static func capture(_ error: Error, extras: [String: Any]? = nil) {
+        let ns = error as NSError
+        let transient = Self.isTransientNetworkError(ns)
+        var merged = extras ?? [:]
+        if transient {
+            merged["transient"] = true
+            merged["urlErrorCode"] = ns.code
+        }
+        let level: SentryLevel = transient ? .warning : .error
         SentrySDK.capture(error: error) { scope in
-            if let extras {
-                for (key, value) in extras {
-                    scope.setExtra(value: value, key: key)
-                }
+            scope.setLevel(level)
+            for (key, value) in merged {
+                scope.setExtra(value: value, key: key)
             }
         }
+    }
+
+    static func captureMediaError(_ error: Error, extras: [String: Any]? = nil) {
+        let ns = error as NSError
+        if Self.isTransientNetworkError(ns) {
+            var data = extras ?? [:]
+            data["urlErrorCode"] = ns.code
+            data["domain"] = ns.domain
+            addBreadcrumb(
+                category: "media.load.fail",
+                message: ns.localizedDescription,
+                level: .info,
+                data: data
+            )
+            return
+        }
+        capture(error, extras: extras)
     }
 
     static func capture(message: String, level: SentryLevel = .info, extras: [String: Any]? = nil) {
@@ -56,6 +80,26 @@ enum SentryLogger {
         crumb.message = message
         crumb.data = data
         SentrySDK.addBreadcrumb(crumb)
+    }
+
+    private static let transientURLErrorCodes: Set<Int> = [
+        NSURLErrorCancelled,
+        NSURLErrorTimedOut,
+        NSURLErrorCannotFindHost,
+        NSURLErrorCannotConnectToHost,
+        NSURLErrorNetworkConnectionLost,
+        NSURLErrorDNSLookupFailed,
+        NSURLErrorNotConnectedToInternet,
+        NSURLErrorInternationalRoamingOff,
+        NSURLErrorCallIsActive,
+        NSURLErrorDataNotAllowed,
+        NSURLErrorRequestBodyStreamExhausted,
+        NSURLErrorBackgroundSessionWasDisconnected,
+    ]
+
+    private static func isTransientNetworkError(_ error: NSError) -> Bool {
+        guard error.domain == NSURLErrorDomain else { return false }
+        return transientURLErrorCodes.contains(error.code)
     }
 
     private static func releaseName() -> String {

--- a/MezonChat/Features/ChannelDetail/CreateThreadFormViewController.swift
+++ b/MezonChat/Features/ChannelDetail/CreateThreadFormViewController.swift
@@ -666,9 +666,28 @@ final class CreateThreadFormViewController: UIViewController {
             DispatchQueue.main.async { [weak self] in self?.sendInputVC.focusTextInput() }
         case "transfer_funds":
             navigateToTransferFundsForThreadForm()
+        case "share_contact":
+            navigateToShareContactForThreadForm()
         default:
             Toast.comingSoonLine(item.label.replacingOccurrences(of: "\n", with: " "))
         }
+    }
+
+    private func navigateToShareContactForThreadForm() {
+        view.endEditing(true)
+        sendInputVC.markAdvancePanelDismissedByHost()
+        handleAdvancePanelToggle(visible: false, collapsedHeight: 0)
+
+        let vc = ShareContactPickerViewController(context: context)
+        vc.onSelectFriend = { [weak self, weak vc] friend in
+            guard let self else { return }
+            self.sendInputVC.sendShareContact(friend: friend)
+            vc?.navigationController?.popViewController(animated: true)
+            DispatchQueue.main.async {
+                self.sendInputVC.focusTextInput()
+            }
+        }
+        navigationController?.pushViewController(vc, animated: true)
     }
 
     private func handleSendLocationForThreadForm() {

--- a/MezonChat/Features/Chat/Cells/MessageBubbleNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageBubbleNode.swift
@@ -20,6 +20,7 @@ final class MessageBubbleNode: ASDisplayNode {
     private var audioAttachmentNode: MessageAudioAttachmentNode?
     private var fileAttachmentNode: MessageFileAttachmentNode?
     private var embedNode: MessageEmbedNode?
+    private var shareContactNode: MessageShareContactNode?
     private var reactionsNode: MessageReactionsNode?
     private var locationNode: MessageLocationNode?
     private var clanInviteLinkNode: MessageClanInviteLinkNode?
@@ -44,6 +45,7 @@ final class MessageBubbleNode: ASDisplayNode {
     private let hasAudio: Bool
     private let hasFiles: Bool
     private let hasEmbeds: Bool
+    private let hasShareContact: Bool
     private let showsReactionStrip: Bool
     private let hasReply: Bool
     private let hasDeletedReply: Bool
@@ -56,6 +58,7 @@ final class MessageBubbleNode: ASDisplayNode {
     private static let contentLeading: CGFloat = 40 + 12.sw
     private static let roleIconSide: CGFloat = 16.sf
     private static let roleIconLeadingGap: CGFloat = 4.sw
+    private static let shareContactTopSpacing: CGFloat = 8
 
     private var cachedNameSize: CGSize = .zero
     private var cachedTimeSize: CGSize = .zero
@@ -70,6 +73,7 @@ final class MessageBubbleNode: ASDisplayNode {
     private var cachedAudioSize: CGSize = .zero
     private var cachedFileSize: CGSize = .zero
     private var cachedEmbedSize: CGSize = .zero
+    private var cachedShareContactSize: CGSize = .zero
     private var cachedReactionsSize: CGSize = .zero
     private var cachedLocationSize: CGSize = .zero
     private var cachedClanInviteSize: CGSize = .zero
@@ -105,6 +109,7 @@ final class MessageBubbleNode: ASDisplayNode {
         self.hasTopic = display.isTopic
 
         let parsed = display.parsedContent
+        let shareContactData = display.shareContactData
         let mediaAttachments = display.attachments.filter { $0.isMedia }
         let audioAttachments = display.attachments.filter { $0.isAudio && !$0.url.isEmpty }
         let fileAttachments = display.attachments.filter {
@@ -117,6 +122,7 @@ final class MessageBubbleNode: ASDisplayNode {
             self.hasAudio = false
             self.hasFiles = false
             self.hasEmbeds = false
+            self.hasShareContact = false
             self.hasLocation = false
         } else if display.isPollMessage {
             self.hasContent = false
@@ -124,6 +130,7 @@ final class MessageBubbleNode: ASDisplayNode {
             self.hasAudio = false
             self.hasFiles = false
             self.hasEmbeds = false
+            self.hasShareContact = false
             self.hasLocation = false
         } else if display.isSendTokenLog {
             self.hasContent = false
@@ -131,6 +138,15 @@ final class MessageBubbleNode: ASDisplayNode {
             self.hasAudio = false
             self.hasFiles = false
             self.hasEmbeds = false
+            self.hasShareContact = false
+            self.hasLocation = false
+        } else if shareContactData != nil {
+            self.hasContent = false
+            self.hasMedia = false
+            self.hasAudio = false
+            self.hasFiles = false
+            self.hasEmbeds = false
+            self.hasShareContact = true
             self.hasLocation = false
         } else if display.isLocation {
             self.hasContent = false
@@ -138,6 +154,7 @@ final class MessageBubbleNode: ASDisplayNode {
             self.hasAudio = false
             self.hasFiles = false
             self.hasEmbeds = false
+            self.hasShareContact = false
             self.hasLocation = true
         } else {
             if display.checkOneLinkImage {
@@ -149,6 +166,7 @@ final class MessageBubbleNode: ASDisplayNode {
             self.hasAudio = !audioAttachments.isEmpty
             self.hasFiles = !fileAttachments.isEmpty
             self.hasEmbeds = !parsed.embeds.isEmpty
+            self.hasShareContact = false
             self.hasLocation = false
         }
         self.showsReactionStrip = Self.shouldShowReactionStrip(for: display)
@@ -343,6 +361,22 @@ final class MessageBubbleNode: ASDisplayNode {
             }
             sendTokenLogNode = stn
             addSubnode(stn)
+        }
+
+        if hasShareContact, let shareContactData {
+            let scn = MessageShareContactNode()
+            scn.configure(data: shareContactData)
+            scn.onProfileTapped = { [weak self] data in
+                self?.interaction.onShareContactProfileTapped(data)
+            }
+            scn.onMessageTapped = { [weak self] data in
+                self?.interaction.onShareContactMessageTapped(data)
+            }
+            scn.onCallTapped = { [weak self] data in
+                self?.interaction.onShareContactCallTapped(data)
+            }
+            shareContactNode = scn
+            addSubnode(scn)
         }
 
         if let topic = display.topicData {
@@ -615,6 +649,34 @@ final class MessageBubbleNode: ASDisplayNode {
                 textContentNode = nil
             }
         }
+
+        let oldShareContact = oldDisplay.shareContactData
+        let newShareContact = newDisplay.shareContactData
+        let shareContactChanged = oldShareContact != newShareContact
+        if let data = newShareContact {
+            if let scn = shareContactNode {
+                if shareContactChanged {
+                    scn.configure(data: data)
+                }
+            } else {
+                let scn = MessageShareContactNode()
+                scn.configure(data: data)
+                scn.onProfileTapped = { [weak self] data in
+                    self?.interaction.onShareContactProfileTapped(data)
+                }
+                scn.onMessageTapped = { [weak self] data in
+                    self?.interaction.onShareContactMessageTapped(data)
+                }
+                scn.onCallTapped = { [weak self] data in
+                    self?.interaction.onShareContactCallTapped(data)
+                }
+                shareContactNode = scn
+                addSubnode(scn)
+            }
+        } else if let scn = shareContactNode {
+            scn.removeFromSupernode()
+            shareContactNode = nil
+        }
         if callLogChanged, let cln = callLogNode, let callLog = newDisplay.callLog {
             cln.configure(
                 callLog: callLog,
@@ -658,11 +720,12 @@ final class MessageBubbleNode: ASDisplayNode {
         }
 
         let embedChanged = oldDisplay.parsedContent.embeds != newDisplay.parsedContent.embeds
+            || (oldDisplay.shareContactData == nil) != (newDisplay.shareContactData == nil)
         if embedChanged {
             embedNode?.removeFromSupernode()
             embedNode = nil
             let newParsed = newDisplay.parsedContent
-            if !newParsed.embeds.isEmpty {
+            if !newParsed.embeds.isEmpty, newDisplay.shareContactData == nil {
                 let en = MessageEmbedNode()
                 en.configure(embeds: newParsed.embeds, messageId: newDisplay.id, isEphemeral: newDisplay.isEphemeral)
                 en.isUserInteractionEnabled = true
@@ -687,6 +750,7 @@ final class MessageBubbleNode: ASDisplayNode {
             || (oldFailed != newDisplay.isFailed)
             || inviteChanged || (oldWantInvite != newWantInvite)
             || (Self.shouldShowTextContent(for: newDisplay) != (textContentNode != nil))
+            || shareContactChanged
             || embedChanged
             || oldDisplay.isSending != newDisplay.isSending
         if needsRelayout {
@@ -703,6 +767,7 @@ final class MessageBubbleNode: ASDisplayNode {
         if display.isLocation { return false }
         if display.isPollMessage { return false }
         if display.isSendTokenLog { return false }
+        if display.shareContactData != nil { return false }
         if display.checkOneLinkImage { return false }
         return !display.parsedContent.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
@@ -1174,6 +1239,13 @@ final class MessageBubbleNode: ASDisplayNode {
             cachedSendTokenLogSize = .zero
         }
 
+        if let shareContactNode {
+            cachedShareContactSize = shareContactNode.measureSize(maxWidth: bodyContentWidth)
+            totalH += Self.shareContactTopSpacing + cachedShareContactSize.height + vertSpacing
+        } else {
+            cachedShareContactSize = .zero
+        }
+
         if let textContentNode {
             cachedTextSize = textContentNode.measureSize(maxWidth: bodyContentWidth)
             totalH += cachedTextSize.height + vertSpacing
@@ -1365,6 +1437,13 @@ final class MessageBubbleNode: ASDisplayNode {
             y += cachedSendTokenLogSize.height + vertSpacing
         }
 
+        if let shareContactNode {
+            y += Self.shareContactTopSpacing
+            shareContactNode.frame = CGRect(x: contentInnerX, y: y, width: cachedShareContactSize.width, height: cachedShareContactSize.height)
+            noteForwardBlock(topY: y, height: cachedShareContactSize.height)
+            y += cachedShareContactSize.height + vertSpacing
+        }
+
         if let textContentNode {
             textContentNode.frame = CGRect(x: contentInnerX, y: y, width: bodyContentWidth, height: cachedTextSize.height)
             noteForwardBlock(topY: y, height: cachedTextSize.height)
@@ -1489,6 +1568,7 @@ final class MessageBubbleNode: ASDisplayNode {
         audioAttachmentNode?.alpha = a
         fileAttachmentNode?.alpha = a
         embedNode?.alpha = a
+        shareContactNode?.alpha = a
         locationNode?.alpha = a
         clanInviteLinkNode?.alpha = a
         forwardHeaderIconNode?.alpha = a
@@ -1501,7 +1581,7 @@ final class MessageBubbleNode: ASDisplayNode {
 
     private static func hasClanInviteCard(for display: ChatMessageDisplay) -> Bool {
         guard let code = display.clanInviteLinkCode, !code.isEmpty else { return false }
-        return !display.isCallLog && !display.isLocation && !display.isPollMessage
+        return !display.isCallLog && !display.isLocation && !display.isPollMessage && display.shareContactData == nil
     }
 
     private static let timeFormatter: DateFormatter = {
@@ -1575,6 +1655,307 @@ final class MessageBubbleNode: ASDisplayNode {
 
     private static func shouldShowReactionStrip(for display: ChatMessageDisplay) -> Bool {
         reactionStripAllowed(for: display) && !display.reactions.isEmpty
+    }
+}
+
+private final class MessageShareContactNode: ASDisplayNode {
+
+    fileprivate static let blurpleColor = UIColor(red: 88/255, green: 101/255, blue: 242/255, alpha: 1)
+
+    private let gradientView = MessageShareContactGradientView()
+    private lazy var gradientNode = ASDisplayNode { [weak self] in
+        self?.gradientView ?? UIView()
+    }
+    private let actionBackgroundNode = ASDisplayNode()
+    private let dividerNode = ASDisplayNode()
+    private let avatarNode = ASImageNode()
+    private let avatarPlaceholderNode = ASTextNode2()
+    private let nameNode = ASTextNode2()
+    private let usernameNode = ASTextNode2()
+    private let profileControl = UIButton(type: .custom)
+    private lazy var profileControlNode = ASDisplayNode { [weak self] in
+        self?.profileControl ?? UIView()
+    }
+    private let callButtonNode = MessageShareContactActionButtonNode(title: "Call", systemIcon: "phone.fill", titleUsesAccent: false)
+    private let messageButtonNode = MessageShareContactActionButtonNode(title: "Message", systemIcon: "message.fill", titleUsesAccent: true)
+
+    private var data: ShareContactData?
+    private var cachedNameSize: CGSize = .zero
+    private var cachedUsernameSize: CGSize = .zero
+    private var cachedTopHeight: CGFloat = 0
+    private var cachedSize: CGSize = .zero
+    private var avatarLoadGeneration: Int = 0
+
+    var onProfileTapped: ((ShareContactData) -> Void)?
+    var onMessageTapped: ((ShareContactData) -> Void)?
+    var onCallTapped: ((ShareContactData) -> Void)?
+
+    override init() {
+        super.init()
+        automaticallyManagesSubnodes = false
+        isUserInteractionEnabled = true
+        cornerRadius = 12
+        clipsToBounds = true
+        borderWidth = 1
+
+        addSubnode(gradientNode)
+        addSubnode(actionBackgroundNode)
+        addSubnode(dividerNode)
+
+        avatarNode.cornerRadius = 20
+        avatarNode.clipsToBounds = true
+        avatarNode.contentMode = .scaleAspectFill
+        avatarNode.borderWidth = 2
+        avatarNode.borderColor = UIColor.white.cgColor
+        addSubnode(avatarNode)
+        addSubnode(avatarPlaceholderNode)
+
+        nameNode.maximumNumberOfLines = 2
+        nameNode.truncationMode = .byTruncatingTail
+        addSubnode(nameNode)
+
+        usernameNode.maximumNumberOfLines = 1
+        usernameNode.truncationMode = .byTruncatingTail
+        addSubnode(usernameNode)
+
+        profileControl.addTarget(self, action: #selector(profileTapped), for: .touchUpInside)
+        addSubnode(profileControlNode)
+
+        callButtonNode.onTapped = { [weak self] in
+            guard let self, let data = self.data else { return }
+            self.onCallTapped?(data)
+        }
+        messageButtonNode.onTapped = { [weak self] in
+            guard let self, let data = self.data else { return }
+            self.onMessageTapped?(data)
+        }
+        addSubnode(callButtonNode)
+        addSubnode(messageButtonNode)
+    }
+
+    func configure(data: ShareContactData) {
+        self.data = data
+        let t = UIColor.theme
+        borderColor = t.borderDim.cgColor
+        gradientView.update(startColor: t.primary, endColor: t.secondaryLight)
+        actionBackgroundNode.backgroundColor = t.secondaryWeight
+        dividerNode.backgroundColor = t.border
+
+        let displayName = data.resolvedDisplayName
+        let username = data.resolvedUsername
+        let avatarSeed = username.isEmpty ? displayName : username
+
+        avatarNode.backgroundColor = UIColor.avatarColor(for: avatarSeed)
+        avatarNode.image = nil
+        avatarPlaceholderNode.attributedText = NSAttributedString(
+            string: String(avatarSeed.prefix(1)).uppercased(),
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 17.sf, weight: .semibold),
+                .foregroundColor: UIColor.white,
+            ]
+        )
+        avatarPlaceholderNode.isHidden = false
+        loadAvatar(data.avatar, seed: avatarSeed)
+
+        nameNode.attributedText = NSAttributedString(
+            string: displayName,
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 14.sf, weight: .semibold),
+                .foregroundColor: t.white,
+            ]
+        )
+        usernameNode.attributedText = NSAttributedString(
+            string: username.isEmpty ? "" : "@\(username)",
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 12.sf),
+                .foregroundColor: t.text,
+            ]
+        )
+        callButtonNode.applyTheme()
+        messageButtonNode.applyTheme()
+    }
+
+    private func loadAvatar(_ rawAvatar: String, seed: String) {
+        avatarLoadGeneration += 1
+        let generation = avatarLoadGeneration
+        let avatar = rawAvatar.trimmingCharacters(in: .whitespacesAndNewlines)
+        let proxied = ImgproxyURL.avatarProxyURL(from: avatar, width: 120, height: 120)
+        guard !proxied.isEmpty, URL(string: proxied) != nil else {
+            avatarNode.image = nil
+            avatarNode.backgroundColor = UIColor.avatarColor(for: seed)
+            avatarPlaceholderNode.isHidden = false
+            return
+        }
+
+        if let cached = ImageCache.shared.cachedImage(forURL: proxied) {
+            guard generation == avatarLoadGeneration else { return }
+            avatarNode.image = cached
+            avatarNode.backgroundColor = .clear
+            avatarPlaceholderNode.isHidden = true
+            return
+        }
+
+        ImageCache.shared.loadAvatar(urlString: proxied) { [weak self] image in
+            guard let self, generation == self.avatarLoadGeneration else { return }
+            if let image {
+                self.avatarNode.image = image
+                self.avatarNode.backgroundColor = .clear
+                self.avatarPlaceholderNode.isHidden = true
+            } else {
+                self.avatarNode.image = nil
+                self.avatarNode.backgroundColor = UIColor.avatarColor(for: seed)
+                self.avatarPlaceholderNode.isHidden = false
+            }
+        }
+    }
+
+    @objc private func profileTapped() {
+        guard let data else { return }
+        onProfileTapped?(data)
+    }
+
+    func measureSize(maxWidth: CGFloat) -> CGSize {
+        let width = maxWidth <= 280 ? maxWidth : min(maxWidth * 0.9, 300)
+        let horizontalInset: CGFloat = 12
+        let avatarSide: CGFloat = 40
+        let gap: CGFloat = 12
+        let textWidth = max(width - horizontalInset * 2 - avatarSide - gap, 1)
+
+        cachedNameSize = nameNode.measure(CGSize(width: textWidth, height: .greatestFiniteMagnitude))
+        cachedUsernameSize = usernameNode.measure(CGSize(width: textWidth, height: 22))
+        let textBlockHeight = cachedNameSize.height + 2 + cachedUsernameSize.height
+        cachedTopHeight = max(72, 16 + max(avatarSide, textBlockHeight) + 16)
+        let actionHeight: CGFloat = 40
+        let height = cachedTopHeight + actionHeight
+        cachedSize = CGSize(width: width, height: height)
+        return cachedSize
+    }
+
+    override func layout() {
+        super.layout()
+        gradientNode.frame = bounds
+
+        let topHeight = cachedTopHeight > 0 ? cachedTopHeight : max(bounds.height - 40, 72)
+        let actionHeight = max(bounds.height - topHeight, 0)
+        actionBackgroundNode.frame = CGRect(x: 0, y: topHeight, width: bounds.width, height: actionHeight)
+        let scale = UIScreen.main.scale
+        let dividerWidth = 1 / scale
+        dividerNode.frame = CGRect(x: floor(bounds.width / 2), y: topHeight, width: dividerWidth, height: actionHeight)
+
+        let inset: CGFloat = 12
+        let avatarSide: CGFloat = 40
+        let gap: CGFloat = 12
+        let avatarY = max((topHeight - avatarSide) / 2, 0)
+        avatarNode.frame = CGRect(x: inset, y: avatarY, width: avatarSide, height: avatarSide)
+        let phSize = avatarPlaceholderNode.measure(CGSize(width: avatarSide, height: avatarSide))
+        avatarPlaceholderNode.frame = CGRect(
+            x: avatarNode.frame.minX + (avatarSide - phSize.width) / 2,
+            y: avatarNode.frame.minY + (avatarSide - phSize.height) / 2,
+            width: phSize.width,
+            height: phSize.height
+        )
+
+        let textX = inset + avatarSide + gap
+        let textWidth = max(bounds.width - textX - inset, 1)
+        let textBlockHeight = cachedNameSize.height + 2 + cachedUsernameSize.height
+        let textY = max((topHeight - textBlockHeight) / 2, 0)
+        nameNode.frame = CGRect(x: textX, y: textY, width: textWidth, height: cachedNameSize.height)
+        usernameNode.frame = CGRect(x: textX, y: nameNode.frame.maxY + 2, width: textWidth, height: cachedUsernameSize.height)
+        profileControlNode.frame = CGRect(x: 0, y: 0, width: bounds.width, height: topHeight)
+
+        let buttonWidth = floor(bounds.width / 2)
+        callButtonNode.frame = CGRect(x: 0, y: topHeight, width: buttonWidth, height: actionHeight)
+        messageButtonNode.frame = CGRect(x: buttonWidth, y: topHeight, width: bounds.width - buttonWidth, height: actionHeight)
+    }
+}
+
+private final class MessageShareContactGradientView: UIView {
+    override class var layerClass: AnyClass {
+        CAGradientLayer.self
+    }
+
+    func update(startColor: UIColor, endColor: UIColor) {
+        guard let gradientLayer = layer as? CAGradientLayer else { return }
+        gradientLayer.startPoint = CGPoint(x: 1, y: 0)
+        gradientLayer.endPoint = CGPoint(x: 0, y: 0)
+        gradientLayer.colors = [startColor.cgColor, endColor.cgColor]
+    }
+}
+
+private final class MessageShareContactActionButtonNode: ASDisplayNode {
+    private let backgroundNode = ASDisplayNode()
+    private let iconNode = ASImageNode()
+    private let titleNode = ASTextNode2()
+    private let control = UIButton(type: .custom)
+    private lazy var controlNode = ASDisplayNode { [weak self] in
+        self?.control ?? UIView()
+    }
+
+    var onTapped: (() -> Void)?
+    private let titleUsesAccent: Bool
+
+    init(title: String, systemIcon: String, titleUsesAccent: Bool) {
+        self.titleUsesAccent = titleUsesAccent
+        super.init()
+        automaticallyManagesSubnodes = false
+        addSubnode(backgroundNode)
+
+        iconNode.image = UIImage(systemName: systemIcon)?
+            .withConfiguration(UIImage.SymbolConfiguration(pointSize: 18, weight: .semibold))
+            .withRenderingMode(.alwaysTemplate)
+        iconNode.contentMode = .scaleAspectFit
+        addSubnode(iconNode)
+
+        titleNode.attributedText = NSAttributedString(
+            string: title,
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 14.sf, weight: .medium),
+                .foregroundColor: titleUsesAccent ? MessageShareContactNode.blurpleColor : UIColor.theme.textStrong,
+            ]
+        )
+        titleNode.maximumNumberOfLines = 1
+        titleNode.truncationMode = .byTruncatingTail
+        addSubnode(titleNode)
+
+        control.addTarget(self, action: #selector(tapped), for: .touchUpInside)
+        addSubnode(controlNode)
+        applyTheme()
+    }
+
+    func applyTheme() {
+        backgroundNode.backgroundColor = .clear
+        iconNode.tintColor = MessageShareContactNode.blurpleColor
+        if let text = titleNode.attributedText?.string {
+            titleNode.attributedText = NSAttributedString(
+                string: text,
+                attributes: [
+                    .font: UIFont.systemFont(ofSize: 14.sf, weight: .medium),
+                    .foregroundColor: titleUsesAccent ? MessageShareContactNode.blurpleColor : UIColor.theme.textStrong,
+                ]
+            )
+        }
+    }
+
+    @objc private func tapped() {
+        onTapped?()
+    }
+
+    override func layout() {
+        super.layout()
+        backgroundNode.frame = bounds
+        let iconSide: CGFloat = 18
+        let gap: CGFloat = 6
+        let labelSize = titleNode.measure(CGSize(width: max(bounds.width - 30, 1), height: bounds.height))
+        let totalWidth = min(iconSide + gap + labelSize.width, bounds.width - 12)
+        let x = max((bounds.width - totalWidth) / 2, 6)
+        iconNode.frame = CGRect(x: x, y: (bounds.height - iconSide) / 2, width: iconSide, height: iconSide)
+        titleNode.frame = CGRect(
+            x: iconNode.frame.maxX + gap,
+            y: (bounds.height - labelSize.height) / 2,
+            width: min(labelSize.width, bounds.width - iconNode.frame.maxX - gap - 6),
+            height: labelSize.height
+        )
+        controlNode.frame = bounds
     }
 }
 

--- a/MezonChat/Features/Chat/Cells/MessageMediaContentNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageMediaContentNode.swift
@@ -383,7 +383,7 @@ final class MessageMediaContentNode: ASDisplayNode {
 
         URLSession.shared.dataTask(with: imageURL) { data, _, error in
             if let error {
-                SentryLogger.capture(error, extras: [
+                SentryLogger.captureMediaError(error, extras: [
                     "where": "MessageMediaContentNode.loadImage",
                     "url": url,
                 ])

--- a/MezonChat/Features/Chat/ChatContainerNode.swift
+++ b/MezonChat/Features/Chat/ChatContainerNode.swift
@@ -44,6 +44,9 @@ struct ChatInteraction {
     let onReactionDetailRequested: (ParsedReaction, ChatMessageDisplay) -> Void
     let onAddReactionTapped: (ChatMessageDisplay) -> Void
     let onAvatarTapped: (ChatMessageDisplay) -> Void
+    let onShareContactProfileTapped: (ShareContactData) -> Void
+    let onShareContactMessageTapped: (ShareContactData) -> Void
+    let onShareContactCallTapped: (ShareContactData) -> Void
     let onSwipeReply: (ChatMessageDisplay) -> Void
     let loadClanInviteInfo: (String, @escaping (ClanInviteInfo?) -> Void) -> Void
     let onClanInvitePrimaryAction: (String, ClanInviteInfo) -> Void

--- a/MezonChat/Features/Chat/ChatViewController.swift
+++ b/MezonChat/Features/Chat/ChatViewController.swift
@@ -133,6 +133,28 @@ struct TopicData {
     let replyCount: Int
 }
 
+struct ShareContactData: Equatable {
+    let userId: String
+    let username: String
+    let displayName: String
+    let avatar: String
+
+    var resolvedDisplayName: String {
+        let name = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !name.isEmpty { return name }
+        let user = username.trimmingCharacters(in: .whitespacesAndNewlines)
+        return user.isEmpty ? userId : user
+    }
+
+    var resolvedUsername: String {
+        username.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var userIdInt: Int64? {
+        Int64(userId.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+}
+
 struct ChatMessageDisplay: Identifiable {
     let message: Message
     let senderDisplayName: String
@@ -169,6 +191,32 @@ struct ChatMessageDisplay: Identifiable {
     var isCallLog: Bool { callLog != nil }
     var isTopic: Bool { topicData != nil }
     var isLocation: Bool { locationData != nil }
+    var shareContactData: ShareContactData? {
+        guard let embed = parsedContent.embeds.first else { return nil }
+        let isShareContact = messageCode == MezonConstants.MessageCode.shareContact.rawValue
+            || embed.fields.first?.value == MezonConstants.shareContactKey
+            || embed.fields.contains { $0.name == "key" && $0.value == MezonConstants.shareContactKey }
+        guard isShareContact else { return nil }
+
+        func value(named name: String, fallbackIndex: Int) -> String {
+            if let byName = embed.fields.first(where: { $0.name == name })?.value {
+                return byName
+            }
+            guard fallbackIndex >= 0, fallbackIndex < embed.fields.count else { return "" }
+            return embed.fields[fallbackIndex].value
+        }
+
+        let data = ShareContactData(
+            userId: value(named: "user_id", fallbackIndex: 1),
+            username: value(named: "username", fallbackIndex: 2),
+            displayName: value(named: "display_name", fallbackIndex: 3),
+            avatar: value(named: "avatar", fallbackIndex: 4)
+        )
+        guard data.userIdInt != nil || !data.resolvedUsername.isEmpty || !data.resolvedDisplayName.isEmpty else {
+            return nil
+        }
+        return data
+    }
 
     var isAnonymousSender: Bool {
         senderDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -517,6 +565,15 @@ final class ChatViewController: ViewController {
             },
             onAvatarTapped: { [weak self] display in
                 self?.showMemberProfile(display)
+            },
+            onShareContactProfileTapped: { [weak self] data in
+                self?.showShareContactProfile(data)
+            },
+            onShareContactMessageTapped: { [weak self] data in
+                self?.openShareContactDirectMessage(data)
+            },
+            onShareContactCallTapped: { [weak self] data in
+                self?.startShareContactCall(data)
             },
             onSwipeReply: { [weak self] display in
                 self?.sendInputViewController.setReply(display)
@@ -3230,6 +3287,8 @@ final class ChatViewController: ViewController {
             navigateToTransferFunds()
         case "create_poll":
             navigateToCreatePoll()
+        case "share_contact":
+            navigateToShareContact()
         default:
             let toast = UILabel()
             toast.text = "  \(item.label.replacingOccurrences(of: "\n", with: " ")) — Coming soon  "
@@ -3255,6 +3314,28 @@ final class ChatViewController: ViewController {
                     toast.removeFromSuperview()
                 }
             }
+        }
+    }
+
+    private func navigateToShareContact() {
+        view.endEditing(true)
+        sendInputViewController.markAdvancePanelDismissedByHost()
+        handleAdvancePanelToggle(visible: false, collapsedHeight: 0)
+
+        let vc = ShareContactPickerViewController(context: context)
+        vc.onSelectFriend = { [weak self, weak vc] friend in
+            guard let self else { return }
+            self.sendInputViewController.sendShareContact(friend: friend)
+            vc?.navigationController?.popViewController(animated: true)
+            DispatchQueue.main.async {
+                self.sendInputViewController.focusTextInput()
+            }
+        }
+
+        if let nav = navigationController {
+            nav.pushViewController(vc, animated: true)
+        } else {
+            present(UINavigationController(rootViewController: vc), animated: true)
         }
     }
 
@@ -3944,6 +4025,122 @@ final class ChatViewController: ViewController {
         )
         presentInGlobalOverlay(sheet)
         sheet.animateIn()
+    }
+
+    private func showShareContactProfile(_ data: ShareContactData) {
+        guard let userId = data.userIdInt else { return }
+        let isCurrentUser = "\(userId)" == context.currentUser?.id
+        let user = apiUserForShareContact(data)
+
+        view.endEditing(true)
+        let sheet = MemberProfileSheetController(
+            user: user,
+            context: context,
+            isCurrentUser: isCurrentUser,
+            onSendMessage: { [weak self] dmChannel in
+                guard let self else { return }
+                self.context.currentClanId = 0
+                let chatVC = ChatViewController(
+                    clanId: 0, channel: dmChannel, context: self.context, parentName: nil)
+                self.navigationController?.pushViewController(chatVC, animated: true)
+            }
+        )
+        presentInGlobalOverlay(sheet)
+        sheet.animateIn()
+    }
+
+    private func apiUserForShareContact(_ data: ShareContactData) -> Mezon_Api_User {
+        let userId = data.userIdInt ?? 0
+        var user = Mezon_Api_User()
+        user.id = userId
+        user.username = data.resolvedUsername
+        user.displayName = data.resolvedDisplayName
+        user.avatarURL = data.avatar.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if let friend = context.engine.friendsData.allFriends().first(where: { $0.hasUser && $0.user.id == userId }) {
+            if user.username.isEmpty { user.username = friend.user.username }
+            if user.displayName.isEmpty || user.displayName == "\(userId)" { user.displayName = friend.user.displayName }
+            if user.avatarURL.isEmpty { user.avatarURL = friend.user.avatarURL }
+        } else if clanId != 0,
+                  let clanUsers = context.engine.clanData.getClanUsers(clanId: clanId),
+                  let found = clanUsers.clanUsers.first(where: { $0.user.id == userId }) {
+            let clanUser = Self.apiUserForMemberProfile(from: found)
+            if user.username.isEmpty { user.username = clanUser.username }
+            if user.displayName.isEmpty || user.displayName == "\(userId)" { user.displayName = clanUser.displayName }
+            if user.avatarURL.isEmpty { user.avatarURL = clanUser.avatarURL }
+        } else if let allUsers = context.engine.clanData.getAllUserClans(),
+                  let found = allUsers.users.first(where: { $0.id == userId }) {
+            if user.username.isEmpty { user.username = found.username }
+            if user.displayName.isEmpty || user.displayName == "\(userId)" { user.displayName = found.displayName }
+            if user.avatarURL.isEmpty { user.avatarURL = found.avatarURL }
+        }
+        return user
+    }
+
+    private func openShareContactDirectMessage(_ data: ShareContactData) {
+        loadOrCreateShareContactDirectMessage(data) { [weak self] channel in
+            guard let self else { return }
+            self.context.currentClanId = 0
+            let chatVC = ChatViewController(clanId: 0, channel: channel, context: self.context, parentName: nil)
+            self.navigationController?.pushViewController(chatVC, animated: true)
+        }
+    }
+
+    private func startShareContactCall(_ data: ShareContactData) {
+        guard data.userId != context.currentUser?.id else {
+            Toast.error("Cannot call yourself")
+            return
+        }
+        loadOrCreateShareContactDirectMessage(data) { [weak self] channel in
+            guard let self, let remoteUserId = data.userIdInt else { return }
+            PeerCallLogMessage.sendStartCallLog(
+                context: self.context,
+                channel: channel,
+                isVideoCall: false
+            )
+            let callVC = PeerCallViewController(
+                context: self.context,
+                remoteUserName: data.resolvedDisplayName,
+                remoteAvatarURL: data.avatar.trimmingCharacters(in: .whitespacesAndNewlines),
+                remoteUserId: remoteUserId,
+                channelId: channel.channelID,
+                isVideo: false
+            )
+            self.pushPeerCallScreen(callVC)
+        }
+    }
+
+    private func loadOrCreateShareContactDirectMessage(
+        _ data: ShareContactData,
+        completion: @escaping (Mezon_Api_ChannelDescription) -> Void
+    ) {
+        guard let targetUserId = data.userIdInt, targetUserId != 0 else { return }
+        Task { @MainActor in
+            guard let token = await context.getToken() else {
+                Toast.error(L(L10n.ClanInviteSheet.sessionNotFound))
+                return
+            }
+
+            let dmChannels = try? await context.account.network.listDirectMessageChannels(token: token)
+            if let existing = dmChannels?.first(where: { ch in
+                ch.type == MezonConstants.ChannelType.dm.rawValue
+                    && ch.userIds.count == 1
+                    && ch.userIds.contains(targetUserId)
+            }) {
+                completion(existing)
+                return
+            }
+
+            do {
+                let channel = try await context.account.network.createDirectMessage(
+                    userId: targetUserId,
+                    token: token
+                )
+                completion(channel)
+            } catch {
+                Toast.error(error.localizedDescription)
+            }
+        }
     }
 
     private weak var activeActionSheet: MessageActionSheetController?

--- a/MezonChat/Features/SendMessageInput/AdvancedFunctionPanelView.swift
+++ b/MezonChat/Features/SendMessageInput/AdvancedFunctionPanelView.swift
@@ -90,12 +90,12 @@ final class AdvancedFunctionPanelView: UIView, UIGestureRecognizerDelegate {
             items.append(AdvancedFunctionItem(id: "anonymous", label: anonLabel, systemIcon: "Chat/AnonymousIcon",
                                               backgroundColor: UIColor(red: 0.32, green: 0.34, blue: 0.42, alpha: 1)))
         }
-        items.append(contentsOf: [
-            AdvancedFunctionItem(id: "transfer_funds", label: "Transfer\nfunds", systemIcon: "arrow.up.circle.fill",
-                                 backgroundColor: UIColor(red: 0.36, green: 0.73, blue: 0.55, alpha: 1)),
-            AdvancedFunctionItem(id: "share_contact", label: "Share This\nContact", systemIcon: "person.crop.circle.badge.plus",
-                                 backgroundColor: UIColor(red: 0.42, green: 0.71, blue: 1.0, alpha: 1)),
-        ])
+        items.append(AdvancedFunctionItem(id: "transfer_funds", label: "Transfer\nfunds", systemIcon: "arrow.up.circle.fill",
+                                          backgroundColor: UIColor(red: 0.36, green: 0.73, blue: 0.55, alpha: 1)))
+        if !anonymousOn {
+            items.append(AdvancedFunctionItem(id: "share_contact", label: "Share\nContact", systemIcon: "person.crop.circle.badge.plus",
+                                              backgroundColor: UIColor(red: 0.42, green: 0.71, blue: 1.0, alpha: 1)))
+        }
         return items
     }
 
@@ -343,6 +343,362 @@ final class AdvancedFunctionPanelView: UIView, UIGestureRecognizerDelegate {
 
         if !expanded {
             gridScrollView.setContentOffset(.zero, animated: false)
+        }
+    }
+}
+
+final class ShareContactPickerViewController: ViewController, UITableViewDataSource, UITableViewDelegate, UITextFieldDelegate {
+
+    var onSelectFriend: ((Mezon_Api_Friend) -> Void)?
+
+    private let context: AccountContext
+    private var allFriends: [Mezon_Api_Friend] = []
+    private var filteredFriends: [Mezon_Api_Friend] = []
+    private var refreshTask: Task<Void, Never>?
+
+    private let headerView = UIView()
+    private let backButton = UIButton(type: .system)
+    private let titleLabel = UILabel()
+    private let searchContainer = UIView()
+    private let searchIcon = UIImageView()
+    private let searchField = UITextField()
+    private let tableView = UITableView(frame: .zero, style: .plain)
+    private let emptyLabel = UILabel()
+
+    init(context: AccountContext) {
+        self.context = context
+        super.init(navigationBarPresentationData: nil)
+    }
+
+    required init(coder aDecoder: NSCoder) { fatalError() }
+
+    deinit {
+        refreshTask?.cancel()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Share Contact"
+        view.backgroundColor = UIColor.theme.primary
+        setupHeader()
+        setupSearch()
+        setupTable()
+        setupEmptyState()
+        reloadFriendsFromCache()
+        refreshFriends()
+    }
+
+    private func setupHeader() {
+        headerView.translatesAutoresizingMaskIntoConstraints = false
+        headerView.backgroundColor = UIColor.theme.primary
+        view.addSubview(headerView)
+
+        backButton.translatesAutoresizingMaskIntoConstraints = false
+        backButton.tintColor = UIColor.theme.textStrong
+        backButton.setImage(UIImage(systemName: "chevron.left"), for: .normal)
+        backButton.imageView?.contentMode = .scaleAspectFit
+        backButton.addTarget(self, action: #selector(backPressed), for: .touchUpInside)
+        headerView.addSubview(backButton)
+
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.text = "Share Contact"
+        titleLabel.font = .systemFont(ofSize: 17, weight: .semibold)
+        titleLabel.textColor = UIColor.theme.textStrong
+        titleLabel.textAlignment = .center
+        headerView.addSubview(titleLabel)
+
+        NSLayoutConstraint.activate([
+            headerView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            headerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            headerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            headerView.heightAnchor.constraint(equalToConstant: 52),
+
+            backButton.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: 8),
+            backButton.centerYAnchor.constraint(equalTo: headerView.centerYAnchor),
+            backButton.widthAnchor.constraint(equalToConstant: 44),
+            backButton.heightAnchor.constraint(equalToConstant: 44),
+
+            titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: backButton.trailingAnchor, constant: 12),
+            titleLabel.centerXAnchor.constraint(equalTo: headerView.centerXAnchor),
+            titleLabel.centerYAnchor.constraint(equalTo: headerView.centerYAnchor),
+        ])
+    }
+
+    private func setupSearch() {
+        searchContainer.translatesAutoresizingMaskIntoConstraints = false
+        searchContainer.backgroundColor = UIColor.theme.secondary
+        searchContainer.layer.cornerRadius = 18
+        searchContainer.clipsToBounds = true
+        view.addSubview(searchContainer)
+
+        searchIcon.translatesAutoresizingMaskIntoConstraints = false
+        searchIcon.image = UIImage(systemName: "magnifyingglass")
+        searchIcon.tintColor = UIColor.theme.textDisabled
+        searchIcon.contentMode = .scaleAspectFit
+        searchContainer.addSubview(searchIcon)
+
+        searchField.translatesAutoresizingMaskIntoConstraints = false
+        searchField.placeholder = L(L10n.DirectMessage.searchFriends)
+        searchField.font = .systemFont(ofSize: 15)
+        searchField.textColor = UIColor.theme.textStrong
+        searchField.tintColor = UIColor.theme.textStrong
+        searchField.autocorrectionType = .no
+        searchField.autocapitalizationType = .none
+        searchField.returnKeyType = .search
+        searchField.clearButtonMode = .whileEditing
+        searchField.delegate = self
+        searchField.addTarget(self, action: #selector(searchChanged), for: .editingChanged)
+        searchField.attributedPlaceholder = NSAttributedString(
+            string: L(L10n.DirectMessage.searchFriends),
+            attributes: [.foregroundColor: UIColor.theme.textDisabled]
+        )
+        searchContainer.addSubview(searchField)
+
+        NSLayoutConstraint.activate([
+            searchContainer.topAnchor.constraint(equalTo: headerView.bottomAnchor, constant: 8),
+            searchContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            searchContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+            searchContainer.heightAnchor.constraint(equalToConstant: 42),
+
+            searchIcon.leadingAnchor.constraint(equalTo: searchContainer.leadingAnchor, constant: 14),
+            searchIcon.centerYAnchor.constraint(equalTo: searchContainer.centerYAnchor),
+            searchIcon.widthAnchor.constraint(equalToConstant: 18),
+            searchIcon.heightAnchor.constraint(equalToConstant: 18),
+
+            searchField.leadingAnchor.constraint(equalTo: searchIcon.trailingAnchor, constant: 10),
+            searchField.trailingAnchor.constraint(equalTo: searchContainer.trailingAnchor, constant: -12),
+            searchField.topAnchor.constraint(equalTo: searchContainer.topAnchor),
+            searchField.bottomAnchor.constraint(equalTo: searchContainer.bottomAnchor),
+        ])
+    }
+
+    private func setupTable() {
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.backgroundColor = .clear
+        tableView.separatorStyle = .none
+        tableView.keyboardDismissMode = .onDrag
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.rowHeight = 64
+        tableView.register(ShareContactPickerCell.self, forCellReuseIdentifier: ShareContactPickerCell.reuseIdentifier)
+        view.addSubview(tableView)
+
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: searchContainer.bottomAnchor, constant: 12),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+    }
+
+    private func setupEmptyState() {
+        emptyLabel.translatesAutoresizingMaskIntoConstraints = false
+        emptyLabel.text = L(L10n.DirectMessage.noFriends)
+        emptyLabel.font = .systemFont(ofSize: 15, weight: .medium)
+        emptyLabel.textColor = UIColor.theme.textDisabled
+        emptyLabel.textAlignment = .center
+        emptyLabel.numberOfLines = 0
+        emptyLabel.isHidden = true
+        view.addSubview(emptyLabel)
+
+        NSLayoutConstraint.activate([
+            emptyLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
+            emptyLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
+            emptyLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+        ])
+    }
+
+    private func reloadFriendsFromCache() {
+        allFriends = context.engine.friendsData.allFriends()
+            .filter { $0.state == EStateFriend.friend.rawValue && $0.hasUser }
+            .sorted { lhs, rhs in
+                friendDisplayName(lhs).localizedCaseInsensitiveCompare(friendDisplayName(rhs)) == .orderedAscending
+            }
+        applyFilter()
+    }
+
+    private func refreshFriends() {
+        refreshTask?.cancel()
+        refreshTask = Task { @MainActor [weak self] in
+            guard let self, let token = await self.context.getToken() else { return }
+            await self.context.engine.friendsData.refreshFromNetwork(token: token)
+            self.reloadFriendsFromCache()
+        }
+    }
+
+    private func applyFilter() {
+        let query = (searchField.text ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .folding(options: .diacriticInsensitive, locale: .current)
+        if query.isEmpty {
+            filteredFriends = allFriends
+        } else {
+            filteredFriends = allFriends.filter { friend in
+                let name = friendDisplayName(friend)
+                    .lowercased()
+                    .folding(options: .diacriticInsensitive, locale: .current)
+                let username = friend.user.username
+                    .lowercased()
+                    .folding(options: .diacriticInsensitive, locale: .current)
+                return name.contains(query) || username.contains(query)
+            }
+        }
+        tableView.reloadData()
+        emptyLabel.isHidden = !filteredFriends.isEmpty
+    }
+
+    private func friendDisplayName(_ friend: Mezon_Api_Friend) -> String {
+        let display = friend.user.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !display.isEmpty { return display }
+        let username = friend.user.username.trimmingCharacters(in: .whitespacesAndNewlines)
+        return username.isEmpty ? "\(friend.user.id)" : username
+    }
+
+    @objc private func searchChanged() {
+        applyFilter()
+    }
+
+    @objc private func backPressed() {
+        if let navigationController, navigationController.viewControllers.count > 1 {
+            navigationController.popViewController(animated: true)
+        } else {
+            dismiss(animated: true)
+        }
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        filteredFriends.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: ShareContactPickerCell.reuseIdentifier, for: indexPath)
+        if let cell = cell as? ShareContactPickerCell {
+            cell.configure(friend: filteredFriends[indexPath.row])
+        }
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        guard indexPath.row < filteredFriends.count else { return }
+        onSelectFriend?(filteredFriends[indexPath.row])
+    }
+}
+
+private final class ShareContactPickerCell: UITableViewCell {
+    static let reuseIdentifier = "ShareContactPickerCell"
+
+    private let avatarView = UIImageView()
+    private let placeholderLabel = UILabel()
+    private let nameLabel = UILabel()
+    private let usernameLabel = UILabel()
+    private var imageTask: URLSessionDataTask?
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        backgroundColor = .clear
+        contentView.backgroundColor = .clear
+        selectedBackgroundView = UIView()
+        selectedBackgroundView?.backgroundColor = UIColor.theme.secondary.withAlphaComponent(0.55)
+
+        avatarView.translatesAutoresizingMaskIntoConstraints = false
+        avatarView.contentMode = .scaleAspectFill
+        avatarView.clipsToBounds = true
+        avatarView.layer.cornerRadius = 22
+        contentView.addSubview(avatarView)
+
+        placeholderLabel.translatesAutoresizingMaskIntoConstraints = false
+        placeholderLabel.font = .systemFont(ofSize: 17, weight: .semibold)
+        placeholderLabel.textColor = .white
+        placeholderLabel.textAlignment = .center
+        avatarView.addSubview(placeholderLabel)
+
+        nameLabel.translatesAutoresizingMaskIntoConstraints = false
+        nameLabel.font = .systemFont(ofSize: 15, weight: .semibold)
+        nameLabel.textColor = UIColor.theme.textStrong
+        nameLabel.numberOfLines = 1
+        contentView.addSubview(nameLabel)
+
+        usernameLabel.translatesAutoresizingMaskIntoConstraints = false
+        usernameLabel.font = .systemFont(ofSize: 13)
+        usernameLabel.textColor = UIColor.theme.textDisabled
+        usernameLabel.numberOfLines = 1
+        contentView.addSubview(usernameLabel)
+
+        let chevron = UIImageView(image: UIImage(systemName: "chevron.right"))
+        chevron.translatesAutoresizingMaskIntoConstraints = false
+        chevron.tintColor = UIColor.theme.textDisabled
+        chevron.contentMode = .scaleAspectFit
+        contentView.addSubview(chevron)
+
+        NSLayoutConstraint.activate([
+            avatarView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            avatarView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            avatarView.widthAnchor.constraint(equalToConstant: 44),
+            avatarView.heightAnchor.constraint(equalToConstant: 44),
+
+            placeholderLabel.leadingAnchor.constraint(equalTo: avatarView.leadingAnchor),
+            placeholderLabel.trailingAnchor.constraint(equalTo: avatarView.trailingAnchor),
+            placeholderLabel.topAnchor.constraint(equalTo: avatarView.topAnchor),
+            placeholderLabel.bottomAnchor.constraint(equalTo: avatarView.bottomAnchor),
+
+            chevron.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -18),
+            chevron.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            chevron.widthAnchor.constraint(equalToConstant: 12),
+            chevron.heightAnchor.constraint(equalToConstant: 16),
+
+            nameLabel.leadingAnchor.constraint(equalTo: avatarView.trailingAnchor, constant: 12),
+            nameLabel.trailingAnchor.constraint(equalTo: chevron.leadingAnchor, constant: -12),
+            nameLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 13),
+
+            usernameLabel.leadingAnchor.constraint(equalTo: nameLabel.leadingAnchor),
+            usernameLabel.trailingAnchor.constraint(equalTo: nameLabel.trailingAnchor),
+            usernameLabel.topAnchor.constraint(equalTo: nameLabel.bottomAnchor, constant: 3),
+        ])
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        imageTask?.cancel()
+        imageTask = nil
+        avatarView.image = nil
+    }
+
+    func configure(friend: Mezon_Api_Friend) {
+        let user = friend.user
+        let display = user.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let username = user.username.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedName = display.isEmpty ? (username.isEmpty ? "\(user.id)" : username) : display
+
+        nameLabel.text = resolvedName
+        usernameLabel.text = username.isEmpty ? "" : "@\(username)"
+        placeholderLabel.text = String((username.isEmpty ? resolvedName : username).prefix(1)).uppercased()
+        avatarView.backgroundColor = UIColor.avatarColor(for: username.isEmpty ? resolvedName : username)
+        placeholderLabel.isHidden = false
+        avatarView.image = nil
+
+        let rawAvatar = user.avatarURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !rawAvatar.isEmpty else { return }
+        let proxied = ImgproxyURL.avatarProxyURL(from: rawAvatar, width: 120, height: 120)
+        if let cached = ImageCache.shared.cachedImage(forURL: proxied) {
+            avatarView.image = cached
+            placeholderLabel.isHidden = true
+            avatarView.backgroundColor = .clear
+            return
+        }
+        imageTask = ImageCache.shared.loadImage(urlString: proxied) { [weak self] image in
+            guard let self, let image else { return }
+            self.avatarView.image = image
+            self.placeholderLabel.isHidden = true
+            self.avatarView.backgroundColor = .clear
         }
     }
 }

--- a/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
+++ b/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
@@ -1114,6 +1114,93 @@ final class SendMessageInputViewController: UIViewController {
         }
     }
 
+    func sendShareContact(friend: Mezon_Api_Friend) {
+        guard !composerSendPermissionBlocked else { return }
+        guard !shouldSendAsAnonymousMessage else { return }
+        if editingDisplay != nil {
+            clearEditingMessage()
+        }
+        guard friend.hasUser, friend.user.id != 0 else { return }
+
+        let user = friend.user
+        let username = user.username.trimmingCharacters(in: .whitespacesAndNewlines)
+        let displayNameRaw = user.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let displayName = displayNameRaw.isEmpty ? username : displayNameRaw
+        let avatar = user.avatarURL.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let contentJSON: [String: Any] = [
+            "t": "",
+            "embed": [[
+                "fields": [
+                    ["name": "key", "value": MezonConstants.shareContactKey, "inline": true],
+                    ["name": "user_id", "value": "\(user.id)", "inline": true],
+                    ["name": "username", "value": username, "inline": true],
+                    ["name": "display_name", "value": displayName, "inline": true],
+                    ["name": "avatar", "value": avatar, "inline": true],
+                ],
+            ]],
+        ]
+        let contentStr: String
+        if let data = try? JSONSerialization.data(withJSONObject: contentJSON),
+           let str = String(data: data, encoding: .utf8) {
+            contentStr = str
+        } else {
+            contentStr = "{}"
+        }
+
+        let mode: Int32 = {
+            switch channel.type {
+            case MezonConstants.ChannelType.thread.rawValue:
+                return MezonConstants.ChannelStreamMode.thread.rawValue
+            case MezonConstants.ChannelType.dm.rawValue:
+                return MezonConstants.ChannelStreamMode.dm.rawValue
+            case MezonConstants.ChannelType.group.rawValue:
+                return MezonConstants.ChannelStreamMode.group.rawValue
+            default:
+                return clanId == 0
+                    ? MezonConstants.ChannelStreamMode.group.rawValue
+                    : MezonConstants.ChannelStreamMode.channel.rawValue
+            }
+        }()
+        let isPublic = channel.channelPrivate == 0
+        let senderAvatar = context.currentUser?.avatarURL?.absoluteString ?? ""
+
+        clearReply()
+        onSent?()
+
+        Task { @MainActor in
+            guard let token = await self.context.getToken() else {
+                self.onError?("No session")
+                return
+            }
+            do {
+                _ = try await self.context.account.network.sendChannelMessage(
+                    clanId: clanId,
+                    channelId: channel.channelID,
+                    mode: mode,
+                    isPublic: isPublic,
+                    content: contentStr,
+                    mentions: [],
+                    attachments: [],
+                    references: [],
+                    anonymous: false,
+                    mentionEveryone: false,
+                    avatar: senderAvatar,
+                    topicId: self.topicId,
+                    code: MezonConstants.MessageCode.shareContact.rawValue,
+                    token: token
+                )
+            } catch {
+                SentryLogger.capture(error, extras: [
+                    "where": "sendShareContact",
+                    "channelId": channel.channelID,
+                    "clanId": clanId,
+                ])
+                self.onError?(error.localizedDescription)
+            }
+        }
+    }
+
     func sendSticker(_ sticker: CachedClanStickerRecord) {
         if editingDisplay != nil {
             clearEditingMessage()
@@ -5027,4 +5114,3 @@ extension SendMessageInputViewController: UIDocumentPickerDelegate {
     func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
     }
 }
-

--- a/project.yml
+++ b/project.yml
@@ -109,6 +109,11 @@ targets:
           /bin/sh "${SRCROOT}/scripts/generate_livekit_webrtc_dsym.sh"
         shell: /bin/sh
         basedOnDependencyAnalysis: false
+      - name: Copy Sentry dSYM
+        script: |
+          /bin/sh "${SRCROOT}/scripts/copy_sentry_dsym.sh"
+        shell: /bin/sh
+        basedOnDependencyAnalysis: false
     settings:
       base:
         ENABLE_USER_SCRIPT_SANDBOXING: NO


### PR DESCRIPTION
Ticket: https://github.com/mezonai/mezon/issues/13104
## 1. Task Description

- Added Share Contact support on iOS.
- Added the Share Contact action to the advanced function panel.
- Added a friend picker screen for sharing contacts, with search, header, and back button.
- Sent Share Contact messages with a React Native-compatible payload:
  - `key = share_contact`
  - `user_id`
  - `username`
  - `display_name`
  - `avatar`
  - `message code = 16`
- Added Share Contact message rendering in chat:
  - Detects by `message code == 16` or embed field `share_contact`.
  - Renders a contact card instead of the raw embed.
  - Card includes avatar, display name, username, Call button, and Message button.
  - Supports opening the contact profile, opening a direct message, and calling the contact.
- Wrapped contact avatars with image proxy and kept placeholder fallback while the image is loading or fails.
- Adjusted the card UI to better match React Native: avatar + info layout, action row, divider, spacing, and width.

## 2. Self-test

- [x] Opened the advanced function panel and verified the Share Contact action is shown.
- [x] Tapped Share Contact and verified the app does not crash.
- [x] Verified the contact picker has a header, title, and back button.
- [x] Verified friend search works.
- [x] Selected a friend and verified the Share Contact message is sent.
- [x] Verified Share Contact messages render as contact cards instead of raw embeds.
- [x] Verified contact avatars are loaded through `ImgproxyURL.avatarProxyURL`.
- [x] Verified avatar placeholder fallback is shown when the avatar is empty or fails to load.
- [x] Tapped the card and verified it opens the contact profile.
- [x] Tapped Message and verified it opens or creates a direct message.
- [x] Tapped Call and verified it opens or creates a direct message and starts a call.