### PR TITLE
260522-IOS-Sync UI avatar text

### DIFF
--- a/MezonChat/Core/UI/TextAvatarView.swift
+++ b/MezonChat/Core/UI/TextAvatarView.swift
@@ -56,7 +56,7 @@ final class TextAvatarView: UIView {
         stopSkeletonShimmer()
         currentUsername = username
         let trimmed = username.trimmingCharacters(in: .whitespacesAndNewlines)
-        let initial = trimmed.first.map { String($0).uppercased() } ?? "?"
+        let initial = trimmed.first.map { String($0).uppercased() } ?? ""
         let resolvedFontSize = fontSize ?? (currentSize * 0.4)
 
         backgroundColor = UIColor.avatarColor(for: username)
@@ -136,7 +136,7 @@ final class TextAvatarNode: ASDisplayNode {
         stopSkeletonShimmer()
         currentUsername = username
         let trimmed = username.trimmingCharacters(in: .whitespacesAndNewlines)
-        let initial = trimmed.first.map { String($0).uppercased() } ?? "?"
+        let initial = trimmed.first.map { String($0).uppercased() } ?? ""
         let resolvedFontSize = fontSize ?? (avatarSize * 0.4)
 
         backgroundColor = UIColor.avatarColor(for: username)

--- a/MezonChat/Core/Utils/MezonConstants.swift
+++ b/MezonChat/Core/Utils/MezonConstants.swift
@@ -2,6 +2,8 @@ import Foundation
 
 enum MezonConstants {
 
+    static let anonymousUserId: Int64 = 1767478432163172999
+
     static let waveStickerFilename = "hello"
     static let waveStickerAttachmentSize: Int32 = 374_892
     static let waveStickerWidth: Int32 = 150

--- a/MezonChat/Features/ChannelDetail/Tabs/MemberListNode.swift
+++ b/MezonChat/Features/ChannelDetail/Tabs/MemberListNode.swift
@@ -343,7 +343,7 @@ fileprivate func memberListResolvedAvatarURL(_ raw: String) -> String {
 
 fileprivate func memberListAvatarInitial(from name: String) -> String {
     let t = name.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !t.isEmpty else { return "?" }
+    guard !t.isEmpty else { return "" }
     for ch in t {
         if ch.isLetter || ch.isNumber {
             return String(ch).uppercased(with: Locale.current)

--- a/MezonChat/Features/Chat/Cells/MessageClanInviteLinkNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageClanInviteLinkNode.swift
@@ -146,7 +146,7 @@ final class MessageClanInviteLinkNode: ASDisplayNode {
         let t = UIColor.theme
         let clanName = (info.clan_name?.isEmpty == false) ? (info.clan_name ?? "") : "Clan"
         let initialSource = clanName.trimmingCharacters(in: .whitespacesAndNewlines)
-        let initial = initialSource.isEmpty ? "?" : String(initialSource.prefix(1)).uppercased()
+        let initial = initialSource.isEmpty ? "" : String(initialSource.prefix(1)).uppercased()
         avatarPlaceholderNode.attributedText = NSAttributedString(
             string: initial,
             attributes: [

--- a/MezonChat/Features/Chat/Cells/MessageReplyNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageReplyNode.swift
@@ -79,7 +79,35 @@ final class MessageReplyNode: ASDisplayNode {
             ]
         )
 
-        if !ref.messageSenderAvatar.isEmpty, let url = URL(string: ref.messageSenderAvatar) {
+        let isAnonymous = ref.messageSenderID == MezonConstants.anonymousUserId
+
+        if isAnonymous {
+            hasAvatar = true
+            avatarPlaceholderNode.isHidden = true
+            avatarImageNode.isHidden = false
+            avatarImageNode.url = nil
+            avatarImageNode.backgroundColor = UIColor.theme.tertiary
+            
+            if let raw = UIImage(named: "Chat/AnonymousIcon") {
+                let size = CGSize(width: avatarSz, height: avatarSz)
+                let format = UIGraphicsImageRendererFormat()
+                format.scale = UIScreen.main.scale
+                format.opaque = false
+                let img = UIGraphicsImageRenderer(size: size, format: format).image { _ in
+                    let tinted = raw.withRenderingMode(.alwaysTemplate).withTintColor(UIColor.theme.textStrong, renderingMode: .alwaysOriginal)
+                    let iconSz = CGSize(width: 14, height: 14)
+                    let origin = CGPoint(x: (size.width - iconSz.width) / 2, y: (size.height - iconSz.height) / 2)
+                    tinted.draw(in: CGRect(origin: origin, size: iconSz))
+                }
+                avatarImageNode.image = img
+            } else {
+                avatarImageNode.image = nil
+            }
+            
+            avatarContainerNode.removeFromSupernode()
+            avatarPlaceholderNode.removeFromSupernode()
+            if avatarImageNode.supernode == nil { addSubnode(avatarImageNode) }
+        } else if !ref.messageSenderAvatar.isEmpty, let url = URL(string: ref.messageSenderAvatar) {
             hasAvatar = true
             avatarPlaceholderNode.isHidden = true
             avatarImageNode.isHidden = false
@@ -92,14 +120,18 @@ final class MessageReplyNode: ASDisplayNode {
             hasAvatar = false
             avatarImageNode.isHidden = true
             avatarPlaceholderNode.isHidden = false
+            
+            let charSource = ref.messageSenderUsername
+            let charStr = String(charSource.prefix(1)).uppercased()
+            
             avatarPlaceholderNode.attributedText = NSAttributedString(
-                string: String(ref.messageSenderUsername.prefix(1)).uppercased(),
+                string: charStr,
                 attributes: [
-                    .font: UIFont.systemFont(ofSize: 8.sf, weight: .semibold),
+                    .font: UIFont.systemFont(ofSize: 10.sf, weight: .semibold),
                     .foregroundColor: UIColor.white
                 ]
             )
-            avatarContainerNode.backgroundColor = UIColor.avatarColor(for: ref.messageSenderUsername)
+            avatarContainerNode.backgroundColor = UIColor.avatarColor(for: charSource)
             avatarImageNode.removeFromSupernode()
             if avatarContainerNode.supernode == nil {
                 addSubnode(avatarContainerNode)

--- a/MezonChat/Features/Chat/Cells/WelcomeCellNode.swift
+++ b/MezonChat/Features/Chat/Cells/WelcomeCellNode.swift
@@ -79,7 +79,7 @@ final class WelcomeCellNode: ASDisplayNode {
                 username: dmPeerUsername,
                 priorityName: priorityName,
                 avatarURL: dmAvatarURL.trimmingCharacters(in: .whitespacesAndNewlines),
-                placeholderLetter: letter.isEmpty ? "?" : letter
+                placeholderLetter: letter.isEmpty ? "" : letter
             )
             showsUsernameRow = !dmPeerUsername.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         } else {

--- a/MezonChat/Features/Chat/ChatViewController.swift
+++ b/MezonChat/Features/Chat/ChatViewController.swift
@@ -171,8 +171,7 @@ struct ChatMessageDisplay: Identifiable {
     var isLocation: Bool { locationData != nil }
 
     var isAnonymousSender: Bool {
-        senderDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
-            .caseInsensitiveCompare("Anonymous") == .orderedSame
+        message.senderId == "\(MezonConstants.anonymousUserId)"
     }
 
     var isSystemMessage: Bool {
@@ -3926,6 +3925,38 @@ final class ChatViewController: ViewController {
         } else if let allUsers = context.engine.clanData.getAllUserClans(),
                   let found = allUsers.users.first(where: { $0.id == userIdInt }) {
             user = found
+        }
+
+        let profile = context.account.postbox.read { $0.getProfile(userId: userId) }
+
+        if user.avatarURL.isEmpty, let av = profile?.avatarUrl, !av.isEmpty {
+            user.avatarURL = av
+        }
+        if user.username.isEmpty, let un = profile?.username, !un.isEmpty {
+            user.username = un
+        }
+        if user.displayName.isEmpty, let dn = profile?.displayName, !dn.isEmpty {
+            user.displayName = dn
+        }
+
+        if user.username.isEmpty || user.displayName.isEmpty {
+            let channelMembers = context.account.postbox.read { tx in
+                tx.getChannelMeta(channelId: channel.channelID)?.members ?? []
+            }
+            if let member = channelMembers.first(where: { $0.userId == userIdInt }) {
+                if user.username.isEmpty, !member.username.isEmpty {
+                    user.username = member.username
+                }
+                if user.displayName.isEmpty {
+                    let memberName = !member.clanNick.isEmpty ? member.clanNick : member.displayName
+                    if !memberName.isEmpty {
+                        user.displayName = memberName
+                    }
+                }
+                if user.avatarURL.isEmpty, !member.clanAvatar.isEmpty {
+                    user.avatarURL = member.clanAvatar
+                }
+            }
         }
 
         view.endEditing(true)

--- a/MezonChat/Features/Clans/ClanInviteSheetViewController.swift
+++ b/MezonChat/Features/Clans/ClanInviteSheetViewController.swift
@@ -294,7 +294,7 @@ private final class ClanInviteFriendCellNode: ASCellNode {
         groupIconNode.tintColor = .white
         groupIconNode.contentMode = .scaleAspectFit
 
-        let initial = name.trimmingCharacters(in: .whitespacesAndNewlines).first.map { String($0).uppercased() } ?? "?"
+        let initial = name.trimmingCharacters(in: .whitespacesAndNewlines).first.map { String($0).uppercased() } ?? ""
 
         switch avatarMode {
         case .image:

--- a/MezonChat/Features/Components/MemberProfileSheetController.swift
+++ b/MezonChat/Features/Components/MemberProfileSheetController.swift
@@ -339,10 +339,18 @@ final class MemberProfileSheetController: ViewController {
             }
 
             do {
-                let channel = try await context.account.network.createDirectMessage(
+                var channel = try await context.account.network.createDirectMessage(
                     userId: targetUserId,
                     token: token
                 )
+                if channel.usernames.isEmpty {
+                    channel.usernames = [user.username]
+                    channel.displayNames = [user.displayName]
+                    channel.avatars = [user.avatarURL]
+                    if channel.userIds.isEmpty {
+                        channel.userIds = [user.id]
+                    }
+                }
                 animateDismiss()
                 onSendMessage?(channel)
             } catch {

--- a/MezonChat/Features/DirectMessages/FriendListContainerNode.swift
+++ b/MezonChat/Features/DirectMessages/FriendListContainerNode.swift
@@ -561,7 +561,7 @@ final class FriendListItemNode: ASCellNode, ASNetworkImageNodeDelegate {
 
         let name = user.displayName.isEmpty ? user.username : user.displayName
         let initialChar = user.username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            ? "?"
+            ? ""
             : String(user.username.trimmingCharacters(in: .whitespacesAndNewlines).prefix(1)).uppercased()
         avatarPlaceholderNode.attributedText = NSAttributedString(
             string: initialChar,

--- a/MezonChat/Features/Profile/ClanPickerSheetViewController.swift
+++ b/MezonChat/Features/Profile/ClanPickerSheetViewController.swift
@@ -212,7 +212,7 @@ private final class ClanPickerCell: UITableViewCell {
         applyCellTheme()
         boundClanId = clan.clanID
         nameLabel.text = clan.clanName
-        let initial = clan.clanName.trimmingCharacters(in: .whitespacesAndNewlines).first.map { String($0).uppercased() } ?? "?"
+        let initial = clan.clanName.trimmingCharacters(in: .whitespacesAndNewlines).first.map { String($0).uppercased() } ?? ""
         initialLabel.text = initial
         checkView.isHidden = !selected
         avatarView.image = nil

--- a/MezonChat/Features/Profile/ProfileContainerNode.swift
+++ b/MezonChat/Features/Profile/ProfileContainerNode.swift
@@ -192,7 +192,7 @@ final class ProfileContainerNode: ASDisplayNode {
         }.withRenderingMode(.alwaysOriginal)
     }
 
-    private static func profileAvatarInitials(displayName: String?, username: String?) -> String {
+    private static func profileAvatarInitials(username: String?) -> String {
         let u = username?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return u.first.map { String($0).uppercased() } ?? ""
     }
@@ -603,7 +603,7 @@ final class ProfileContainerNode: ASDisplayNode {
 
     private func applyProfileAvatarPlaceholder() {
         let u = context.currentUser
-        avatarPlaceholderLabel.text = Self.profileAvatarInitials(displayName: u?.displayName, username: u?.username)
+        avatarPlaceholderLabel.text = Self.profileAvatarInitials(username: u?.username)
         avatarImageView.image = nil
         avatarPlaceholderLabel.isHidden = false
         avatarContainerView.backgroundColor = UIColor.avatarColor(for: u?.username ?? "")
@@ -622,7 +622,7 @@ final class ProfileContainerNode: ASDisplayNode {
     func updateContent() {
         let user = context.currentUser
 
-        let initials = Self.profileAvatarInitials(displayName: user?.displayName, username: user?.username)
+        let initials = Self.profileAvatarInitials(username: user?.username)
         avatarPlaceholderLabel.text = initials
 
         if let url = user?.avatarURL, !url.absoluteString.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -740,22 +740,14 @@ final class ProfileContainerNode: ASDisplayNode {
 
     private func applyFriendAvatarsFromFriendsData() {
         let list = context.engine.friendsData.allFriends()
-        let previews: [(avatarURL: String?, displayName: String, username: String)] = Array(
+        let previews: [(avatarURL: String?, username: String)] = Array(
             list
                 .filter { $0.state == EStateFriend.friend.rawValue && $0.hasUser }
                 .prefix(5)
-                .map { f -> (avatarURL: String?, displayName: String, username: String) in
+                .map { f -> (avatarURL: String?, username: String) in
                     let u = f.user
                     let url = u.avatarURL.isEmpty ? nil : u.avatarURL
-                    let name: String
-                    if !u.username.isEmpty {
-                        name = u.username
-                    } else if !u.displayName.isEmpty {
-                        name = u.displayName
-                    } else {
-                        name = ""
-                    }
-                    return (avatarURL: url, displayName: name, username: u.username)
+                    return (avatarURL: url, username: u.username)
                 }
         )
         setupFriendAvatars(previews: previews)
@@ -819,14 +811,13 @@ final class ProfileContainerNode: ASDisplayNode {
         return formatter.string(from: date)
     }
 
-    private func setupFriendAvatars(previews: [(avatarURL: String?, displayName: String, username: String)]) {
+    private func setupFriendAvatars(previews: [(avatarURL: String?, username: String)]) {
         friendsAvatarStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
 
         let avatarSmall: CGFloat = 28.swh
         for item in previews {
             let view = friendAvatarView(
                 avatarURL: item.avatarURL,
-                displayName: item.displayName,
                 username: item.username,
                 size: avatarSmall
             )
@@ -836,7 +827,6 @@ final class ProfileContainerNode: ASDisplayNode {
 
     private func friendAvatarView(
         avatarURL: String?,
-        displayName: String,
         username: String,
         size: CGFloat
     ) -> UIView {

--- a/MezonChat/Features/Profile/ProfileContainerNode.swift
+++ b/MezonChat/Features/Profile/ProfileContainerNode.swift
@@ -193,11 +193,8 @@ final class ProfileContainerNode: ASDisplayNode {
     }
 
     private static func profileAvatarInitials(displayName: String?, username: String?) -> String {
-        let d = displayName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let u = username?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        let base = !d.isEmpty ? d : u
-        if base.isEmpty { return "?" }
-        return base.first.map { String($0).uppercased() } ?? "?"
+        return u.first.map { String($0).uppercased() } ?? ""
     }
 
     private static func statusBadgeAssetName(for status: User.OnlineStatus) -> String {
@@ -756,7 +753,7 @@ final class ProfileContainerNode: ASDisplayNode {
                     } else if !u.displayName.isEmpty {
                         name = u.displayName
                     } else {
-                        name = "?"
+                        name = ""
                     }
                     return (avatarURL: url, displayName: name, username: u.username)
                 }

--- a/MezonChat/Features/Profile/ProfileSettingViewController.swift
+++ b/MezonChat/Features/Profile/ProfileSettingViewController.swift
@@ -990,7 +990,7 @@ final class ProfileSettingViewController: BaseViewController {
 
     private func avatarInitialText() -> String {
         let trimmed = userName.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.first.map { String($0).uppercased() } ?? "?"
+        return trimmed.first.map { String($0).uppercased() } ?? ""
     }
 
     private func showAvatarPlaceholder() {

--- a/MezonChat/Features/Search/SearchViewController.swift
+++ b/MezonChat/Features/Search/SearchViewController.swift
@@ -693,7 +693,10 @@ final class SearchViewController: ViewController {
     }
 
     private func effectiveClanId(for channel: Mezon_Api_ChannelDescription) -> Int64 {
-        channel.clanID != 0 ? channel.clanID : clanId
+        if channel.type == MezonConstants.ChannelType.dm.rawValue || channel.type == MezonConstants.ChannelType.group.rawValue {
+            return 0
+        }
+        return channel.clanID != 0 ? channel.clanID : clanId
     }
 
     private func encodeChannelIdPreference(_ id: Int64) -> Data {

--- a/MezonChat/Features/Search/SearchViewController.swift
+++ b/MezonChat/Features/Search/SearchViewController.swift
@@ -1538,7 +1538,7 @@ final class MemberSearchCellNode: ASCellNode {
         }
 
         let initialSource = user.username.trimmingCharacters(in: .whitespacesAndNewlines)
-        let initialChar = initialSource.isEmpty ? "?" : String(initialSource.prefix(1)).uppercased()
+        let initialChar = initialSource.isEmpty ? "" : String(initialSource.prefix(1)).uppercased()
         let side = Self.avatarSize
         let para = NSMutableParagraphStyle()
         para.alignment = .center

--- a/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
+++ b/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
@@ -4643,7 +4643,7 @@ final class SendMessageInputViewController: UIViewController {
         ref.messageRefID = Int64(display.message.id) ?? 0
         ref.refType = 0
         ref.messageSenderID = Int64(display.message.senderId) ?? 0
-        ref.messageSenderUsername = display.senderDisplayName
+        ref.messageSenderUsername = display.senderUsername
         ref.messageSenderDisplayName = display.senderDisplayName
         ref.messageSenderAvatar = display.avatarURL ?? ""
         ref.hasAttachment_p = !display.attachments.isEmpty


### PR DESCRIPTION
issue: https://github.com/mezonai/mezon-ios/issues/152
root cause: 
Incorrect Anonymous Check Logic: The system on iOS was relying on comparing senderDisplayName or username with the string "Anonymous" to identify anonymous messages. This led to a bug: if a normal user changed their name to "Anonymous", the system would incorrectly flag them. (The legacy React Native codebase correctly used NX_CHAT_APP_ANNONYMOUS_USER_ID for exact identification).
Text Avatar Discrepancies: The default avatar rendering logic (text avatar) for Reply Nodes confused senderDisplayName with senderUsername, causing the first character displayed on the avatar to mismatch the original username.
Incorrect Reply Data Storage: In the reply data builder (SendMessageInputViewController), the system mistakenly saved the displayName into the messageSenderUsername property, causing the backend to store incorrect data for future messages.

solution: 
Define Standard Constant: Declared the constant MezonConstants.anonymousUserId = 1767478432163172999 (equivalent to the .env variable ID in the React Native version).
Update Anonymous Check Logic: Updated the isAnonymousSender variable in ChatViewController and isAnonymous in MessageReplyNode to check directly against senderId == "\(MezonConstants.anonymousUserId)" and ref.messageSenderID == MezonConstants.anonymousUserId. Completely eliminated the string case-insensitive comparison method.
Sync Username Data: Fixed the buildReplyRef function in SendMessageInputViewController to strictly assign display.senderUsername to ref.messageSenderUsername. This ensures the quoted data stores the correct user ID.

TC:
1	Standard Message Send	The sender's avatar displays their actual uploaded image. If none is uploaded, it displays the Avatar Text using the first letter of their username.
2	Standard Message Reply	The quoted container (Reply node) displays a small avatar matching the original message author's avatar, WITHOUT mistakenly using the first letter of their displayName.
3	Anonymous Message Send	Enable Anonymous mode on the keyboard -> Send a message. The message must display the Anonymous Icon Avatar (with a tertiary background color) and the name "Anonymous".
4	Anonymous Message Reply	Another user selects Reply on the anonymous message above -> The small quote box must accurately display the miniaturized Anonymous Icon Avatar (14x14 size) with the correct theme color fill.
5	"Anonymous" Impersonator Message	Create an account with the username or change the displayName to "Anonymous" -> Send a normal message (Anonymous mode disabled) -> The avatar must display the letter "A" or the user's real image, it MUST NOT turn into the anonymous icon.
6	Reply to "Anonymous" Impersonator	Reply to the user's message from Case 5 -> The small quote box displays their normal avatar, verifying that the anonymous ID logic works correctly instead of string matching.
7	Post-fix Text Avatar Check	A user with username = "hoang_minh", displayName = "David" -> Sends a message and receives a reply -> The character in the Text Avatar (circle border) must be the letter "H" (first letter of username), not "D".
8	Dark / Light Mode Toggle	Scroll to an anonymous message, reply to an anonymous message, then toggle Dark Mode / Light Mode -> The Magnifying Glass / Anonymous icon automatically switches to the appropriate contrasting tint color (using textStrong).
9	Icon Scale UI Render Test	Open the chat channel screen: Observe the large anonymous avatar (40x40) of the original Bubble and the small anonymous avatar (18x18) of the Reply box. Ensure both are sharp, perfectly centered, and not distorted.
10	Payload Data Sync	Swipe right on any message to reply. Enter text -> Hit Send. Open Charles Proxy or Network Logger to inspect the WebSocket payload -> The references -> messageSenderUsername sent matches exactly 100% with the quoted user's username.
