### PR TITLE
fix: loadmore media in channel detail and add/remove members in group DM

### DIFF
--- a/MezonChat/Application/AppDelegate.swift
+++ b/MezonChat/Application/AppDelegate.swift
@@ -349,36 +349,130 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         return s.isEmpty ? nil : s
     }
 
-    private static func pushPayloadString(_ userInfo: [AnyHashable: Any], keys: [String]) -> String? {
-        let dataDict = userInfo["data"] as? [String: Any]
-        for key in keys {
-            if let v = stringFromPushValue(userInfo[key]) { return v }
-            if let dataDict, let v = stringFromPushValue(dataDict[key]) { return v }
+    private static func payloadDictionary(_ value: Any?) -> [AnyHashable: Any]? {
+        if let dict = value as? [AnyHashable: Any] {
+            return dict
+        }
+        if let dict = value as? [String: Any] {
+            var result: [AnyHashable: Any] = [:]
+            dict.forEach { result[$0.key] = $0.value }
+            return result
+        }
+        if let raw = value as? String,
+           let data = raw.data(using: .utf8),
+           let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            var result: [AnyHashable: Any] = [:]
+            dict.forEach { result[$0.key] = $0.value }
+            return result
         }
         return nil
     }
 
-    private static func parseFCMPayload(_ userInfo: [AnyHashable: Any]) -> (channelId: String?, clanId: String?, isDM: Bool) {
-        let channelId = pushPayloadString(userInfo, keys: [
-            "channel", "channel_id", "channelId", "channelID",
-            "message_channel_id", "messageChannelId", "target_channel_id", "targetChannelId",
-        ])
+    private static func pushPayloadDictionaries(_ userInfo: [AnyHashable: Any]) -> [[AnyHashable: Any]] {
+        var dictionaries: [[AnyHashable: Any]] = [userInfo]
+        for key in ["data", "payload", "notification"] {
+            if let nested = payloadDictionary(userInfo[key]) {
+                dictionaries.append(nested)
+            }
+        }
+        return dictionaries
+    }
 
+    private static func pushPayloadString(_ userInfo: [AnyHashable: Any], keys: [String]) -> String? {
+        let dictionaries = pushPayloadDictionaries(userInfo)
+        for key in keys {
+            for dict in dictionaries {
+                if let v = stringFromPushValue(dict[key]) { return v }
+            }
+        }
+        return nil
+    }
+
+    private static func pushPayloadInt64(_ userInfo: [AnyHashable: Any], keys: [String]) -> Int64? {
+        guard let raw = pushPayloadString(userInfo, keys: keys)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !raw.isEmpty else { return nil }
+        return Int64(raw)
+    }
+
+    private static func pushPayloadBool(_ userInfo: [AnyHashable: Any], keys: [String]) -> Bool? {
+        guard let raw = pushPayloadString(userInfo, keys: keys)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased(),
+              !raw.isEmpty else { return nil }
+        if ["1", "true", "yes", "y", "dm", "direct"].contains(raw) { return true }
+        if ["0", "false", "no", "n"].contains(raw) { return false }
+        return nil
+    }
+
+    private static func parseFCMLink(_ link: String) -> (channelId: String?, clanId: String?, isDM: Bool) {
+        let lowered = link.lowercased()
+        var channelId: String?
         var clanId: String?
-        var isDM = false
+        var isDM = lowered.contains("direct") || lowered.contains("/dm")
 
-        if let link = pushPayloadString(userInfo, keys: ["link"]) {
-            isDM = link.lowercased().contains("direct")
-            if let url = URL(string: link) {
-                let parts = url.pathComponents
-                if let i = parts.firstIndex(of: "clans"), i + 1 < parts.count {
-                    clanId = parts[i + 1]
+        if let url = URL(string: link) {
+            let parts = url.pathComponents.filter { $0 != "/" }
+            if let i = parts.firstIndex(of: "clans"), i + 1 < parts.count {
+                clanId = parts[i + 1]
+            }
+            for segment in ["channels", "channel", "direct", "dm", "c"] {
+                if let i = parts.firstIndex(of: segment), i + 1 < parts.count, channelId == nil {
+                    channelId = parts[i + 1]
+                    if segment == "direct" || segment == "dm" {
+                        isDM = true
+                    }
+                }
+            }
+            if let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems {
+                for item in queryItems {
+                    let name = item.name.lowercased()
+                    guard let value = item.value, Int64(value) != nil else { continue }
+                    if channelId == nil, name.contains("channel") || name == "cid" || name == "c" {
+                        channelId = value
+                    }
+                    if clanId == nil, name.contains("clan") || name.contains("guild") {
+                        clanId = value
+                    }
+                    if name == "direct" || name == "dm" || name == "isdm" || name == "is_dm" {
+                        isDM = value == "1" || value.lowercased() == "true"
+                    }
                 }
             }
         }
 
-        if clanId == nil {
-            clanId = pushPayloadString(userInfo, keys: ["clan_id", "clanId", "clan", "guild_id", "guildId"])
+        if let clanId, Int64(clanId) == 0 {
+            isDM = true
+        }
+        return (channelId, clanId, isDM)
+    }
+
+    private static func parseFCMPayload(_ userInfo: [AnyHashable: Any]) -> (channelId: String?, clanId: String?, isDM: Bool) {
+        var channelId = pushPayloadString(userInfo, keys: [
+            "channel", "channel_id", "channelId", "channelID",
+            "message_channel_id", "messageChannelId", "target_channel_id", "targetChannelId",
+        ])
+
+        var clanId = pushPayloadString(userInfo, keys: ["clan_id", "clanId", "clanID", "clan", "guild_id", "guildId"])
+        var isDM = pushPayloadBool(userInfo, keys: ["is_dm", "isDM", "is_direct", "isDirect", "direct", "dm"]) ?? false
+
+        if let link = pushPayloadString(userInfo, keys: ["link"]) {
+            let routed = parseFCMLink(link)
+            if channelId == nil { channelId = routed.channelId }
+            if clanId == nil { clanId = routed.clanId }
+            isDM = isDM || routed.isDM
+        }
+
+        let channelType = pushPayloadInt64(userInfo, keys: ["channel_type", "channelType", "channelTypeRaw", "type"])
+        let streamMode = pushPayloadInt64(userInfo, keys: ["mode", "stream_mode", "streamMode"])
+        let clanIdValue = clanId.flatMap { Int64($0) }
+        if channelType == Int64(MezonConstants.ChannelType.dm.rawValue)
+            || streamMode == Int64(MezonConstants.ChannelStreamMode.dm.rawValue) {
+            isDM = true
+        }
+        if channelType == Int64(MezonConstants.ChannelType.group.rawValue),
+           clanIdValue == nil || clanIdValue == 0 {
+            isDM = true
         }
 
         if let c = clanId, let v = Int64(c), v == 0 {

--- a/MezonChat/Core/Extensions/UIColor+Theme.swift
+++ b/MezonChat/Core/Extensions/UIColor+Theme.swift
@@ -45,6 +45,7 @@ extension UIColor {
 
     static var mezonUnreadBadge:         UIColor { UIColor(hex: 0xC61E1B) }
     static var mezonMention:             UIColor { theme.textWarning.withAlphaComponent(0.3) }
+    static var groupDMDefaultAvatar:     UIColor { UIColor(red: 249/255, green: 115/255, blue: 22/255, alpha: 1) }
 
     static var loginGradientColors:      [UIColor] { theme.loginGradientColors }
     static var loginInputBg:             UIColor { theme.loginInputBg }

--- a/MezonChat/Core/Localization/L10n.swift
+++ b/MezonChat/Core/Localization/L10n.swift
@@ -655,6 +655,7 @@ enum L10n {
     enum MuteDuration {
         static let title              = "muteDuration.title"
         static let titleThread        = "muteDuration.titleThread"
+        static let titleConversation  = "muteDuration.titleConversation"
         static let for15Minutes       = "muteDuration.for15Minutes"
         static let for1Hour           = "muteDuration.for1Hour"
         static let for3Hours          = "muteDuration.for3Hours"
@@ -855,6 +856,12 @@ enum L10n {
         static let groupDeleted = "channelDetail.groupDeleted"
         static let updateGroupFailed = "channelDetail.updateGroupFailed"
         static let leaveGroupFailed = "channelDetail.leaveGroupFailed"
+        static let removeFromGroup = "channelDetail.removeFromGroup"
+        static let removeFromGroupConfirmTitle = "channelDetail.removeFromGroupConfirmTitle"
+        static let removeFromGroupConfirmBody = "channelDetail.removeFromGroupConfirmBody"
+        static let removeFromGroupConfirmAction = "channelDetail.removeFromGroupConfirmAction"
+        static let removeFromGroupFailed = "channelDetail.removeFromGroupFailed"
+        static let memberRemoved = "channelDetail.memberRemoved"
     }
 
     enum FriendRequest {
@@ -1441,6 +1448,7 @@ extension L10n {
         "emojiPicker.title":                   "Emojis",
         "muteDuration.title":              "Mute this channel",
         "muteDuration.titleThread":        "Mute this thread",
+        "muteDuration.titleConversation":  "Mute this conversation",
         "muteDuration.for15Minutes":       "For 15 minutes",
         "muteDuration.for1Hour":           "For 1 hour",
         "muteDuration.for3Hours":          "For 3 hours",
@@ -1803,6 +1811,12 @@ extension L10n {
         "channelDetail.groupDeleted": "Group deleted",
         "channelDetail.updateGroupFailed": "Could not update group.",
         "channelDetail.leaveGroupFailed": "Could not leave group.",
+        "channelDetail.removeFromGroup": "Remove From Group",
+        "channelDetail.removeFromGroupConfirmTitle": "Remove from group?",
+        "channelDetail.removeFromGroupConfirmBody": "%@ will be removed from this group.",
+        "channelDetail.removeFromGroupConfirmAction": "Remove",
+        "channelDetail.removeFromGroupFailed": "Could not remove member.",
+        "channelDetail.memberRemoved": "Member removed",
 
         "embed.onlyVisibleToRecipient": "Only visible to recipient",
 
@@ -2307,6 +2321,7 @@ extension L10n {
         "emojiPicker.title":                   "Cảm xúc",
         "muteDuration.title":              "Tắt thông báo kênh này",
         "muteDuration.titleThread":        "Tắt thông báo chủ đề này",
+        "muteDuration.titleConversation":  "Tắt thông báo cuộc trò chuyện này",
         "muteDuration.for15Minutes":       "Trong 15 phút",
         "muteDuration.for1Hour":           "Trong 1 giờ",
         "muteDuration.for3Hours":          "Trong 3 giờ",
@@ -2670,6 +2685,12 @@ extension L10n {
         "channelDetail.groupDeleted": "Đã xóa nhóm",
         "channelDetail.updateGroupFailed": "Không thể cập nhật nhóm.",
         "channelDetail.leaveGroupFailed": "Không thể rời nhóm.",
+        "channelDetail.removeFromGroup": "Xóa khỏi nhóm",
+        "channelDetail.removeFromGroupConfirmTitle": "Xóa khỏi nhóm?",
+        "channelDetail.removeFromGroupConfirmBody": "%@ sẽ bị xóa khỏi nhóm này.",
+        "channelDetail.removeFromGroupConfirmAction": "Xóa",
+        "channelDetail.removeFromGroupFailed": "Không thể xóa thành viên.",
+        "channelDetail.memberRemoved": "Đã xóa thành viên",
 
         "embed.onlyVisibleToRecipient": "Chỉ người nhận mới thấy được",
 

--- a/MezonChat/Core/MezonEngine/MezonEngine+ClanData.swift
+++ b/MezonChat/Core/MezonEngine/MezonEngine+ClanData.swift
@@ -700,7 +700,8 @@ extension MezonEngine {
 
                 guard let count = readUInt32() else { return [] }
                 var result: [Mezon_Api_Friend] = []
-                result.reserveCapacity(Int(count))
+                let maxPossibleEntries = (rawPtr.count - offset) / 4
+                result.reserveCapacity(min(Int(count), maxPossibleEntries))
                 for _ in 0..<count {
                     guard let len = readUInt32() else { break }
                     let intLen = Int(len)

--- a/MezonChat/Core/UI/MediaLoadingSignals.swift
+++ b/MezonChat/Core/UI/MediaLoadingSignals.swift
@@ -15,8 +15,9 @@ final class ImageCache {
 
     private let memoryCache: NSCache<NSString, UIImage> = {
         let c = NSCache<NSString, UIImage>()
-        c.countLimit = 200
-        c.totalCostLimit = 400 * 1024 * 1024
+        c.countLimit = 150
+        let physical = ProcessInfo.processInfo.physicalMemory
+        c.totalCostLimit = Int(min(physical / 10, 120 * 1024 * 1024))
         return c
     }()
 
@@ -38,6 +39,30 @@ final class ImageCache {
 
     private var inflightCallbacks: [String: [(UIImage?) -> Void]] = [:]
     private let inflightLock = NSLock()
+
+    init() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleMemoryWarning),
+            name: UIApplication.didReceiveMemoryWarningNotification,
+            object: nil
+        )
+    }
+
+    @objc private func handleMemoryWarning() {
+        memoryCache.removeAllObjects()
+    }
+
+    private func memoryCost(of image: UIImage) -> Int {
+        let frameCount = max(image.images?.count ?? 1, 1)
+        if let cg = image.cgImage {
+            return cg.bytesPerRow * cg.height * frameCount
+        }
+        let scale = image.scale
+        let pixels = Int(image.size.width * scale) * Int(image.size.height * scale)
+        return pixels * 4 * frameCount
+    }
+
     func memoryImage(forKey key: String) -> UIImage? {
         return memoryCache.object(forKey: key as NSString)
     }
@@ -53,7 +78,7 @@ final class ImageCache {
         guard let data = try? Data(contentsOf: fileURL),
               let image = UIImage.decompressedImage(from: data) else { return nil }
 
-        memoryCache.setObject(image, forKey: nsKey, cost: data.count)
+        memoryCache.setObject(image, forKey: nsKey, cost: memoryCost(of: image))
         return image
     }
 
@@ -66,7 +91,7 @@ final class ImageCache {
                 DispatchQueue.main.async { completion(nil) }
                 return
             }
-            self.memoryCache.setObject(image, forKey: key as NSString, cost: data.count)
+            self.memoryCache.setObject(image, forKey: key as NSString, cost: self.memoryCost(of: image))
             DispatchQueue.main.async { completion(image) }
         }
     }
@@ -78,8 +103,7 @@ final class ImageCache {
 
     func setImage(_ image: UIImage, data: Data?, forKey key: String) {
         let nsKey = key as NSString
-        let cost = data?.count ?? 0
-        memoryCache.setObject(image, forKey: nsKey, cost: cost)
+        memoryCache.setObject(image, forKey: nsKey, cost: memoryCost(of: image))
 
         if let data {
             let fileURL = diskCacheURL.appendingPathComponent(key.sha256Hash)

--- a/MezonChat/Features/ChannelDetail/ChannelDetailContainerNode.swift
+++ b/MezonChat/Features/ChannelDetail/ChannelDetailContainerNode.swift
@@ -23,6 +23,7 @@ final class ChannelDetailContainerNode: ASDisplayNode {
     private let headerTrailingSpacerNode = ASDisplayNode()
     private let titleNode = ASTextNode2()
     private let channelIconNode = ASImageNode()
+    private let groupAvatarNode = ASNetworkImageNode()
 
     private let actionButtonsNode: ChannelDetailActionButtonsNode
 
@@ -175,6 +176,10 @@ final class ChannelDetailContainerNode: ASDisplayNode {
         titleNode.truncationMode = .byTruncatingTail
         titleNode.style.flexShrink = 1
 
+        groupAvatarNode.cornerRadius = 14.sf
+        groupAvatarNode.clipsToBounds = true
+        groupAvatarNode.contentMode = .scaleAspectFill
+
         headerTrailingSpacerNode.style.preferredSize = CGSize(width: 52.sf, height: 44.sf)
         headerTrailingSpacerNode.isUserInteractionEnabled = false
         headerTrailingSpacerNode.backgroundColor = .clear
@@ -194,6 +199,14 @@ final class ChannelDetailContainerNode: ASDisplayNode {
             channelIconNode.isHidden = false
         }
 
+        if let avatarURL = resolvedGroupDMAvatarURL() {
+            groupAvatarNode.url = avatarURL
+            groupAvatarNode.isHidden = false
+        } else {
+            groupAvatarNode.url = nil
+            groupAvatarNode.isHidden = true
+        }
+
         titleNode.attributedText = NSAttributedString(
             string: title,
             attributes: [
@@ -201,6 +214,25 @@ final class ChannelDetailContainerNode: ASDisplayNode {
                 .foregroundColor: UIColor.theme.textStrong,
             ]
         )
+    }
+
+    private func resolvedGroupDMAvatarURL() -> URL? {
+        guard isGroupDirectMessage else { return nil }
+        let raw = channel.channelAvatar.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !raw.isEmpty, !raw.contains("avatar-group.png") else { return nil }
+
+        let absolute: String
+        if let url = URL(string: raw), url.scheme != nil {
+            absolute = raw
+        } else if raw.hasPrefix("//") {
+            absolute = "https:\(raw)"
+        } else {
+            let base = MezonConfig.baseImgURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+            absolute = raw.hasPrefix("/") ? "\(base)\(raw)" : "\(base)/\(raw)"
+        }
+
+        let proxied = ImgproxyURL.avatarProxyURL(from: absolute, width: 180, height: 180)
+        return URL(string: proxied)
     }
 
     func applyUpdatedChannel(_ updated: Mezon_Api_ChannelDescription) {
@@ -293,15 +325,20 @@ final class ChannelDetailContainerNode: ASDisplayNode {
 
     override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
         channelIconNode.style.preferredSize = CGSize(width: 16.sf, height: 16.sf)
+        let showsGroupAvatar = resolvedGroupDMAvatarURL() != nil
+        groupAvatarNode.style.preferredSize = CGSize(width: 28.sf, height: 28.sf)
+        let headerContentChildren: [ASLayoutElement] = showsGroupAvatar
+            ? [groupAvatarNode, titleNode]
+            : [channelIconNode, titleNode]
         let headerContent = ASStackLayoutSpec(
             direction: .horizontal,
             spacing: 8.sw,
             justifyContent: .start,
             alignItems: .center,
-            children: [channelIconNode, titleNode]
+            children: headerContentChildren
         )
         let headerHorizontalControlsWidth = 44.sf + 52.sf
-        let headerTitlePadding: CGFloat = 20.sw
+        let headerTitlePadding: CGFloat = 20.sw + (showsGroupAvatar ? 36.sf : 0)
         let maxHeaderContentWidth = max(
             0,
             constrainedSize.max.width - 32.sw - headerHorizontalControlsWidth - headerTitlePadding
@@ -359,12 +396,16 @@ final class ChannelDetailContainerNode: ASDisplayNode {
         )
         tabsHeader.style.alignSelf = .stretch
 
+        var headerChildren: [ASLayoutElement] = [topBar]
+        headerChildren.append(actionButtonsNode)
+        headerChildren.append(tabsHeader)
+
         let headerSection = ASStackLayoutSpec(
             direction: .vertical,
             spacing: 0,
             justifyContent: .start,
             alignItems: .stretch,
-            children: [topBar, actionButtonsNode, tabsHeader]
+            children: headerChildren
         )
         headerSection.style.alignSelf = .stretch
 

--- a/MezonChat/Features/ChannelDetail/ChannelDetailViewController.swift
+++ b/MezonChat/Features/ChannelDetail/ChannelDetailViewController.swift
@@ -191,7 +191,8 @@ final class ChannelDetailViewController: ViewController {
             channelId: channel.channelID,
             clanId: channel.clanID,
             context: self.context,
-            isThread: isThread
+            isThread: isThread,
+            isGroupDirectMessage: isGroupDirectMessage
         ) { [weak self] duration in
             self?.handleMuteChannel(muteTimeSeconds: duration.seconds)
         }
@@ -519,9 +520,10 @@ private final class GroupDMOptionsSheetViewController: UIViewController {
     }
 }
 
-private final class GroupDMCustomizeViewController: UIViewController, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+private final class GroupDMCustomizeViewController: UIViewController, UIImagePickerControllerDelegate, UINavigationControllerDelegate, UITextFieldDelegate {
 
     private static let maxAvatarBytes = 10 * 1024 * 1024
+    private static let maxGroupNameLength = 64
 
     private let context: AccountContext
     private let originalChannel: Mezon_Api_ChannelDescription
@@ -532,6 +534,9 @@ private final class GroupDMCustomizeViewController: UIViewController, UIImagePic
     private var selectedImageData: Data?
     private var avatarLoadTask: URLSessionDataTask?
     private var isSaving = false
+    private var trimmedGroupName: String {
+        (nameField.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    }
 
     private let titleLabel = UILabel()
     private let avatarButton = UIButton(type: .system)
@@ -539,6 +544,7 @@ private final class GroupDMCustomizeViewController: UIViewController, UIImagePic
     private let avatarPlaceholderImageView = UIImageView()
     private let removeAvatarButton = UIButton(type: .system)
     private let nameLabel = UILabel()
+    private let nameCounterLabel = UILabel()
     private let nameField = UITextField()
     private let cancelButton = UIButton(type: .system)
     private let saveButton = UIButton(type: .system)
@@ -617,6 +623,13 @@ private final class GroupDMCustomizeViewController: UIViewController, UIImagePic
         nameLabel.textColor = UIColor.theme.text
         nameLabel.font = .systemFont(ofSize: 13.sf, weight: .semibold)
 
+        nameCounterLabel.translatesAutoresizingMaskIntoConstraints = false
+        nameCounterLabel.textColor = UIColor.theme.textDisabled
+        nameCounterLabel.font = .systemFont(ofSize: 12.sf, weight: .medium)
+        nameCounterLabel.textAlignment = .right
+        nameCounterLabel.setContentHuggingPriority(.required, for: .horizontal)
+        nameCounterLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+
         nameField.translatesAutoresizingMaskIntoConstraints = false
         nameField.text = originalChannel.channelLabel
         nameField.placeholder = L(L10n.ChannelDetail.groupName)
@@ -630,6 +643,8 @@ private final class GroupDMCustomizeViewController: UIViewController, UIImagePic
         nameField.rightViewMode = .always
         nameField.clearButtonMode = .whileEditing
         nameField.returnKeyType = .done
+        nameField.delegate = self
+        nameField.addTarget(self, action: #selector(nameFieldEditingChanged), for: .editingChanged)
         nameField.addTarget(self, action: #selector(nameFieldDidReturn), for: .editingDidEndOnExit)
 
         cancelButton.translatesAutoresizingMaskIntoConstraints = false
@@ -643,6 +658,7 @@ private final class GroupDMCustomizeViewController: UIViewController, UIImagePic
         saveButton.translatesAutoresizingMaskIntoConstraints = false
         saveButton.setTitle(L(L10n.Common.save), for: .normal)
         saveButton.setTitleColor(.white, for: .normal)
+        saveButton.setTitleColor(.white.withAlphaComponent(0.65), for: .disabled)
         saveButton.titleLabel?.font = .systemFont(ofSize: 16.sf, weight: .semibold)
         saveButton.backgroundColor = UIColor.theme.bgViolet
         saveButton.layer.cornerRadius = 10.sf
@@ -664,10 +680,16 @@ private final class GroupDMCustomizeViewController: UIViewController, UIImagePic
         buttonStack.spacing = 12.sw
         buttonStack.distribution = .fillEqually
 
+        let nameHeaderStack = UIStackView(arrangedSubviews: [nameLabel, nameCounterLabel])
+        nameHeaderStack.translatesAutoresizingMaskIntoConstraints = false
+        nameHeaderStack.axis = .horizontal
+        nameHeaderStack.alignment = .center
+        nameHeaderStack.spacing = 8.sw
+
         let contentStack = UIStackView(arrangedSubviews: [
             titleLabel,
             avatarStack,
-            nameLabel,
+            nameHeaderStack,
             nameField,
             buttonStack
         ])
@@ -675,7 +697,7 @@ private final class GroupDMCustomizeViewController: UIViewController, UIImagePic
         contentStack.axis = .vertical
         contentStack.spacing = 14.sh
         contentStack.setCustomSpacing(18.sh, after: titleLabel)
-        contentStack.setCustomSpacing(8.sh, after: nameLabel)
+        contentStack.setCustomSpacing(8.sh, after: nameHeaderStack)
 
         view.addSubview(contentStack)
         saveButton.addSubview(activityIndicator)
@@ -716,6 +738,8 @@ private final class GroupDMCustomizeViewController: UIViewController, UIImagePic
             activityIndicator.centerXAnchor.constraint(equalTo: saveButton.centerXAnchor),
             activityIndicator.centerYAnchor.constraint(equalTo: saveButton.centerYAnchor),
         ])
+
+        updateSaveButtonState()
     }
 
     private func updateAvatarPreview() {
@@ -731,12 +755,12 @@ private final class GroupDMCustomizeViewController: UIViewController, UIImagePic
         }
 
         let trimmed = avatarURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        removeAvatarButton.isHidden = trimmed.isEmpty
+        removeAvatarButton.isHidden = trimmed.isEmpty || trimmed.contains("avatar-group.png")
         guard !trimmed.isEmpty, !trimmed.contains("avatar-group.png") else {
             avatarImageView.image = nil
             avatarImageView.isHidden = true
             avatarPlaceholderImageView.isHidden = false
-            avatarButton.backgroundColor = UIColor.theme.bgViolet
+            avatarButton.backgroundColor = .groupDMDefaultAvatar
             return
         }
 
@@ -751,7 +775,7 @@ private final class GroupDMCustomizeViewController: UIViewController, UIImagePic
         avatarImageView.image = nil
         avatarImageView.isHidden = true
         avatarPlaceholderImageView.isHidden = false
-        avatarButton.backgroundColor = UIColor.theme.bgViolet
+        avatarButton.backgroundColor = .groupDMDefaultAvatar
         avatarLoadTask = ImageCache.shared.loadImage(urlString: proxied) { [weak self] image in
             guard let self, let image else { return }
             self.avatarImageView.image = image
@@ -780,15 +804,48 @@ private final class GroupDMCustomizeViewController: UIViewController, UIImagePic
         view.endEditing(true)
     }
 
+    @objc private func nameFieldEditingChanged() {
+        updateSaveButtonState()
+    }
+
+    func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        guard textField === nameField else { return true }
+        let current = textField.text ?? ""
+        guard let stringRange = Range(range, in: current) else { return false }
+        let proposed = current.replacingCharacters(in: stringRange, with: string)
+        if proposed.count <= Self.maxGroupNameLength || proposed.count < current.count {
+            return true
+        }
+
+        let keptPrefixCount = current.distance(from: current.startIndex, to: stringRange.lowerBound)
+        let keptSuffixCount = current.distance(from: stringRange.upperBound, to: current.endIndex)
+        let remaining = Self.maxGroupNameLength - keptPrefixCount - keptSuffixCount
+        guard remaining > 0 else { return false }
+
+        let allowed = String(string.prefix(remaining))
+        textField.text = current.replacingCharacters(in: stringRange, with: allowed)
+        nameFieldEditingChanged()
+        return false
+    }
+
     @objc private func cancelTapped() {
         dismiss(animated: true)
     }
 
     @objc private func saveTapped() {
         guard !isSaving else { return }
-        let name = (nameField.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let name = trimmedGroupName
         guard !name.isEmpty else {
+            updateSaveButtonState()
             Toast.error(L(L10n.ChannelDetail.groupNameRequired))
+            return
+        }
+        guard name.count <= Self.maxGroupNameLength else {
+            updateSaveButtonState()
             return
         }
 
@@ -844,11 +901,29 @@ private final class GroupDMCustomizeViewController: UIViewController, UIImagePic
         avatarButton.isEnabled = !saving
         removeAvatarButton.isEnabled = !saving
         saveButton.setTitle(saving ? nil : L(L10n.Common.save), for: .normal)
+        updateSaveButtonState()
         if saving {
             activityIndicator.startAnimating()
         } else {
             activityIndicator.stopAnimating()
         }
+    }
+
+    private func updateSaveButtonState() {
+        updateNameCounter()
+        let enabled = !trimmedGroupName.isEmpty && trimmedGroupName.count <= Self.maxGroupNameLength && !isSaving
+        saveButton.isEnabled = enabled
+        saveButton.backgroundColor = (enabled || isSaving)
+            ? UIColor.theme.bgViolet
+            : UIColor.theme.textDisabled.withAlphaComponent(0.45)
+    }
+
+    private func updateNameCounter() {
+        let count = nameField.text?.count ?? 0
+        nameCounterLabel.text = "\(count)/\(Self.maxGroupNameLength)"
+        nameCounterLabel.textColor = count > Self.maxGroupNameLength
+            ? UIColor.systemRed
+            : UIColor.theme.textDisabled
     }
 
     private func uploadSelectedAvatarIfNeeded(token: String) async throws -> String {

--- a/MezonChat/Features/ChannelDetail/Tabs/MediaGalleryNode.swift
+++ b/MezonChat/Features/ChannelDetail/Tabs/MediaGalleryNode.swift
@@ -11,6 +11,9 @@ final class MediaGalleryNode: ASDisplayNode {
     private var attachments: [Mezon_Api_ChannelAttachment] = []
     private var didLoadMedia = false
     private var mediaFetchCompleted = false
+    private var isLoadingMore = false
+    private var hasMoreMedia = true
+    private let mediaPageLimit: Int32 = 50
 
     private let collectionNode: ASCollectionNode
     private let loadingHostNode: ASDisplayNode
@@ -68,20 +71,12 @@ final class MediaGalleryNode: ASDisplayNode {
             guard let self else { return }
             do {
                 let token = await context.getToken() ?? ""
-                let targetClanId =
-                    (channelType == MezonConstants.ChannelType.dm.rawValue
-                        || channelType == MezonConstants.ChannelType.group.rawValue) ? 0 : clanId
-
-
-                let res = try await context.account.network.listChannelAttachments(
-                    clanId: targetClanId,
-                    channelId: channelId,
-                    fileType: "image",
-                    limit: 50,
-                    token: token
-                )
+                let res = try await self.requestAttachments(before: 0, token: token)
                 let raw = res.attachments
-                let visual = raw.filter { Self.isVisualAttachment($0) }
+                self.hasMoreMedia = raw.count >= Int(self.mediaPageLimit)
+                let visual = raw
+                    .filter { Self.isVisualAttachment($0) }
+                    .sorted { $0.createTimeSeconds > $1.createTimeSeconds }
                 self.attachments = visual
 
                 await self.collectionNode.reloadData()
@@ -92,6 +87,64 @@ final class MediaGalleryNode: ASDisplayNode {
                 self.setNeedsLayout()
             }
         }
+    }
+
+    private func requestAttachments(before: UInt32, token: String) async throws
+        -> Mezon_Api_ChannelAttachmentList
+    {
+        let targetClanId =
+            (channelType == MezonConstants.ChannelType.dm.rawValue
+                || channelType == MezonConstants.ChannelType.group.rawValue) ? 0 : clanId
+        return try await context.account.network.listChannelAttachments(
+            clanId: targetClanId,
+            channelId: channelId,
+            fileType: "image",
+            limit: mediaPageLimit,
+            before: before,
+            token: token
+        )
+    }
+
+    private func loadMoreMediaIfNeeded() {
+        guard mediaFetchCompleted, hasMoreMedia, !isLoadingMore,
+            let oldest = attachments.last, oldest.createTimeSeconds > 0
+        else { return }
+        isLoadingMore = true
+        let before = oldest.createTimeSeconds
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer { self.isLoadingMore = false }
+            do {
+                let token = await self.context.getToken() ?? ""
+                let res = try await self.requestAttachments(before: before, token: token)
+                let raw = res.attachments
+                self.hasMoreMedia = raw.count >= Int(self.mediaPageLimit)
+                let existingKeys = Set(self.attachments.map { Self.dedupKey($0) })
+                let newItems = raw
+                    .filter { Self.isVisualAttachment($0) }
+                    .filter { !existingKeys.contains(Self.dedupKey($0)) }
+                    .sorted { $0.createTimeSeconds > $1.createTimeSeconds }
+                guard !newItems.isEmpty else {
+                    self.hasMoreMedia = false
+                    return
+                }
+                let startIndex = self.attachments.count
+                self.attachments.append(contentsOf: newItems)
+                let indexPaths = (startIndex..<self.attachments.count).map {
+                    IndexPath(item: $0, section: 0)
+                }
+                self.collectionNode.performBatch(
+                    animated: false,
+                    updates: { self.collectionNode.insertItems(at: indexPaths) },
+                    completion: nil
+                )
+            } catch {
+            }
+        }
+    }
+
+    private static func dedupKey(_ att: Mezon_Api_ChannelAttachment) -> String {
+        att.id != 0 ? "id:\(att.id)" : "url:\(att.url)"
     }
 
     private static func isVisualAttachment(_ att: Mezon_Api_ChannelAttachment) -> Bool {
@@ -245,6 +298,16 @@ extension MediaGalleryNode: ASCollectionDataSource, ASCollectionDelegate {
         -> Int
     {
         attachments.count
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let offset = scrollView.contentOffset.y
+        let contentHeight = scrollView.contentSize.height
+        let frameHeight = scrollView.frame.height
+        guard contentHeight > frameHeight else { return }
+        if offset > contentHeight - frameHeight * 1.5 {
+            loadMoreMediaIfNeeded()
+        }
     }
 
     func collectionNode(_ collectionNode: ASCollectionNode, nodeBlockForItemAt indexPath: IndexPath)

--- a/MezonChat/Features/ChannelDetail/Tabs/MemberListNode.swift
+++ b/MezonChat/Features/ChannelDetail/Tabs/MemberListNode.swift
@@ -70,6 +70,10 @@ final class MemberListNode: ASDisplayNode {
         super.init()
         self.automaticallyManagesSubnodes = true
 
+        if effectiveType == group, channelDescription.creatorID != 0 {
+            self.ownerId = String(channelDescription.creatorID)
+        }
+
         tableNode.dataSource = self
         tableNode.delegate = self
         tableNode.backgroundColor = .clear
@@ -519,10 +523,20 @@ extension MemberListNode: ASTableDataSource, ASTableDelegate {
 
         guard let host = tableNode.view.findHostingViewController() else { return }
 
+        let groupAction: MemberProfileGroupAction? = {
+            guard isCurrentGroupCreator, !isCurrentUser else { return nil }
+            let label = !user.displayName.isEmpty ? user.displayName : user.username
+            let removedId = user.id
+            return MemberProfileGroupAction(confirmUserLabel: label, onRemove: { [weak self] in
+                try await self?.removeMemberFromGroup(userId: removedId)
+            })
+        }()
+
         let sheet = MemberProfileSheetController(
             user: user,
             context: context,
             isCurrentUser: isCurrentUser,
+            groupAction: groupAction,
             onSendMessage: { [weak self, weak host] dmChannel in
                 guard let self, let host else { return }
                 self.context.currentClanId = 0
@@ -535,15 +549,102 @@ extension MemberListNode: ASTableDataSource, ASTableDelegate {
         sheet.animateIn()
     }
 
+    private var isCurrentGroupCreator: Bool {
+        guard channelType == MezonConstants.ChannelType.group.rawValue,
+              channelDescription.creatorID != 0,
+              let myId = context.currentUser.flatMap({ Int64($0.id) }) else { return false }
+        return myId == channelDescription.creatorID
+    }
+
+    private func removeMemberFromGroup(userId: Int64) async throws {
+        guard let token = await context.getToken() else {
+            throw NSError(
+                domain: "MezonRemoveMember", code: -1,
+                userInfo: [NSLocalizedDescriptionKey: L(L10n.ChannelDetail.removeFromGroupFailed)])
+        }
+        try await context.account.network.removeChannelUsers(
+            channelId: channelId, userIds: [userId], token: token)
+        context.account.postbox.write { [channelId] tx in
+            let current = tx.getChannelMeta(channelId: channelId)?.members ?? []
+            let updated = current.filter { $0.userId != userId }
+            tx.updateChannelMembers(updated, channelId: channelId)
+        }
+        Toast.success(L(L10n.ChannelDetail.memberRemoved))
+    }
+
     private func handleHeaderActionTapped(tableNode: ASTableNode) {
         guard let host = tableNode.view.findHostingViewController() else { return }
         guard channelType == MezonConstants.ChannelType.group.rawValue else { return }
+        let memberSnapshot = currentGroupMemberSnapshot()
         let vc = NewGroupDMViewController(
             context: context,
             existingGroupChannel: channelDescription,
-            onMembersAdded: { _ in }
+            existingMemberIds: memberSnapshot.ids,
+            existingMemberCount: memberSnapshot.count,
+            onMembersAdded: { [weak self] updated in
+                let expectedCount: Int? = updated.memberCount > 0 ? Int(updated.memberCount) : nil
+                self?.refreshGroupMembersAfterAdd(expectedMemberCount: expectedCount)
+            }
         )
         host.navigationController?.pushViewController(vc, animated: true)
+    }
+
+    private func refreshGroupMembersAfterAdd(expectedMemberCount: Int?) {
+        guard channelType == MezonConstants.ChannelType.group.rawValue else { return }
+        let channelId = self.channelId
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard let token = await self.context.getTokenPreferringCachedSkipSessionReadyWait() else { return }
+            for attempt in 0..<3 {
+                if attempt > 0 {
+                    try? await Task.sleep(nanoseconds: 500_000_000)
+                }
+                do {
+                    let response = try await self.context.account.network.listChannelUsersUC(
+                        channelId: channelId,
+                        limit: 500,
+                        token: token
+                    )
+                    guard !response.userIds.isEmpty else { continue }
+                    self.applyGroupMemberList(response)
+                    if let expectedMemberCount {
+                        if Set(response.userIds).count >= expectedMemberCount { return }
+                    } else {
+                        return
+                    }
+                } catch {
+                }
+            }
+        }
+    }
+
+    private func currentGroupMemberSnapshot() -> (ids: Set<Int64>, count: Int) {
+        var ids = Set<Int64>()
+        if case .channel(let members) = onlineMembers {
+            ids.formUnion(members.map(\.userId))
+        }
+        if case .channel(let members) = offlineMembers {
+            ids.formUnion(members.map(\.userId))
+        }
+        if !ids.isEmpty {
+            return (ids, ids.count)
+        }
+
+        let cachedIds = context.account.postbox.read { tx in
+            Set(tx.getChannelMeta(channelId: self.channelId)?.members.map(\.userId) ?? [])
+        }
+        if !cachedIds.isEmpty {
+            return (cachedIds, cachedIds.count)
+        }
+
+        ids = Set(channelDescription.userIds)
+        if channelDescription.memberCount > 0 {
+            return (ids, Int(channelDescription.memberCount))
+        }
+        if let currentUserId = context.currentUser.flatMap({ Int64($0.id) }) {
+            ids.insert(currentUserId)
+        }
+        return (ids, max(ids.count, 1))
     }
 
     private static func apiUser(from member: ChannelMemberRecord) -> Mezon_Api_User {

--- a/MezonChat/Features/ChannelList/ChannelListViewController.swift
+++ b/MezonChat/Features/ChannelList/ChannelListViewController.swift
@@ -1309,6 +1309,7 @@ final class ChannelListViewController: ViewController {
         fetchDisposable.set(nil)
         self.clanId = clanId
         self.clanName = clanName
+        emptyChannelRetryCountByClanId[clanId] = 0
         self.showEmptyCategoriesEnabled = loadShowEmptyCategoriesPreference(clanId: clanId)
         channelsLoadedPromise.set(false)
         errorMessage = nil
@@ -1378,6 +1379,8 @@ final class ChannelListViewController: ViewController {
     private var inflightChannelFetchClanId: Int64 = 0
     private var lastChannelFetchAtByClanId: [Int64: Date] = [:]
     private let channelFetchCooldown: TimeInterval = 5.0
+    private var emptyChannelRetryCountByClanId: [Int64: Int] = [:]
+    private let maxEmptyChannelFetchRetries = 4
 
     private func fetchChannelsWithoutLoadingSignal(allowEmptyChannelAppsOverwrite: Bool = false) {
         guard clanId != 0 else {
@@ -1439,7 +1442,69 @@ final class ChannelListViewController: ViewController {
                         Task { @MainActor [weak self] in
                             await self?.applyChannelBadgeCounts(clanId: clanId)
                         }
+                        if !categoryDescs.isEmpty {
+                            self.lastChannelFetchAtByClanId.removeValue(forKey: clanId)
+                        }
                         self.clearInflightChannelFetchIfMatches(clanId: clanId)
+                        return
+                    }
+                    if channels.isEmpty, let recoveredChannels = self.recoveryChannelsForEmptyFetch(clanId: clanId) {
+                        Task { @MainActor [weak self] in
+                            guard let self else { return }
+                            guard self.isCurrentSessionAlive else {
+                                self.clearInflightChannelFetchIfMatches(clanId: clanId)
+                                return
+                            }
+                            guard self.clanId == clanId else {
+                                self.clearInflightChannelFetchIfMatches(clanId: clanId)
+                                return
+                            }
+                            let resolvedCategoryDescs = categoryDescs.isEmpty ? self.channelListCategoryDescs : categoryDescs
+                            let resolvedFavoriteIds = favoriteIds.isEmpty ? self.channelListFavoriteIds : favoriteIds
+                            let merged = await self.fetchMergedChannelsWithBadgeCounts(base: recoveredChannels, clanId: clanId)
+                            self.channelListCategoryDescs = resolvedCategoryDescs
+                            self.channelListFavoriteIds = resolvedFavoriteIds
+                            self.allChannels = merged
+                            let storedCollapsed = self.loadCollapsedCategoryIds()
+                            let built = buildChannelCategories(
+                                merged,
+                                categoryDescs: resolvedCategoryDescs,
+                                favoriteChannelIds: resolvedFavoriteIds,
+                                collapsedIds: storedCollapsed
+                            )
+                            let cats = self.applyBuiltCategoriesPreservingCollapse(built)
+                            self.categories = cats
+                            self.channelsLoadedPromise.set(true)
+                            self.syncSelectedChannelFromStoredPreferences()
+                            self.categoriesPipe.putNext(cats)
+                            self.fetchChannelApps(allowEmptyOverwrite: allowEmptyApps)
+                            self.persistFullChannelListCache(
+                                clanId: clanId,
+                                channels: merged,
+                                categoryDescs: resolvedCategoryDescs,
+                                favoriteIds: resolvedFavoriteIds,
+                                categories: cats
+                            )
+                            self.channelListNode.endRefreshing()
+                            self.isLoadingPipe.putNext(false)
+                            self.needsReloadPipe.putNext(())
+                            self.postClanSidebarUnreadDerivedFromCurrentChannels()
+                            self.lastChannelFetchAtByClanId.removeValue(forKey: clanId)
+                            self.clearInflightChannelFetchIfMatches(clanId: clanId)
+                        }
+                        return
+                    }
+                    if channels.isEmpty {
+                        self.channelsLoadedPromise.set(!self.allChannels.isEmpty)
+                        self.channelListNode.endRefreshing()
+                        self.isLoadingPipe.putNext(false)
+                        self.fetchChannelApps(allowEmptyOverwrite: allowEmptyApps)
+                        self.needsReloadPipe.putNext(())
+                        self.lastChannelFetchAtByClanId.removeValue(forKey: clanId)
+                        self.clearInflightChannelFetchIfMatches(clanId: clanId)
+                        if self.allChannels.isEmpty {
+                            self.scheduleEmptyChannelRetryIfNeeded(clanId: clanId)
+                        }
                         return
                     }
                     Task { @MainActor [weak self] in
@@ -1456,6 +1521,7 @@ final class ChannelListViewController: ViewController {
                         self.channelListCategoryDescs = categoryDescs
                         self.channelListFavoriteIds = favoriteIds
                         self.allChannels = merged
+                        self.emptyChannelRetryCountByClanId[clanId] = 0
                         let storedCollapsed = self.loadCollapsedCategoryIds()
                         let built = buildChannelCategories(
                             merged,
@@ -1501,6 +1567,23 @@ final class ChannelListViewController: ViewController {
     private func clearInflightChannelFetchIfMatches(clanId: Int64) {
         if inflightChannelFetchClanId == clanId {
             inflightChannelFetchClanId = 0
+        }
+    }
+
+    private func scheduleEmptyChannelRetryIfNeeded(clanId: Int64) {
+        guard clanId != 0, clanId == self.clanId, self.allChannels.isEmpty,
+              NetworkMonitor.shared.isConnected else { return }
+        let attempt = emptyChannelRetryCountByClanId[clanId, default: 0]
+        guard attempt < maxEmptyChannelFetchRetries else { return }
+        emptyChannelRetryCountByClanId[clanId] = attempt + 1
+        let delayNanos = UInt64(700_000_000) * UInt64(attempt + 1)
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: delayNanos)
+            guard let self else { return }
+            guard self.clanId == clanId, self.allChannels.isEmpty,
+                  self.isCurrentSessionAlive, NetworkMonitor.shared.isConnected else { return }
+            self.lastChannelFetchAtByClanId.removeValue(forKey: clanId)
+            self.fetchChannelsWithoutLoadingSignal(allowEmptyChannelAppsOverwrite: false)
         }
     }
 
@@ -1742,10 +1825,22 @@ final class ChannelListViewController: ViewController {
     }
 
     func updateChannels(_ channels: [Mezon_Api_ChannelDescription]) {
-        allChannels = channels
+        let resolvedChannels: [Mezon_Api_ChannelDescription]
+        if channels.isEmpty {
+            if let recoveredChannels = recoveryChannelsForEmptyFetch(clanId: clanId) {
+                resolvedChannels = recoveredChannels
+                lastChannelFetchAtByClanId.removeValue(forKey: clanId)
+            } else {
+                if !channelListCategoryDescs.isEmpty { return }
+                resolvedChannels = channels
+            }
+        } else {
+            resolvedChannels = channels
+        }
+        allChannels = resolvedChannels
         let storedCollapsed = loadCollapsedCategoryIds()
         let built = buildChannelCategories(
-            channels,
+            resolvedChannels,
             categoryDescs: channelListCategoryDescs,
             favoriteChannelIds: channelListFavoriteIds,
             collapsedIds: storedCollapsed
@@ -2074,6 +2169,21 @@ final class ChannelListViewController: ViewController {
             return false
         }
         return true
+    }
+
+    private func recoveryChannelsForEmptyFetch(clanId: Int64) -> [Mezon_Api_ChannelDescription]? {
+        guard clanId != 0 else { return nil }
+        if clanId == self.clanId, !allChannels.isEmpty {
+            return allChannels
+        }
+        if let cached = readChannelCachePayloadIfAvailable(clanId: clanId)?.channels, !cached.isEmpty {
+            return cached
+        }
+        if let allChannelsByUser = context.engine.clanData.getAllChannelsByUser()?.channeldesc {
+            let filtered = allChannelsByUser.filter { $0.clanID == clanId }
+            if !filtered.isEmpty { return filtered }
+        }
+        return nil
     }
 
     private func readChannelCachePayloadIfAvailable(clanId: Int64) -> (channels: [Mezon_Api_ChannelDescription], meta: ChannelListCachedMeta?)? {

--- a/MezonChat/Features/ChannelList/MuteDurationSheetController.swift
+++ b/MezonChat/Features/ChannelList/MuteDurationSheetController.swift
@@ -39,6 +39,7 @@ final class MuteDurationViewController: ViewController {
     private let clanId: Int64
     private let context: AccountContext
     private let isThread: Bool
+    private let isGroupDirectMessage: Bool
     private let onSelect: (MuteDuration) -> Void
 
     private let scrollView = UIScrollView()
@@ -50,6 +51,7 @@ final class MuteDurationViewController: ViewController {
         clanId: Int64,
         context: AccountContext,
         isThread: Bool,
+        isGroupDirectMessage: Bool = false,
         onSelect: @escaping (MuteDuration) -> Void
     ) {
         self.channelName = channelName
@@ -57,6 +59,7 @@ final class MuteDurationViewController: ViewController {
         self.clanId = clanId
         self.context = context
         self.isThread = isThread
+        self.isGroupDirectMessage = isGroupDirectMessage
         self.onSelect = onSelect
         super.init(navigationBarPresentationData: nil)
     }
@@ -105,12 +108,12 @@ final class MuteDurationViewController: ViewController {
         headerBar.addSubview(backBtn)
 
         let titleLbl = UILabel()
-        titleLbl.text = isThread ? L(L10n.MuteDuration.titleThread) : L(L10n.MuteDuration.title)
+        titleLbl.text = muteTitle
         titleLbl.font = .systemFont(ofSize: 17, weight: .semibold)
         titleLbl.textColor = .mezonTextStrong
 
         let subtitleLbl = UILabel()
-        subtitleLbl.text = "#\(channelName)"
+        subtitleLbl.text = isGroupDirectMessage ? channelName : "#\(channelName)"
         subtitleLbl.font = .systemFont(ofSize: 13, weight: .regular)
         subtitleLbl.textColor = .mezonTextMuted
         subtitleLbl.lineBreakMode = .byTruncatingTail
@@ -179,39 +182,48 @@ final class MuteDurationViewController: ViewController {
             }
         }
 
-        let gap = UIView()
-        gap.backgroundColor = bg
-        gap.translatesAutoresizingMaskIntoConstraints = false
-        gap.heightAnchor.constraint(equalToConstant: 16).isActive = true
-        contentStack.addArrangedSubview(gap)
+        if !isGroupDirectMessage {
+            let gap = UIView()
+            gap.backgroundColor = bg
+            gap.translatesAutoresizingMaskIntoConstraints = false
+            gap.heightAnchor.constraint(equalToConstant: 16).isActive = true
+            contentStack.addArrangedSubview(gap)
 
-        let settingsRow = makeSettingsRow(
-            title: L(L10n.MuteDuration.notificationSettings),
-            bgColor: cellBg
-        ) { [weak self] in
-            self?.presentNotificationSettings()
+            let settingsRow = makeSettingsRow(
+                title: L(L10n.MuteDuration.notificationSettings),
+                bgColor: cellBg
+            ) { [weak self] in
+                self?.presentNotificationSettings()
+            }
+            contentStack.addArrangedSubview(settingsRow)
+
+            let descWrapper = UIView()
+            descWrapper.backgroundColor = bg
+            descWrapper.translatesAutoresizingMaskIntoConstraints = false
+
+            let descLabel = UILabel()
+            descLabel.text = L(L10n.MuteDuration.description)
+            descLabel.font = .systemFont(ofSize: 13, weight: .regular)
+            descLabel.textColor = .mezonTextMuted
+            descLabel.numberOfLines = 0
+            descLabel.translatesAutoresizingMaskIntoConstraints = false
+            descWrapper.addSubview(descLabel)
+
+            NSLayoutConstraint.activate([
+                descLabel.topAnchor.constraint(equalTo: descWrapper.topAnchor, constant: 12),
+                descLabel.leadingAnchor.constraint(equalTo: descWrapper.leadingAnchor, constant: 16),
+                descLabel.trailingAnchor.constraint(equalTo: descWrapper.trailingAnchor, constant: -16),
+                descLabel.bottomAnchor.constraint(equalTo: descWrapper.bottomAnchor, constant: -12),
+            ])
+            contentStack.addArrangedSubview(descWrapper)
         }
-        contentStack.addArrangedSubview(settingsRow)
+    }
 
-        let descWrapper = UIView()
-        descWrapper.backgroundColor = bg
-        descWrapper.translatesAutoresizingMaskIntoConstraints = false
-
-        let descLabel = UILabel()
-        descLabel.text = L(L10n.MuteDuration.description)
-        descLabel.font = .systemFont(ofSize: 13, weight: .regular)
-        descLabel.textColor = .mezonTextMuted
-        descLabel.numberOfLines = 0
-        descLabel.translatesAutoresizingMaskIntoConstraints = false
-        descWrapper.addSubview(descLabel)
-
-        NSLayoutConstraint.activate([
-            descLabel.topAnchor.constraint(equalTo: descWrapper.topAnchor, constant: 12),
-            descLabel.leadingAnchor.constraint(equalTo: descWrapper.leadingAnchor, constant: 16),
-            descLabel.trailingAnchor.constraint(equalTo: descWrapper.trailingAnchor, constant: -16),
-            descLabel.bottomAnchor.constraint(equalTo: descWrapper.bottomAnchor, constant: -12),
-        ])
-        contentStack.addArrangedSubview(descWrapper)
+    private var muteTitle: String {
+        if isGroupDirectMessage {
+            return L(L10n.MuteDuration.titleConversation)
+        }
+        return isThread ? L(L10n.MuteDuration.titleThread) : L(L10n.MuteDuration.title)
     }
 
     private func makeOptionRow(title: String, bgColor: UIColor, action: @escaping () -> Void) -> UIView {

--- a/MezonChat/Features/Chat/Cells/WelcomeCellNode.swift
+++ b/MezonChat/Features/Chat/Cells/WelcomeCellNode.swift
@@ -31,7 +31,6 @@ final class WelcomeCellNode: ASDisplayNode {
     private static let dmAvatarSize: CGFloat = 64
     private static let groupDmSize: CGFloat = 50
     private static let groupDmIconInner: CGFloat = 22
-    private static let groupDmPlaceholderOrange = UIColor(red: 249/255, green: 115/255, blue: 22/255, alpha: 1)
 
     private var cachedTitleSize: CGSize = .zero
     private var cachedUsernameSize: CGSize = .zero
@@ -201,7 +200,7 @@ final class WelcomeCellNode: ASDisplayNode {
         case let .dmGroup(label, groupAvatarURL):
             groupDmOuterNode.cornerRadius = Self.groupDmSize / 2
             groupDmOuterNode.clipsToBounds = true
-            groupDmOuterNode.backgroundColor = Self.groupDmPlaceholderOrange
+            groupDmOuterNode.backgroundColor = .groupDMDefaultAvatar
             addSubnode(groupDmOuterNode)
 
             groupDmOuterNode.addSubnode(groupDmImageNode)

--- a/MezonChat/Features/Chat/ChatContainerNode.swift
+++ b/MezonChat/Features/Chat/ChatContainerNode.swift
@@ -592,9 +592,33 @@ final class ChatContainerNode: ASDisplayNode {
         return "\(m.id)|\(m.message.senderId)|\(m.message.createdAt.timeIntervalSince1970)|\(edited)|\(m.senderDisplayName)|\(m.avatarURL ?? "")|\(m.messageCode)|\(grouping)|\(m.parsedContent.text)|\(att)|\(pin)|\(pollHash)|\(embedHash)|\(ogpHash)|\(topicHash)|\(sendFeedback)"
     }
 
+    private static func welcomeFingerprint(_ state: ChatState) -> String {
+        [
+            state.channelLabel,
+            "\(state.channelType)",
+            state.isPrivate ? "1" : "0",
+            state.isAgeRestricted ? "1" : "0",
+            state.isDM ? "1" : "0",
+            state.dmPeerUsername,
+            state.dmPeerDisplayName,
+            state.dmAvatarURL,
+            state.dmGroupAvatarURL,
+        ].joined(separator: "|")
+    }
+
     private func applyInPlaceUpdates(old: ChatState, new: ChatState, newIds: [String], forceAll: Bool = false) {
         let newItems = buildItems(from: new)
         var updateItems: [ListViewUpdateItem] = []
+
+        if Self.welcomeFingerprint(old) != Self.welcomeFingerprint(new),
+           let welcomeIndex = newItems.firstIndex(where: { $0 is ChatWelcomeItem }) {
+            updateItems.append(ListViewUpdateItem(
+                index: welcomeIndex,
+                previousIndex: welcomeIndex,
+                item: newItems[welcomeIndex],
+                directionHint: nil
+            ))
+        }
 
         var oldLookup: [String: (reactions: [ParsedReaction], sendingState: SendingState, fingerprint: String)] = [:]
         for msg in old.messages {

--- a/MezonChat/Features/Chat/ChatViewController.swift
+++ b/MezonChat/Features/Chat/ChatViewController.swift
@@ -1421,6 +1421,10 @@ final class ChatViewController: ViewController {
     private func setErrorMessage(_ v: String?) { errorMessage = v; metadataOnlyPipe.putNext(()) }
 
     private var hasCompletedInitialFetch = false
+    private static let initialEmptyMessageRetryDelaysNanoseconds: [UInt64] = [
+        600_000_000,
+        1_200_000_000
+    ]
 
     func start() {
         if topicId == 0 {
@@ -1798,7 +1802,7 @@ final class ChatViewController: ViewController {
             setIsLoadingMessageContext(true)
         }
         setErrorMessage(nil)
-        let preferHTTPFirst = nextFetchPrefersHTTPFirst
+        let preferHTTPFirst = true
         nextFetchPrefersHTTPFirst = false
 
         Task { @MainActor in
@@ -1812,9 +1816,43 @@ final class ChatViewController: ViewController {
             if let token { resolvedToken = token } else { resolvedToken = await self.context.getTokenPreferringCachedSkipSessionReadyWait() }
             guard let token = resolvedToken else { return }
             do {
-                var response = try await self.context.account.network.listChannelMessages(clanId: clanId, channelId: channel.channelID, messageId: 0, direction: 2, limit: 30, topicId: self.topicId, token: token, preferHTTPFirst: preferHTTPFirst)
-                if response.messages.isEmpty {
-                    response = try await self.context.account.network.listChannelMessages(clanId: clanId, channelId: channel.channelID, messageId: 0, direction: 3, limit: 30, topicId: self.topicId, token: token, preferHTTPFirst: preferHTTPFirst)
+                func loadInitialMessages() async throws -> Mezon_Api_ChannelMessageList {
+                    var response = try await self.context.account.network.listChannelMessages(
+                        clanId: clanId,
+                        channelId: channel.channelID,
+                        messageId: 0,
+                        direction: 2,
+                        limit: 30,
+                        topicId: self.topicId,
+                        token: token,
+                        preferHTTPFirst: preferHTTPFirst
+                    )
+                    if response.messages.isEmpty {
+                        response = try await self.context.account.network.listChannelMessages(
+                            clanId: clanId,
+                            channelId: channel.channelID,
+                            messageId: 0,
+                            direction: 3,
+                            limit: 30,
+                            topicId: self.topicId,
+                            token: token,
+                            preferHTTPFirst: preferHTTPFirst
+                        )
+                    }
+                    return response
+                }
+
+                var response = try await loadInitialMessages()
+                if response.messages.isEmpty && !hadCachedMessages && !hadCachedInPostbox {
+                    for delay in Self.initialEmptyMessageRetryDelaysNanoseconds {
+                        guard response.messages.isEmpty,
+                              NetworkMonitor.shared.isConnected,
+                              !Task.isCancelled else {
+                            break
+                        }
+                        try await Task.sleep(nanoseconds: delay)
+                        response = try await loadInitialMessages()
+                    }
                 }
                 self.setHasMoreOlder(response.messages.count > 1)
                 let records = response.messages.map { self.messageRecord(from: $0) }
@@ -2193,6 +2231,10 @@ final class ChatViewController: ViewController {
             var lastIsAgeRestricted = self.currentState.isAgeRestricted
             var lastChannelLabel = self.currentState.channelLabel
             var lastChannelType = self.currentState.channelType
+            var lastDmPeerUsername = self.currentState.dmPeerUsername
+            var lastDmPeerDisplayName = self.currentState.dmPeerDisplayName
+            var lastDmAvatarURL = self.currentState.dmAvatarURL
+            var lastDmGroupAvatarURL = self.currentState.dmGroupAvatarURL
             subscriber.putNext(self.currentState)
             let merged = Signal<Void, NoError> { subscriber in
                 let d1 = self.needsReloadPipe.signal().start(next: { subscriber.putNext(()) })
@@ -2224,6 +2266,10 @@ final class ChatViewController: ViewController {
                         || newState.isAgeRestricted != lastIsAgeRestricted
                         || newState.channelLabel != lastChannelLabel
                         || newState.channelType != lastChannelType
+                        || newState.dmPeerUsername != lastDmPeerUsername
+                        || newState.dmPeerDisplayName != lastDmPeerDisplayName
+                        || newState.dmAvatarURL != lastDmAvatarURL
+                        || newState.dmGroupAvatarURL != lastDmGroupAvatarURL
                     guard changed else { return }
                     lastIds = newIds
                     lastSendingStates = newSendingStates
@@ -2242,6 +2288,10 @@ final class ChatViewController: ViewController {
                     lastIsAgeRestricted = newState.isAgeRestricted
                     lastChannelLabel = newState.channelLabel
                     lastChannelType = newState.channelType
+                    lastDmPeerUsername = newState.dmPeerUsername
+                    lastDmPeerDisplayName = newState.dmPeerDisplayName
+                    lastDmAvatarURL = newState.dmAvatarURL
+                    lastDmGroupAvatarURL = newState.dmGroupAvatarURL
                     subscriber.putNext(newState)
                 })
         }

--- a/MezonChat/Features/ClanSettings/Roles/SetupPermissionsViewController.swift
+++ b/MezonChat/Features/ClanSettings/Roles/SetupPermissionsViewController.swift
@@ -510,7 +510,7 @@ private final class PermissionRowCell: UITableViewCell {
     private let titleLabel = UILabel()
     private let descriptionLabel = UILabel()
     private let lockIcon = UIImageView()
-    private let toggle = UISwitch()
+    private let toggle = FlatPermissionSwitch()
 
     var onToggle: ((Bool) -> Void)?
 
@@ -557,7 +557,6 @@ private final class PermissionRowCell: UITableViewCell {
         titleRowStack.addArrangedSubview(titleLabel)
         titleRowStack.addArrangedSubview(lockIcon)
 
-        toggle.onTintColor = UIColor.theme.bgViolet
         toggle.addTarget(self, action: #selector(switchChanged(_:)), for: .valueChanged)
         toggle.setContentHuggingPriority(.required, for: .horizontal)
         toggle.setContentCompressionResistancePriority(.required, for: .horizontal)
@@ -594,7 +593,137 @@ private final class PermissionRowCell: UITableViewCell {
         titleLabel.textColor = isDisabled ? UIColor.theme.textDisabled : .mezonTextPrimary
     }
 
-    @objc private func switchChanged(_ sender: UISwitch) {
+    @objc private func switchChanged(_ sender: FlatPermissionSwitch) {
         onToggle?(sender.isOn)
+    }
+}
+
+private final class FlatPermissionSwitch: UIControl {
+
+    private let trackView = UIView()
+    private let thumbView = UIView()
+    private(set) var isOn = false
+
+    override var intrinsicContentSize: CGSize {
+        CGSize(width: 52, height: 32)
+    }
+
+    override var isEnabled: Bool {
+        didSet {
+            updateAppearance(animated: false)
+        }
+    }
+
+    override var isHighlighted: Bool {
+        didSet {
+            UIView.animate(withDuration: 0.12) {
+                self.alpha = self.isHighlighted && self.isEnabled ? 0.82 : 1.0
+            }
+        }
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        isAccessibilityElement = true
+        accessibilityTraits = [.button]
+
+        trackView.isUserInteractionEnabled = false
+        trackView.layer.masksToBounds = true
+        addSubview(trackView)
+
+        thumbView.isUserInteractionEnabled = false
+        thumbView.layer.masksToBounds = true
+        addSubview(thumbView)
+
+        updateAppearance(animated: false)
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        updateAppearance(animated: false)
+    }
+
+    func setOn(_ isOn: Bool, animated: Bool) {
+        guard self.isOn != isOn else {
+            updateAppearance(animated: false)
+            return
+        }
+        self.isOn = isOn
+        updateAppearance(animated: animated)
+    }
+
+    override func beginTracking(_ touch: UITouch, with event: UIEvent?) -> Bool {
+        guard isEnabled else { return false }
+        isHighlighted = true
+        return true
+    }
+
+    override func endTracking(_ touch: UITouch?, with event: UIEvent?) {
+        defer { isHighlighted = false }
+        guard isEnabled, let location = touch?.location(in: self),
+              bounds.insetBy(dx: -12, dy: -12).contains(location) else {
+            return
+        }
+        setOn(!isOn, animated: true)
+        sendActions(for: .valueChanged)
+    }
+
+    override func cancelTracking(with event: UIEvent?) {
+        isHighlighted = false
+    }
+
+    private func updateAppearance(animated: Bool) {
+        let trackHeight = max(0, min(bounds.height - 4, 28))
+        let thumbDiameter = max(0, trackHeight - 2)
+        let horizontalInset: CGFloat = 3
+        let trackFrame = CGRect(
+            x: 0,
+            y: (bounds.height - trackHeight) / 2,
+            width: bounds.width,
+            height: trackHeight
+        )
+        let thumbX = isOn
+            ? bounds.width - thumbDiameter - horizontalInset
+            : horizontalInset
+        let thumbFrame = CGRect(
+            x: thumbX,
+            y: (bounds.height - thumbDiameter) / 2,
+            width: thumbDiameter,
+            height: thumbDiameter
+        )
+
+        let trackColor: UIColor
+        let thumbColor: UIColor
+        if isEnabled {
+            trackColor = isOn ? UIColor.theme.bgViolet : UIColor.theme.tertiary.withAlphaComponent(0.72)
+            thumbColor = .white
+        } else {
+            trackColor = isOn ? UIColor.theme.bgViolet.withAlphaComponent(0.38) : UIColor.theme.tertiary.withAlphaComponent(0.55)
+            thumbColor = UIColor.theme.textDisabled
+        }
+
+        let changes = {
+            self.trackView.frame = trackFrame
+            self.trackView.layer.cornerRadius = trackHeight / 2
+            self.trackView.backgroundColor = trackColor
+            self.thumbView.frame = thumbFrame
+            self.thumbView.layer.cornerRadius = thumbDiameter / 2
+            self.thumbView.backgroundColor = thumbColor
+        }
+
+        if animated {
+            UIView.animate(withDuration: 0.18, delay: 0, options: [.curveEaseInOut, .beginFromCurrentState], animations: changes)
+        } else {
+            changes()
+        }
+
+        accessibilityValue = isOn ? "On" : "Off"
+        if isOn {
+            accessibilityTraits.insert(.selected)
+        } else {
+            accessibilityTraits.remove(.selected)
+        }
     }
 }

--- a/MezonChat/Features/Components/MemberProfileSheetController.swift
+++ b/MezonChat/Features/Components/MemberProfileSheetController.swift
@@ -9,6 +9,11 @@ struct MemberProfileVoiceChannelActions {
     let onKick: () async throws -> Void
 }
 
+struct MemberProfileGroupAction {
+    let confirmUserLabel: String
+    let onRemove: () async throws -> Void
+}
+
 private final class VoiceActionClosureButton: UIButton {
     var onTap: (() -> Void)?
     init() {
@@ -208,6 +213,7 @@ final class MemberProfileSheetController: ViewController {
     private let context: AccountContext
     private let isCurrentUser: Bool
     private let voiceChannelActions: MemberProfileVoiceChannelActions?
+    private let groupAction: MemberProfileGroupAction?
     private let onDismiss: (() -> Void)?
     private let onSendMessage: ((Mezon_Api_ChannelDescription) -> Void)?
 
@@ -218,6 +224,7 @@ final class MemberProfileSheetController: ViewController {
         context: AccountContext,
         isCurrentUser: Bool = false,
         voiceChannelActions: MemberProfileVoiceChannelActions? = nil,
+        groupAction: MemberProfileGroupAction? = nil,
         onDismiss: (() -> Void)? = nil,
         onSendMessage: ((Mezon_Api_ChannelDescription) -> Void)? = nil
     ) {
@@ -225,6 +232,7 @@ final class MemberProfileSheetController: ViewController {
         self.context = context
         self.isCurrentUser = isCurrentUser
         self.voiceChannelActions = voiceChannelActions
+        self.groupAction = groupAction
         self.onDismiss = onDismiss
         self.onSendMessage = onSendMessage
         super.init(navigationBarPresentationData: nil)
@@ -239,6 +247,7 @@ final class MemberProfileSheetController: ViewController {
             user: user,
             isCurrentUser: isCurrentUser,
             voiceChannelActions: voiceChannelActions,
+            showRemoveFromGroup: groupAction != nil && !isCurrentUser,
             onSendMessageTapped: { [weak self] in
                 self?.handleSendMessage()
             },
@@ -250,6 +259,9 @@ final class MemberProfileSheetController: ViewController {
             },
             onVoiceKickTap: { [weak self] in
                 self?.presentVoiceKickConfirm()
+            },
+            onRemoveFromGroupTap: { [weak self] in
+                self?.presentRemoveFromGroupConfirm()
             }
         )
         displayNodeDidLoad()
@@ -303,6 +315,32 @@ final class MemberProfileSheetController: ViewController {
             }
         }
         present(vc, animated: true)
+    }
+
+    private func presentRemoveFromGroupConfirm() {
+        guard let action = groupAction else { return }
+        let alert = UIAlertController(
+            title: L(L10n.ChannelDetail.removeFromGroupConfirmTitle),
+            message: L(L10n.ChannelDetail.removeFromGroupConfirmBody, action.confirmUserLabel),
+            preferredStyle: .alert)
+        alert.addAction(UIAlertAction(
+            title: L(L10n.Common.cancel),
+            style: .cancel))
+        alert.addAction(UIAlertAction(
+            title: L(L10n.ChannelDetail.removeFromGroupConfirmAction),
+            style: .destructive,
+            handler: { [weak self] _ in
+                Task { @MainActor in
+                    guard let self else { return }
+                    do {
+                        try await action.onRemove()
+                        self.animateDismiss()
+                    } catch {
+                        Toast.error(L(L10n.ChannelDetail.removeFromGroupFailed))
+                    }
+                }
+            }))
+        present(alert, animated: true)
     }
 
     private func presentVoiceMeetError(_ error: Error) {
@@ -380,6 +418,7 @@ private final class MemberProfileSheetNode: ASDisplayNode {
     private let messageBtn = ProfileActionButton(icon: "bubble.left.fill", title: "Message")
     private let callBtn = ProfileActionButton(icon: "phone.fill", title: "Call")
     private let addFriendBtn = ProfileActionButton(icon: "person.badge.plus", title: "Add Friend", isGreen: true)
+    private let removeFromGroupButton = ASButtonNode()
 
     private let memberCardNode = ASDisplayNode()
     private let memberSinceTitleNode = ASTextNode2()
@@ -389,8 +428,10 @@ private final class MemberProfileSheetNode: ASDisplayNode {
     private let onDimTapped: () -> Void
     private let onVoiceMuteTap: () -> Void
     private let onVoiceKickTap: () -> Void
+    private let onRemoveFromGroupTap: () -> Void
     private let isCurrentUser: Bool
     private let voiceChannelActions: MemberProfileVoiceChannelActions?
+    private let showRemoveFromGroup: Bool
 
     private var containerHeight: CGFloat = 0
     private var validLayout: ContainerViewLayout?
@@ -409,18 +450,22 @@ private final class MemberProfileSheetNode: ASDisplayNode {
         user: Mezon_Api_User,
         isCurrentUser: Bool,
         voiceChannelActions: MemberProfileVoiceChannelActions?,
+        showRemoveFromGroup: Bool,
         onSendMessageTapped: @escaping () -> Void,
         onDimTapped: @escaping () -> Void,
         onVoiceMuteTap: @escaping () -> Void,
-        onVoiceKickTap: @escaping () -> Void
+        onVoiceKickTap: @escaping () -> Void,
+        onRemoveFromGroupTap: @escaping () -> Void
     ) {
         self.user = user
         self.isCurrentUser = isCurrentUser
         self.voiceChannelActions = voiceChannelActions
+        self.showRemoveFromGroup = showRemoveFromGroup
         self.onSendMessageTapped = onSendMessageTapped
         self.onDimTapped = onDimTapped
         self.onVoiceMuteTap = onVoiceMuteTap
         self.onVoiceKickTap = onVoiceKickTap
+        self.onRemoveFromGroupTap = onRemoveFromGroupTap
         super.init()
 
         let t = UIColor.theme
@@ -533,6 +578,18 @@ private final class MemberProfileSheetNode: ASDisplayNode {
         actionRow.addSubnode(messageBtn)
         actionRow.addSubnode(callBtn)
         actionRow.addSubnode(addFriendBtn)
+        if showRemoveFromGroup {
+            let danger = UIColor(red: 0.92, green: 0.25, blue: 0.25, alpha: 1)
+            removeFromGroupButton.setTitle(
+                L(L10n.ChannelDetail.removeFromGroup),
+                with: UIFont.systemFont(ofSize: 15.sf, weight: .semibold),
+                with: danger,
+                for: .normal)
+            removeFromGroupButton.backgroundColor = t.tertiary
+            removeFromGroupButton.cornerRadius = 10.sf
+            removeFromGroupButton.clipsToBounds = true
+            infoCardNode.addSubnode(removeFromGroupButton)
+        }
         containerNode.addSubnode(memberCardNode)
         memberCardNode.addSubnode(memberSinceTitleNode)
         memberCardNode.addSubnode(memberSinceDateNode)
@@ -569,6 +626,10 @@ private final class MemberProfileSheetNode: ASDisplayNode {
         messageBtn.onTapped = { [weak self] in self?.messageTapped() }
         callBtn.onTapped = { [weak self] in self?.callTapped() }
         addFriendBtn.onTapped = { [weak self] in self?.addFriendTapped() }
+        if showRemoveFromGroup {
+            removeFromGroupButton.addTarget(
+                self, action: #selector(removeFromGroupTapped), forControlEvents: .touchUpInside)
+        }
 
         let pan = UIPanGestureRecognizer(target: self, action: #selector(handlePan(_:)))
         pan.cancelsTouchesInView = false
@@ -649,6 +710,7 @@ private final class MemberProfileSheetNode: ASDisplayNode {
     }
 
     @objc private func dimTapped() { onDimTapped() }
+    @objc private func removeFromGroupTapped() { onRemoveFromGroupTap() }
     private func messageTapped() { onSendMessageTapped() }
     private func callTapped() {  }
     private func addFriendTapped() {  }
@@ -771,7 +833,16 @@ private final class MemberProfileSheetNode: ASDisplayNode {
         infoY += 12
         actionRow.frame = CGRect(x: infoCardPad, y: infoY, width: actionW, height: btnH)
         messageBtn.frame = CGRect(x: 0, y: 0, width: btnW, height: btnH)
-        infoY += btnH + infoBottomPad
+        infoY += btnH
+
+        if showRemoveFromGroup {
+            infoY += 12.sh
+            let removeH: CGFloat = 48.sh
+            removeFromGroupButton.frame = CGRect(x: infoCardPad, y: infoY, width: actionW, height: removeH)
+            infoY += removeH
+        }
+
+        infoY += infoBottomPad
 
         let infoCardH = infoY
         infoCardNode.frame = CGRect(x: pad, y: infoCardBaseTop, width: cardW, height: infoCardH)

--- a/MezonChat/Features/DirectMessages/DirectMessagesViewController.swift
+++ b/MezonChat/Features/DirectMessages/DirectMessagesViewController.swift
@@ -815,7 +815,8 @@ final class NewGroupDMViewController: ViewController, UITableViewDataSource, UIT
     private let context: AccountContext
     private let onChannelCreated: (Mezon_Api_ChannelDescription) -> Void
     private let existingGroupChannel: Mezon_Api_ChannelDescription?
-    private let excludedMemberIds: Set<Int64>
+    private var excludedMemberIds: Set<Int64>
+    private var existingMemberCountOverride: Int?
 
     private let headerView = UIView()
     private let backButton = UIButton(type: .system)
@@ -838,6 +839,7 @@ final class NewGroupDMViewController: ViewController, UITableViewDataSource, UIT
     private var searchText = ""
     private var isCreating = false
     private var refreshTask: Task<Void, Never>?
+    private var existingMembersRefreshTask: Task<Void, Never>?
     private var friendsUpdatedDisposable: Disposable?
 
     init(context: AccountContext, onChannelCreated: @escaping (Mezon_Api_ChannelDescription) -> Void) {
@@ -845,18 +847,37 @@ final class NewGroupDMViewController: ViewController, UITableViewDataSource, UIT
         self.onChannelCreated = onChannelCreated
         self.existingGroupChannel = nil
         self.excludedMemberIds = []
+        self.existingMemberCountOverride = nil
         super.init(navigationBarPresentationData: nil)
     }
 
     init(
         context: AccountContext,
         existingGroupChannel: Mezon_Api_ChannelDescription,
+        existingMemberIds: Set<Int64>? = nil,
+        existingMemberCount: Int? = nil,
         onMembersAdded: @escaping (Mezon_Api_ChannelDescription) -> Void
     ) {
         self.context = context
         self.onChannelCreated = onMembersAdded
         self.existingGroupChannel = existingGroupChannel
-        self.excludedMemberIds = Set(existingGroupChannel.userIds)
+        var excludedIds = Set(existingGroupChannel.userIds)
+        if let existingMemberIds, !existingMemberIds.isEmpty {
+            excludedIds.formUnion(existingMemberIds)
+        }
+        if let currentUserId = context.currentUser.flatMap({ Int64($0.id) }) {
+            excludedIds.insert(currentUserId)
+        }
+        self.excludedMemberIds = excludedIds
+        if let existingMemberCount {
+            self.existingMemberCountOverride = existingMemberCount
+        } else if let existingMemberIds, !existingMemberIds.isEmpty {
+            self.existingMemberCountOverride = existingMemberIds.count
+        } else if existingGroupChannel.memberCount > 0 {
+            self.existingMemberCountOverride = Int(existingGroupChannel.memberCount)
+        } else {
+            self.existingMemberCountOverride = nil
+        }
         super.init(navigationBarPresentationData: nil)
     }
 
@@ -865,6 +886,7 @@ final class NewGroupDMViewController: ViewController, UITableViewDataSource, UIT
     deinit {
         NotificationCenter.default.removeObserver(self)
         refreshTask?.cancel()
+        existingMembersRefreshTask?.cancel()
         friendsUpdatedDisposable?.dispose()
     }
 
@@ -875,6 +897,7 @@ final class NewGroupDMViewController: ViewController, UITableViewDataSource, UIT
         setupLayout()
         applyTheme()
         syncFriendsFromStore()
+        refreshExistingGroupMembersIfNeeded()
 
         NotificationCenter.default.addObserver(self, selector: #selector(handleThemeChanged), name: ThemeManager.didChangeNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleLanguageChanged), name: LanguageManager.didChangeNotification, object: nil)
@@ -1068,12 +1091,7 @@ final class NewGroupDMViewController: ViewController, UITableViewDataSource, UIT
     }
 
     private func updateMemberCount() {
-        let baseCount: Int
-        if let existing = existingGroupChannel {
-            baseCount = existing.userIds.count + 1
-        } else {
-            baseCount = 1
-        }
+        let baseCount = baseMemberCount()
         subtitleLabel.text = L(
             L10n.DirectMessage.memberCount,
             baseCount + selectedFriendIds.count,
@@ -1113,6 +1131,43 @@ final class NewGroupDMViewController: ViewController, UITableViewDataSource, UIT
             guard let self else { return }
             guard let token = await self.context.getTokenPreferringCachedSkipSessionReadyWait() else { return }
             await self.context.engine.friendsData.refreshFromNetwork(token: token)
+        }
+    }
+
+    private func refreshExistingGroupMembersIfNeeded() {
+        guard let existingGroup = existingGroupChannel else { return }
+        existingMembersRefreshTask?.cancel()
+        existingMembersRefreshTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard let token = await self.context.getTokenPreferringCachedSkipSessionReadyWait() else { return }
+            do {
+                let response = try await self.context.account.network.listChannelUsersUC(
+                    channelId: existingGroup.channelID,
+                    limit: 500,
+                    token: token
+                )
+                var ids = Set(response.userIds)
+                guard !ids.isEmpty else { return }
+                if let currentUserId = self.context.currentUser.flatMap({ Int64($0.id) }) {
+                    ids.insert(currentUserId)
+                }
+                self.excludedMemberIds.formUnion(ids)
+                self.existingMemberCountOverride = ids.count
+                self.selectedFriendIds.subtract(self.excludedMemberIds)
+                self.trimSelectionToMemberLimit()
+                let labels = existingGroup.dmMemberLabelsForChannelList()
+                self.context.account.postbox.write { tx in
+                    tx.applyAllUsersAddChannelResponse(
+                        response,
+                        channelId: existingGroup.channelID,
+                        dmMemberLabelByUserId: labels
+                    )
+                }
+                self.syncFriendsFromStore()
+                self.updateMemberCount()
+                self.updateCreateButtonState()
+            } catch {
+            }
         }
     }
 
@@ -1161,14 +1216,31 @@ final class NewGroupDMViewController: ViewController, UITableViewDataSource, UIT
         return username.isEmpty ? L(L10n.Common.detail) : username
     }
 
-    private func canSelectAdditionalFriend() -> Bool {
-        let baseCount: Int
+    private func baseMemberCount() -> Int {
         if let existing = existingGroupChannel {
-            baseCount = existing.userIds.count + 1
-        } else {
-            baseCount = 1
+            if let existingMemberCountOverride {
+                return existingMemberCountOverride
+            }
+            if existing.memberCount > 0 {
+                return Int(existing.memberCount)
+            }
+            var ids = Set(existing.userIds)
+            if let currentUserId = context.currentUser.flatMap({ Int64($0.id) }) {
+                ids.insert(currentUserId)
+            }
+            return max(ids.count, 1)
         }
-        return baseCount + selectedFriendIds.count < Self.maximumMembers
+        return 1
+    }
+
+    private func canSelectAdditionalFriend() -> Bool {
+        baseMemberCount() + selectedFriendIds.count < Self.maximumMembers
+    }
+
+    private func trimSelectionToMemberLimit() {
+        let remainingSlots = max(0, Self.maximumMembers - baseMemberCount())
+        guard selectedFriendIds.count > remainingSlots else { return }
+        selectedFriendIds = Set(selectedFriendIds.sorted().prefix(remainingSlots))
     }
 
     private func toggleSelection(for friend: Mezon_Api_Friend) {
@@ -1199,6 +1271,10 @@ final class NewGroupDMViewController: ViewController, UITableViewDataSource, UIT
     @objc private func createTapped() {
         guard !selectedFriendIds.isEmpty, !isCreating else { return }
         let selectedIds = Array(selectedFriendIds)
+        guard baseMemberCount() + selectedIds.count <= Self.maximumMembers else {
+            Toast.info(L(L10n.DirectMessage.memberLimitReached))
+            return
+        }
         isCreating = true
         updateCreateButtonState()
 
@@ -1221,6 +1297,19 @@ final class NewGroupDMViewController: ViewController, UITableViewDataSource, UIT
                     var merged = updated.userIds
                     for id in selectedIds where !merged.contains(id) { merged.append(id) }
                     updated.userIds = merged
+                    updated.memberCount = Int32(min(Self.maximumMembers, self.baseMemberCount() + selectedIds.count))
+                    if let members = try? await self.context.account.network.listChannelUsersUC(
+                        channelId: existingGroup.channelID, limit: 500, token: token
+                    ) {
+                        let labels = updated.dmMemberLabelsForChannelList()
+                        self.context.account.postbox.write { tx in
+                            tx.applyAllUsersAddChannelResponse(
+                                members,
+                                channelId: existingGroup.channelID,
+                                dmMemberLabelByUserId: labels
+                            )
+                        }
+                    }
                     self.onChannelCreated(updated)
                     self.navigationController?.popViewController(animated: true)
                 } catch {

--- a/MezonChat/Features/DirectMessages/DmListItemCell.swift
+++ b/MezonChat/Features/DirectMessages/DmListItemCell.swift
@@ -5,8 +5,6 @@ final class DmListItemCell: UITableViewCell {
 
     static let reuseId = "DmListItemCell"
 
-    private static let groupDmListPlaceholderOrange = UIColor(red: 249/255, green: 115/255, blue: 22/255, alpha: 1)
-
     private let textAvatar = TextAvatarView(username: "", size: 40.swh, fontSize: 16.sf)
 
     private let avatarImageView: UIImageView = {
@@ -181,7 +179,7 @@ final class DmListItemCell: UITableViewCell {
                 imageTask = nil
                 avatarImageView.image = nil
                 textAvatar.showImageMode()
-                textAvatar.backgroundColor = Self.groupDmListPlaceholderOrange
+                textAvatar.backgroundColor = .groupDMDefaultAvatar
                 groupIconView.tintColor = .white
                 groupIconView.isHidden = false
             }
@@ -335,7 +333,7 @@ final class DmListItemCell: UITableViewCell {
             return (Self.previewWhenNoMessageBody(), time)
         }
         let body = Self.normalizeJsonEscapedSlashes(in: preview)
-        return (body.count >= 20 ? body + "..." : body, time)
+        return (body.count >= 32 ? body + "..." : body, time)
     }
 
     private static let contentKeysAllowingEmptyAttachmentInference: Set<String> = ["t", "mk", "ej", "hg"]

--- a/MezonChat/Features/Main/MezonRootController.swift
+++ b/MezonChat/Features/Main/MezonRootController.swift
@@ -422,8 +422,29 @@ final class MezonRootController: NavigationController {
         return fallbackClanId
     }
 
+    private func isKnownDirectMessageChannel(channelId: Int64) -> Bool {
+        if let found = directMessagesController?.directMessages.first(where: { $0.channelID == channelId }) {
+            return found.type == MezonConstants.ChannelType.dm.rawValue
+                || found.type == MezonConstants.ChannelType.group.rawValue
+                || found.clanID == 0
+        }
+        if let cached = context.account.postbox.getDMChannelDescription(channelId: channelId) {
+            return cached.type == MezonConstants.ChannelType.dm.rawValue
+                || cached.type == MezonConstants.ChannelType.group.rawValue
+                || cached.clanID == 0
+        }
+        return false
+    }
+
     private func navigateToChannel(channelIdStr: String, clanIdStr: String?) {
         guard let channelIdInt = Int64(channelIdStr) else { return }
+        let notificationClanId: Int64? = clanIdStr.flatMap { Int64($0) }
+
+        if notificationClanId == 0 || (notificationClanId == nil && isKnownDirectMessageChannel(channelId: channelIdInt)) {
+            navigateToDM(channelIdStr: channelIdStr)
+            return
+        }
+
         if bringChatForChannelToFrontIfOnStack(channelIdInt: channelIdInt, clanIdStr: clanIdStr) { return }
 
         rootTabController?.selectedIndex = 0
@@ -431,8 +452,6 @@ final class MezonRootController: NavigationController {
         popToTabBarController()
 
         guard let homeVC = homeController else { return }
-
-        let notificationClanId: Int64? = clanIdStr.flatMap { Int64($0) }
 
         if let (cachedClanId, cachedChannel) = context.account.postbox.getChannelDescription(channelId: channelIdInt) {
             let resolvedClanId = resolvedClanIdForOpenChat(
@@ -495,6 +514,11 @@ final class MezonRootController: NavigationController {
             )
             chatVC.markNextFetchPrefersHTTPFirst()
             pushViewController(chatVC, animated: false)
+            return
+        }
+
+        if notificationClanId == nil {
+            navigateToDM(channelIdStr: channelIdStr)
             return
         }
 
@@ -589,8 +613,7 @@ final class MezonRootController: NavigationController {
             do {
                 let channels = try await self.context.account.network.listChannelDescs(clanId: clanId, token: token)
                 guard self.context.isStillCurrentSession(epoch: startEpoch) else { return }
-                let hadCache = (self.context.account.postbox.getPreferenceData(key: PreferencesKeys.channelList(clanId: clanId))?.isEmpty == false)
-                if channels.isEmpty && hadCache {
+                if channels.isEmpty {
                     if let homeVC = self.homeController, homeVC.channelListVC.clanId == clanId,
                        let selectChannelId {
                         homeVC.channelListVC.selectWithoutNavigation(channelId: selectChannelId)

--- a/MezonChat/Features/Search/SearchViewController.swift
+++ b/MezonChat/Features/Search/SearchViewController.swift
@@ -2007,7 +2007,6 @@ final class SearchFilterTooltipView: UIView {
 
 final class DMGroupSearchCellNode: ASCellNode {
 
-    private static let groupPlaceholderOrange = UIColor(red: 249/255, green: 115/255, blue: 22/255, alpha: 1)
     private static let avatarSize: CGFloat = 40.sf
     private static let margin: CGFloat = 12.sf
     private static let padding: CGFloat = 16.sf
@@ -2053,7 +2052,7 @@ final class DMGroupSearchCellNode: ASCellNode {
             }
             groupIconNode.isHidden = true
         } else {
-            avatarBackplate.backgroundColor = Self.groupPlaceholderOrange
+            avatarBackplate.backgroundColor = .groupDMDefaultAvatar
             groupIconNode.image = UIImage(systemName: "person.2.fill")?.withRenderingMode(.alwaysTemplate)
             groupIconNode.tintColor = .white
             groupIconNode.contentMode = .scaleAspectFit

--- a/MezonChat/Networking/MezonHTTPClient.swift
+++ b/MezonChat/Networking/MezonHTTPClient.swift
@@ -89,6 +89,87 @@ final class MezonHTTPClient {
         protoBaseURL = MezonConfig.protoBaseURL
     }
 
+    private static let transientRetryDelaysNanoseconds: [UInt64] = [
+        350_000_000,
+        1_000_000_000
+    ]
+
+    private func retryingTransientRequest<Response>(
+        operationName: String,
+        operation: () async throws -> Response
+    ) async throws -> Response {
+        var attempt = 1
+        while true {
+            do {
+                return try await operation()
+            } catch {
+                if error is CancellationError || Task.isCancelled {
+                    throw error
+                }
+                guard attempt <= Self.transientRetryDelaysNanoseconds.count,
+                      Self.isRetriableTransientError(error) else {
+                    throw error
+                }
+
+                let delay = Self.transientRetryDelaysNanoseconds[attempt - 1]
+                MezonRPCLog.response("\(operationName) transient fail attempt=\(attempt) retryDelayMs=\(delay / 1_000_000) error=\(error.localizedDescription)")
+                attempt += 1
+                try await Task.sleep(nanoseconds: delay)
+            }
+        }
+    }
+
+    private static func isRetriableTransientError(_ error: Error) -> Bool {
+        if error is CancellationError {
+            return false
+        }
+
+        if let mezonError = error as? MezonError {
+            switch mezonError {
+            case .invalidResponse, .socketError:
+                return true
+            case .httpError(let statusCode, _):
+                return statusCode == 0
+                    || statusCode == 408
+                    || statusCode == 425
+                    || statusCode == 429
+                    || (500...599).contains(statusCode)
+            }
+        }
+
+        if let urlError = error as? URLError {
+            return isRetriableURLErrorCode(urlError.code)
+        }
+
+        let nsError = error as NSError
+        if nsError.domain == NSURLErrorDomain {
+            return isRetriableURLErrorCode(URLError.Code(rawValue: nsError.code))
+        }
+
+        return false
+    }
+
+    private static func isRetriableURLErrorCode(_ code: URLError.Code) -> Bool {
+        switch code {
+        case .timedOut,
+             .cannotFindHost,
+             .cannotConnectToHost,
+             .networkConnectionLost,
+             .dnsLookupFailed,
+             .notConnectedToInternet,
+             .secureConnectionFailed,
+             .cannotLoadFromNetwork,
+             .internationalRoamingOff,
+             .callIsActive,
+             .dataNotAllowed,
+             .badServerResponse,
+             .cannotParseResponse:
+            return true
+        default:
+            return false
+        }
+    }
+
     func updateUsername(username: String, token: String) async throws -> Mezon_Api_Session {
         var req = Mezon_Api_UpdateUsernameRequest()
         req.username = username
@@ -897,21 +978,25 @@ final class MezonHTTPClient {
         limit: Int32 = 50,
         topicId: Int64 = 0,
         token: String,
-        preferHTTPFirst: Bool = false
+        preferHTTPFirst: Bool = true
     ) async throws -> Mezon_Api_ChannelMessageList {
-        var req = Mezon_Api_ListChannelMessagesRequest()
-        req.clanID = clanId
-        req.channelID = channelId
-        req.messageID = messageId
-        req.direction = direction
-        req.limit = limit
-        req.topicID = topicId
-        return try await postProto(
-            path: "/mezon.api.Mezon/ListChannelMessages",
-            message: req,
-            auth: .bearer(token),
-            preferHTTPFirst: preferHTTPFirst
-        )
+        try await retryingTransientRequest(
+            operationName: "ListChannelMessages clanId=\(clanId) channelId=\(channelId) messageId=\(messageId) direction=\(direction)"
+        ) {
+            var req = Mezon_Api_ListChannelMessagesRequest()
+            req.clanID = clanId
+            req.channelID = channelId
+            req.messageID = messageId
+            req.direction = direction
+            req.limit = limit
+            req.topicID = topicId
+            return try await self.postProto(
+                path: "/mezon.api.Mezon/ListChannelMessages",
+                message: req,
+                auth: .bearer(token),
+                preferHTTPFirst: preferHTTPFirst
+            )
+        }
     }
 
     func updateChannelDesc(


### PR DESCRIPTION
## Summary

- Fix media tab load-more in channel detail for group DMs (and DMs).
- Complete add/remove members for group DMs from the member list and friend picker composer.

## 1. Root Cause

### Media load-more

- [ ] `listChannelAttachments` was called with the wrong `clanId` for DM/group channels (empty or incorrect pagination).
- [ ] Pagination cursor (`before`) or `hasMoreMedia` did not match post-filter results (visual-only / dedup) → scroll did not load more or repeated requests.
- [ ] `isLoadingMore` / `mediaFetchCompleted` blocked load-more when scrolling near the bottom of the grid.
- [ ] Other: _short description_

### Group DM — add/remove members

- [ ] After `addChannelUsers`, postbox / `memberCount` / DM list labels were not updated.
- [ ] Add-member composer did not exclude existing members or enforced the 20-member cap incorrectly.
- [ ] Remove member: creator-only flow did not update UI/API/postbox after `removeChannelUsers`.
- [ ] Member list refresh after add was too early (backend eventual consistency).
- [ ] Other: _short description_

## 2. Solution

### Media (`MediaGalleryNode`)

- Call the attachments API with `clanId = 0` for DM and group DM channels.
- Load-more: use `before = createTimeSeconds` of the oldest item; dedupe by `id`/`url`; append only visual attachments; clear `hasMoreMedia` when the page is empty after filtering.
- Trigger load-more when scrolling near the bottom (~1.5× viewport height from the end).

### Group DM members

- **Add:** `MemberListNode` → `NewGroupDMViewController` (existing group mode): `addChannelUsers`, merge `userIds`, `listChannelUsersUC` + `applyAllUsersAddChannelResponse`, callback to refresh the member list (with retries if needed).
- **Remove:** Creator opens member profile → `removeChannelUsers` + `updateChannelMembers` on postbox + success toast.
- **Composer:** `excludedMemberIds` / `existingMemberCount` / refresh current members before selecting more.

### Main files (update for your PR)

- `MezonChat/Features/ChannelDetail/Tabs/MediaGalleryNode.swift`
- `MezonChat/Features/ChannelDetail/Tabs/MemberListNode.swift`
- `MezonChat/Features/DirectMessages/DirectMessagesViewController.swift` (`NewGroupDMViewController`)
- _add any others_

## 3. Self-test

### Media tab (group DM)

- [x] Open a group DM with more than one page of images/videos → Media tab shows the initial grid.
- [ ] Scroll to the bottom → older items load; no duplicates.
- [ ] End of data → no infinite API calls / no stuck loading state.
- [ ] 1:1 DM and clan channels (if shared code paths) still load media correctly.

### Add members

- [ ] As creator: Members → Add Members → select friends → add succeeds.
- [ ] New members appear in the list (online/offline) and group title on the DM list updates.
- [ ] Existing members are not selectable again; at 20 members → limit toast.
- [ ] Non-creator cannot use the add flow (if that matches product rules).

### Remove members

- [ ] As creator: open another member’s profile → Remove → confirm → member disappears from the list.
- [ ] Removed user: behavior matches spec (toast / leave chat / etc.).
- [ ] No remove action for self or when not creator.

### Regression

- [ ] Create new group DM from the DM list still works.
- [ ] Chat, search, and DM mute are unaffected.
