### PR TITLE
fix: issue about block user

### DIFF
--- a/MezonChat/Core/AccountContext/AccountContextImpl.swift
+++ b/MezonChat/Core/AccountContext/AccountContextImpl.swift
@@ -49,6 +49,7 @@ final class AccountContextImpl: AccountContext {
 
     func applyCurrentUser(_ user: User) {
         currentUser = user
+        SentryLogger.setUser(username: user.username)
         NotificationCenter.default.post(name: .mezonAccountCurrentUserDidChange, object: nil)
     }
 
@@ -300,6 +301,7 @@ final class AccountContextImpl: AccountContext {
         account.network.resetProtoBaseURLToDefault()
         session = nil
         currentUser = nil
+        SentryLogger.setUser(username: nil)
         NotificationCenter.default.post(name: .mezonAccountCurrentUserDidChange, object: nil)
         currentClanId = 0
         currentChannel = nil

--- a/MezonChat/Core/MezonEngine/MezonEngine+ClanData.swift
+++ b/MezonChat/Core/MezonEngine/MezonEngine+ClanData.swift
@@ -547,12 +547,28 @@ extension MezonEngine {
                 |> deliverOnMainQueue).start(next: { [weak self] event in
                     guard let self else { return }
                     switch event {
-                    case .addFriend, .removeFriend, .blockFriend:
+                    case .blockFriend(let m):
+                        self.applyLocalBlockState(userId: m.userID, blocked: true)
+                        self.scheduleRefreshFromSocket()
+                    case .unBlockFriend(let m):
+                        self.applyLocalBlockState(userId: m.userID, blocked: false)
+                        self.scheduleRefreshFromSocket()
+                    case .addFriend, .removeFriend:
                         self.scheduleRefreshFromSocket()
                     default:
                         break
                     }
                 })
+        }
+
+        private func applyLocalBlockState(userId: Int64, blocked: Bool) {
+            guard userId != 0 else { return }
+            var list = allFriends()
+            guard let idx = list.firstIndex(where: { $0.user.id == userId }) else { return }
+            let newState = blocked ? EStateFriend.block.rawValue : EStateFriend.friend.rawValue
+            guard list[idx].state != newState else { return }
+            list[idx].state = newState
+            persistFriends(list)
         }
 
         func allFriends() -> [Mezon_Api_Friend] {
@@ -605,25 +621,14 @@ extension MezonEngine {
 
         private func performRefreshFromNetwork(token: String) async {
             let net = network
-            async let friendList = (try? net.listFriends(token: token, state: EStateFriend.friend.rawValue))?.friends
-            async let otherPendingList = (try? net.listFriends(token: token, state: EStateFriend.otherPending.rawValue))?.friends
-            async let myPendingList = (try? net.listFriends(token: token, state: EStateFriend.myPending.rawValue))?.friends
-            async let blockList = (try? net.listFriends(token: token, state: EStateFriend.block.rawValue))?.friends
-
-            let lists = [await friendList, await otherPendingList, await myPendingList, await blockList].compactMap { $0 }
+            guard let fetched = (try? await net.listFriends(token: token, limit: 100, state: -1))?.friends else { return }
             let cached = allFriends()
 
-            guard !lists.isEmpty else { return }
-
-            if lists.count == 4, isAllListsIdentical(lists), !cached.isEmpty {
-                return
-            }
+            guard !fetched.isEmpty || cached.isEmpty else { return }
 
             var dedupByUserId: [Int64: Mezon_Api_Friend] = [:]
-            for list in lists {
-                for friend in list {
-                    dedupByUserId[friend.user.id] = friend
-                }
+            for friend in fetched {
+                dedupByUserId[friend.user.id] = friend
             }
 
             guard !dedupByUserId.isEmpty || cached.isEmpty else { return }
@@ -637,14 +642,6 @@ extension MezonEngine {
                 return lName.localizedCaseInsensitiveCompare(rName) == .orderedAscending
             }
             persistFriends(Array(merged))
-        }
-
-        private func isAllListsIdentical(_ lists: [[Mezon_Api_Friend]]) -> Bool {
-            guard let first = lists.first, !first.isEmpty else { return false }
-            let firstSignature = first.map { "\($0.user.id):\($0.state)" }.sorted()
-            return lists.dropFirst().allSatisfy {
-                $0.map { "\($0.user.id):\($0.state)" }.sorted() == firstSignature
-            }
         }
 
         func removePendingRequest(userId: Int64) {

--- a/MezonChat/Core/UI/ReactionEmojiImageLoader.swift
+++ b/MezonChat/Core/UI/ReactionEmojiImageLoader.swift
@@ -111,6 +111,28 @@ enum ReactionEmojiImageLoader {
     }
 
     @discardableResult
+    static func loadAnimatedDataBestEffort(
+        emojiId: String, imgproxyFitSide: Int, completion: @escaping (Data?) -> Void
+    ) -> URLSessionDataTask? {
+        guard let direct = MezonConfig.emojiImageURL(emojiId: emojiId) else {
+            return loadDataBestEffort(emojiId: emojiId, imgproxyFitSide: imgproxyFitSide, completion: completion)
+        }
+        return loadData(from: direct) { data in
+            if data != nil {
+                completion(data)
+                return
+            }
+            guard let proxied = MezonConfig.emojiResourceURL(emojiId: emojiId, imgproxyFitSide: imgproxyFitSide),
+                proxied.absoluteString != direct.absoluteString
+            else {
+                completion(nil)
+                return
+            }
+            _ = loadData(from: proxied, completion: completion)
+        }
+    }
+
+    @discardableResult
     private static func loadData(from url: URL, completion: @escaping (Data?) -> Void) -> URLSessionDataTask? {
         let key = url.absoluteString
         if let cached = EmojiDataCache.shared.data(forKey: key) {

--- a/MezonChat/Core/Utils/SentryLogger.swift
+++ b/MezonChat/Core/Utils/SentryLogger.swift
@@ -20,12 +20,12 @@ enum SentryLogger {
         }
     }
 
-    static func setUser(id: String?, username: String?) {
-        guard let id else {
+    static func setUser(username: String?) {
+        guard let username, !username.isEmpty else {
             SentrySDK.setUser(nil)
             return
         }
-        let user = Sentry.User(userId: id)
+        let user = Sentry.User(userId: username)
         user.username = username
         SentrySDK.setUser(user)
     }

--- a/MezonChat/Features/Chat/Cells/MessageReactionsNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageReactionsNode.swift
@@ -455,7 +455,7 @@ final class ReactionPillNode: ASDisplayNode {
             return
         }
         let cacheKey = "reactionEmoji.\(currentId).100"
-        imageTask = ReactionEmojiImageLoader.loadDataBestEffort(
+        imageTask = ReactionEmojiImageLoader.loadAnimatedDataBestEffort(
             emojiId: currentId, imgproxyFitSide: 100
         ) { [weak self] data in
             guard let self, self.emojiId == currentId else { return }

--- a/MezonChat/Features/Chat/Cells/MessageTextContentNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageTextContentNode.swift
@@ -545,7 +545,7 @@ final class EmojiTextView: UIView {
         let scale = UIScreen.main.scale
         let pixelSide = max(displayPxSide * scale, CGFloat(imgproxyFitSide))
         let cacheKey = "emoji.\(emojiId).\(imgproxyFitSide)"
-        ReactionEmojiImageLoader.loadDataBestEffort(emojiId: emojiId, imgproxyFitSide: imgproxyFitSide) { [weak self, weak view] data in
+        ReactionEmojiImageLoader.loadAnimatedDataBestEffort(emojiId: emojiId, imgproxyFitSide: imgproxyFitSide) { [weak self, weak view] data in
             guard let view, view.superview != nil else { return }
             view.setData(data, displayPixelMaxSide: pixelSide, cacheKey: cacheKey)
             self?.setNeedsLayout()

--- a/MezonChat/Features/Chat/ChatContainerNode.swift
+++ b/MezonChat/Features/Chat/ChatContainerNode.swift
@@ -241,7 +241,8 @@ final class ChatContainerNode: ASDisplayNode {
             channelType: state.channelType,
             isPrivate: state.isPrivate,
             isAgeRestricted: state.isAgeRestricted,
-            isDM: isDM
+            isDM: isDM,
+            isBlocked: state.isPeerBlocked
         )
     }
 

--- a/MezonChat/Features/Chat/ChatHeaderNode.swift
+++ b/MezonChat/Features/Chat/ChatHeaderNode.swift
@@ -68,7 +68,7 @@ final class ChatHeaderNode: ASDisplayNode {
 
     func configure(
         title: String, subtitle: String? = nil, channelType: Int32, isPrivate: Bool,
-        isAgeRestricted: Bool, isDM: Bool = false
+        isAgeRestricted: Bool, isDM: Bool = false, isBlocked: Bool = false
     ) {
         let t = UIColor.theme
 
@@ -117,7 +117,7 @@ final class ChatHeaderNode: ASDisplayNode {
 
         if isDmOrGroup {
             channelIconNode.isHidden = true
-            callButtonNode.isHidden = !isDM 
+            callButtonNode.isHidden = !isDM || isBlocked
             videoCallButtonNode.isHidden = true
         } else {
             channelIconNode.isHidden = false

--- a/MezonChat/Features/Chat/ChatViewController.swift
+++ b/MezonChat/Features/Chat/ChatViewController.swift
@@ -277,6 +277,7 @@ struct ChatState {
     var isPrivate: Bool
     var isAgeRestricted: Bool
     var isDM: Bool
+    var isPeerBlocked: Bool
     var dmPeerUsername: String
     var dmPeerDisplayName: String
     var dmAvatarURL: String
@@ -294,7 +295,7 @@ struct ChatState {
 
     static let empty = ChatState(
         messages: [], channelLabel: "", channelType: 0, isPrivate: false, isAgeRestricted: false,
-        isDM: false, dmPeerUsername: "", dmPeerDisplayName: "", dmAvatarURL: "", dmGroupAvatarURL: "",
+        isDM: false, isPeerBlocked: false, dmPeerUsername: "", dmPeerDisplayName: "", dmAvatarURL: "", dmGroupAvatarURL: "",
         hasMoreOlder: false, hasMoreNewer: false, isLoadingMore: false, isLoadingNewer: false,
         isLoadingMessageContext: false,
         isLoading: false, errorMessage: nil, lastSeenMessageId: nil, currentUserId: nil,
@@ -2145,6 +2146,12 @@ final class ChatViewController: ViewController {
         }
     }
 
+    private var isDirectMessagePeerBlocked: Bool {
+        guard channel.type == MezonConstants.ChannelType.dm.rawValue else { return false }
+        guard let peerId = channel.userIds.first, peerId != 0 else { return false }
+        return context.engine.friendsData.blockedUserIds().contains(peerId)
+    }
+
     var currentState: ChatState {
         let labelFromMeta = parentChannelMeta?.label
         let resolvedParentName =
@@ -2157,6 +2164,7 @@ final class ChatViewController: ViewController {
             isPrivate: channel.channelPrivate != 0,
             isAgeRestricted: channel.ageRestricted != 0,
             isDM: clanId == 0,
+            isPeerBlocked: isDirectMessagePeerBlocked,
             dmPeerUsername: channel.usernames.first ?? "",
             dmPeerDisplayName: channel.displayNames.first ?? "",
             dmAvatarURL: channel.avatars.first ?? "",
@@ -2229,6 +2237,7 @@ final class ChatViewController: ViewController {
             var lastParentName = self.currentState.parentName
             var lastIsPrivate = self.currentState.isPrivate
             var lastIsAgeRestricted = self.currentState.isAgeRestricted
+            var lastIsPeerBlocked = self.currentState.isPeerBlocked
             var lastChannelLabel = self.currentState.channelLabel
             var lastChannelType = self.currentState.channelType
             var lastDmPeerUsername = self.currentState.dmPeerUsername
@@ -2239,7 +2248,8 @@ final class ChatViewController: ViewController {
             let merged = Signal<Void, NoError> { subscriber in
                 let d1 = self.needsReloadPipe.signal().start(next: { subscriber.putNext(()) })
                 let d2 = self.metadataOnlyPipe.signal().start(next: { subscriber.putNext(()) })
-                return ActionDisposable { d1.dispose(); d2.dispose() }
+                let d3 = self.context.engine.friendsData.friendsUpdated.signal().start(next: { subscriber.putNext(()) })
+                return ActionDisposable { d1.dispose(); d2.dispose(); d3.dispose() }
                 }
             return (merged
                 |> map { [weak self] _ in self?.currentState ?? .empty }
@@ -2264,6 +2274,7 @@ final class ChatViewController: ViewController {
                         || newState.parentName != lastParentName
                         || newState.isPrivate != lastIsPrivate
                         || newState.isAgeRestricted != lastIsAgeRestricted
+                        || newState.isPeerBlocked != lastIsPeerBlocked
                         || newState.channelLabel != lastChannelLabel
                         || newState.channelType != lastChannelType
                         || newState.dmPeerUsername != lastDmPeerUsername
@@ -2286,6 +2297,7 @@ final class ChatViewController: ViewController {
                     lastParentName = newState.parentName
                     lastIsPrivate = newState.isPrivate
                     lastIsAgeRestricted = newState.isAgeRestricted
+                    lastIsPeerBlocked = newState.isPeerBlocked
                     lastChannelLabel = newState.channelLabel
                     lastChannelType = newState.channelType
                     lastDmPeerUsername = newState.dmPeerUsername

--- a/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
+++ b/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
@@ -869,7 +869,19 @@ final class SendMessageInputViewController: UIViewController {
                                                name: .mezonChannelOverriddenPermissionsDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleSendPermissionContextChanged),
                                                name: .mezonRolesDidChange, object: nil)
+        disposables.add(
+            (context.engine.friendsData.friendsUpdated.signal() |> deliverOnMainQueue)
+                .start(next: { [weak self] _ in
+                    self?.refreshSendPermissionAvailability()
+                })
+        )
         refreshSendPermissionAvailability()
+        if channelStreamMode == MezonConstants.ChannelStreamMode.dm.rawValue {
+            Task { [weak self] in
+                guard let self, let token = await self.context.getToken() else { return }
+                await self.context.engine.friendsData.refreshFromNetwork(token: token)
+            }
+        }
     }
 
     @objc private func keyboardWillShow(_ notification: Notification) {
@@ -925,6 +937,12 @@ final class SendMessageInputViewController: UIViewController {
             || m == MezonConstants.ChannelStreamMode.group.rawValue
     }
 
+    private var isDirectMessageWithBlockedPeer: Bool {
+        guard channelStreamMode == MezonConstants.ChannelStreamMode.dm.rawValue else { return false }
+        guard let peerId = channel.userIds.first, peerId != 0 else { return false }
+        return context.engine.friendsData.blockedUserIds().contains(peerId)
+    }
+
     private func refreshSendPermissionAvailability() {
         let exempt = isChannelStreamExemptFromSendPermissionGate
         let chId = channel.channelID
@@ -932,7 +950,9 @@ final class SendMessageInputViewController: UIViewController {
             context.rolePermissions.ensureChannelPermissions(clanId: clanId, channelId: chId)
         }
         let blocked: Bool
-        if exempt || clanId == 0 || chId == 0 {
+        if isDirectMessageWithBlockedPeer {
+            blocked = true
+        } else if exempt || clanId == 0 || chId == 0 {
             blocked = false
         } else if !context.rolePermissions.hasResolvedChannelOverriddenPermissionsSnapshot(channelId: chId) {
             blocked = false

--- a/MezonChat/Networking/MezonSocket.swift
+++ b/MezonChat/Networking/MezonSocket.swift
@@ -45,6 +45,7 @@ enum SocketEvent {
     case userProfileUpdated(Mezon_Realtime_UserProfileUpdatedEvent)
     case removeFriend(Mezon_Realtime_RemoveFriend)
     case blockFriend(Mezon_Realtime_BlockFriend)
+    case unBlockFriend(Mezon_Realtime_UnblockFriend)
     case addFriend(Mezon_Realtime_AddFriend)
     case tokenSent(Mezon_Api_TokenSentEvent)
     case giveCoffee(Mezon_Api_GiveCoffeeEvent)
@@ -660,6 +661,8 @@ final class MezonSocket: NSObject {
             eventPipe.putNext(.removeFriend(m))
         case .blockFriend(let m):
             eventPipe.putNext(.blockFriend(m))
+        case .unBlockFriend(let m):
+            eventPipe.putNext(.unBlockFriend(m))
         case .addFriend(let m):
             eventPipe.putNext(.addFriend(m))
         case .tokenSentEvent(let m):


### PR DESCRIPTION
## Summary
Fix blocking review items 

## 1. Root Cause
### Blocking 1: New channel missing from list when cache is empty
- **Cause:** `mergeIntoClanChannelListPreferenceIfPresent` no-ops when the preference blob is empty.

## 2. Solution
- Append channel to cache / trigger list reload after create; add `CreateChannelIcon` or use the correct asset; disable UI while the create request is in flight.

## 3. Self-test
- [ ] User without `manageChannel`: cannot open create flow
- [ ] Empty / invalid name → error, no API call
- [ ] Text public/private, voice, stream all create successfully
- [ ] New channel appears in the list immediately (including empty cache edge case)
- [ ] Cancel closes the form without creating a channel