### PR TITLE
fix: issue about role & permission

### DIFF
--- a/MezonChat/Core/AccountContext/AccountContextImpl.swift
+++ b/MezonChat/Core/AccountContext/AccountContextImpl.swift
@@ -565,13 +565,17 @@ final class AccountContextImpl: AccountContext {
 
     func prepareForVoIPAnswerConnectivity() async -> Bool {
         let disk = SessionStore.load()
-        guard let baseSession = session ?? disk else { return false }
-        // Warm path: the app is already running with a live session and a
-        // connected signaling socket (e.g. VoIP push arrived while the user
-        // had the app open or backgrounded but not killed). Skip the refresh
-        // round-trip and the redundant socket reconnect — both add latency
-        // before we can deliver the answer SDP.
+        let candidates = [session, disk].compactMap { $0 }
+        guard let baseSession = candidates.first(where: { !$0.isExpired }) ?? candidates.first else {
+            return false
+        }
         if let s = session, !s.isExpired, account.socket.isConnected {
+            markSessionReady()
+            return true
+        }
+        if !baseSession.isExpired {
+            account.network.updateBaseURL(from: baseSession)
+            applySession(baseSession, user: currentUser, connectSocket: true, fetchAccount: false)
             markSessionReady()
             return true
         }
@@ -616,7 +620,7 @@ final class AccountContextImpl: AccountContext {
     }
 
     private func joinDirectMessageClanOnSocketConnected() {
-        account.socket.joinClanChat(clanId: 0)
+        joinDirectMessageSocketRoomOnSocketConnected()
 
         let cachedClanId: Int64
         if currentClanId != 0 {
@@ -630,6 +634,10 @@ final class AccountContextImpl: AccountContext {
             account.socket.joinClanChat(clanId: cachedClanId)
             currentClanId = cachedClanId
         }
+    }
+
+    private func joinDirectMessageSocketRoomOnSocketConnected() {
+        account.socket.joinClanChat(clanId: 0)
     }
 
     private func rejoinCurrentChannel() {
@@ -810,7 +818,9 @@ final class AccountContextImpl: AccountContext {
     private func handleSocketEvent(_ event: SocketEvent) {
         switch event {
         case .connected:
-            if !VoIPMinimalCallBootstrap.isMinimalChromeActive {
+            if VoIPMinimalCallBootstrap.isMinimalChromeActive {
+                joinDirectMessageSocketRoomOnSocketConnected()
+            } else {
                 joinDirectMessageClanOnSocketConnected()
                 rejoinCurrentChannel()
             }

--- a/MezonChat/Core/Localization/L10n.swift
+++ b/MezonChat/Core/Localization/L10n.swift
@@ -450,6 +450,7 @@ enum L10n {
         static let defaultRole            = "clanRoles.defaultRole"
         static let everyone               = "clanRoles.everyone"
         static let rolesCount             = "clanRoles.rolesCount"
+        static let member                 = "clanRoles.member"
         static let members                = "clanRoles.members"
         static let allMembers             = "clanRoles.allMembers"
         static let noRole                 = "clanRoles.noRole"
@@ -492,6 +493,7 @@ enum L10n {
         static let permissionsHeading     = "clanRoles.permissions.heading"
         static let permissionsSearch      = "clanRoles.permissions.search"
         static let permissionsNext        = "clanRoles.permissions.next"
+        static let permissionsNotFound    = "clanRoles.permissions.notFound"
         static let permissionNotAvailable = "clanRoles.permissions.notAvailable"
 
         static let membersTitle           = "clanRoles.members.title"
@@ -1264,11 +1266,12 @@ extension L10n {
 
         "clanRoles.title":                  "Roles",
         "clanRoles.roleDescription":        "Use roles to group your clan members and assign permissions.",
-        "clanRoles.defaultRole":            "Default permissions for all members.",
+        "clanRoles.defaultRole":            "Default permissions for all clan members.",
         "clanRoles.everyone":               "@everyone",
         "clanRoles.rolesCount":             "Roles — %d",
+        "clanRoles.member":                 "member",
         "clanRoles.members":                "members",
-        "clanRoles.allMembers":             "All members",
+        "clanRoles.allMembers":             "All clan members",
         "clanRoles.noRole":                 "No role yet. Tap + to create one.",
         "clanRoles.role":                   "Role",
         "clanRoles.save":                   "Save",
@@ -1276,7 +1279,7 @@ extension L10n {
         "clanRoles.failed":                 "Something went wrong. Try again.",
         "clanRoles.skipStep":               "Skip this step",
 
-        "clanRoles.create.title":           "Create New Role",
+        "clanRoles.create.title":           "Create a new role",
         "clanRoles.create.heading":         "Create a new role",
         "clanRoles.create.description":     "Roles represent a set of permissions assigned to a group of clan members.",
         "clanRoles.create.roleName":        "Role name",
@@ -1309,6 +1312,7 @@ extension L10n {
         "clanRoles.permissions.heading":    "Choose what members of this role can do.",
         "clanRoles.permissions.search":     "Search permission",
         "clanRoles.permissions.next":       "Next",
+        "clanRoles.permissions.notFound":   "No permissions found.",
         "clanRoles.permissions.notAvailable": "No description available for this permission.",
 
         "clanRoles.members.title":          "Add Members",
@@ -2137,11 +2141,12 @@ extension L10n {
 
         "clanRoles.title":                  "Vai trò",
         "clanRoles.roleDescription":        "Dùng vai trò để nhóm thành viên và phân quyền trong clan.",
-        "clanRoles.defaultRole":            "Quyền mặc định cho tất cả thành viên.",
+        "clanRoles.defaultRole":            "Quyền mặc định cho tất cả thành viên trong clan.",
         "clanRoles.everyone":               "@everyone",
         "clanRoles.rolesCount":             "Vai trò — %d",
+        "clanRoles.member":                 "thành viên",
         "clanRoles.members":                "thành viên",
-        "clanRoles.allMembers":             "Tất cả thành viên",
+        "clanRoles.allMembers":             "Tất cả thành viên trong clan",
         "clanRoles.noRole":                 "Chưa có vai trò nào. Nhấn + để tạo mới.",
         "clanRoles.role":                   "Vai trò",
         "clanRoles.save":                   "Lưu",
@@ -2182,6 +2187,7 @@ extension L10n {
         "clanRoles.permissions.heading":    "Chọn các quyền cho thành viên có vai trò này.",
         "clanRoles.permissions.search":     "Tìm quyền",
         "clanRoles.permissions.next":       "Tiếp theo",
+        "clanRoles.permissions.notFound":   "Không tìm thấy quyền nào.",
         "clanRoles.permissions.notAvailable": "Chưa có mô tả cho quyền này.",
 
         "clanRoles.members.title":          "Thêm thành viên",

--- a/MezonChat/Core/RolePermission/RolePermissionService.swift
+++ b/MezonChat/Core/RolePermission/RolePermissionService.swift
@@ -402,6 +402,13 @@ final class RolePermissionService {
     func canManageClan(clanId: Int64) -> Bool {
         return hasClanPermission(.manageClan, clanId: clanId)
     }
+
+    func canManageRoles(clanId: Int64) -> Bool {
+        if isClanOwner(clanId: clanId) { return true }
+        if hasClanPermission(.administrator, clanId: clanId) { return true }
+        if hasClanPermission(.manageClan, clanId: clanId) { return true }
+        return false
+    }
 }
 
 extension Notification.Name {

--- a/MezonChat/Features/Auth/UpdateUsername/UpdateUsernameViewController.swift
+++ b/MezonChat/Features/Auth/UpdateUsername/UpdateUsernameViewController.swift
@@ -63,17 +63,6 @@ final class UpdateUsernameViewController: BaseViewController, AuthScreenStatusBa
         return l
     }()
 
-    private lazy var errorLabel: UILabel = {
-        let l = UILabel()
-        l.font = .systemFont(ofSize: 13.sf)
-        l.textColor = .systemRed
-        l.textAlignment = .center
-        l.numberOfLines = 0
-        l.isHidden = true
-        l.translatesAutoresizingMaskIntoConstraints = false
-        return l
-    }()
-
     private lazy var actionButton: GradientButton = {
         let btn = GradientButton(type: .custom)
         btn.titleLabel?.font = .systemFont(ofSize: 16.sf, weight: .semibold)
@@ -172,7 +161,7 @@ final class UpdateUsernameViewController: BaseViewController, AuthScreenStatusBa
         altStack.spacing = 8.sh
         altStack.alignment = .center
 
-        let contentStack = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel, nameField, previewLabel, errorLabel, actionButton, altStack])
+        let contentStack = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel, nameField, previewLabel, actionButton, altStack])
         contentStack.axis = .vertical
         contentStack.spacing = 12.sh
         contentStack.setCustomSpacing(18.sh, after: titleLabel)
@@ -250,7 +239,6 @@ final class UpdateUsernameViewController: BaseViewController, AuthScreenStatusBa
     }
 
     @objc private func nameChanged() {
-        errorLabel.isHidden = true
         updatePreview()
         updateActionButtonEnabled()
     }
@@ -305,13 +293,11 @@ final class UpdateUsernameViewController: BaseViewController, AuthScreenStatusBa
         updateActionButtonEnabled()
         loadingIndicator.startAnimating()
         actionButton.isUserInteractionEnabled = false
-        errorLabel.isHidden = true
         do {
             let authSession = context.session ?? pendingSession
             let proto = try await context.account.network.updateUsername(username: sanitized, token: authSession.token)
             guard !proto.token.isEmpty else {
-                errorLabel.text = L(L10n.UpdateUsername.errorDuplicate)
-                errorLabel.isHidden = false
+                Toast.error(L(L10n.UpdateUsername.errorDuplicate))
                 finishLoading()
                 return
             }
@@ -329,8 +315,7 @@ final class UpdateUsernameViewController: BaseViewController, AuthScreenStatusBa
                 nav.filterController(self, animated: true)
             }
         } catch {
-            errorLabel.text = L(L10n.UpdateUsername.errorDuplicate)
-            errorLabel.isHidden = false
+            Toast.error(Self.toastMessage(for: error))
         }
         finishLoading()
     }
@@ -343,13 +328,25 @@ final class UpdateUsernameViewController: BaseViewController, AuthScreenStatusBa
     }
 
     private static func sanitizeUsername(_ raw: String) -> String {
-        let folded = raw.folding(options: .diacriticInsensitive, locale: .current)
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        let folded = trimmed.folding(options: .diacriticInsensitive, locale: .current)
         var out = ""
         out.reserveCapacity(folded.count)
         for scalar in folded.unicodeScalars where CharacterSet.alphanumerics.contains(scalar) {
             out.unicodeScalars.append(scalar)
         }
         return out
+    }
+
+    private static func toastMessage(for error: Error) -> String {
+        if case let MezonError.httpError(_, message) = error {
+            let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+        let message = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+        return message.isEmpty ? L(L10n.UpdateUsername.errorDuplicate) : message
     }
 }
 

--- a/MezonChat/Features/ChannelDetail/ThreadListViewController.swift
+++ b/MezonChat/Features/ChannelDetail/ThreadListViewController.swift
@@ -35,6 +35,8 @@ final class ThreadListViewController: ViewController {
     private static let joinedStatus: Int32 = 1
     private static let activePublicStatus: Int32 = 2
     private static let activePrivateStatus: Int32 = 3
+    private static let threadsPageLimit: Int32 = 50
+    private static let threadsMaxPages: Int32 = 40
 
     init(
         context: AccountContext,
@@ -324,7 +326,7 @@ final class ThreadListViewController: ViewController {
                 label: searchText,
                 token: token
             )
-            searchResults = Self.filterPrivateThreads(list.channeldesc)
+            searchResults = Self.sortedByLastActivity(Self.filterPrivateThreads(list.channeldesc))
             rebuildSections()
             tableView.reloadData()
         } catch {
@@ -332,11 +334,26 @@ final class ThreadListViewController: ViewController {
     }
 
     private func applyCachedThreadsIfAny() {
+        var cachedThreads: [Mezon_Api_ChannelDescription] = []
         guard let data = context.account.postbox.getPreferenceData(
             key: PreferencesKeys.threadList(clanId: clanId, parentChannelId: parentChannelId)
-        ) else { return }
+        ) else {
+            cachedThreads = cachedThreadChannelsFromChannelCaches()
+            if !cachedThreads.isEmpty {
+                allThreads = Self.sortedByLastActivity(Self.filterPrivateThreads(cachedThreads))
+                cachedClanMembersList = nil
+            }
+            return
+        }
         if let decoded = Self.decodeThreadListCache(data) {
-            allThreads = Self.filterPrivateThreads(decoded.channels)
+            cachedThreads = decoded.channels
+        }
+        let merged = Self.mergeThreads(
+            cachedThreads,
+            withFallback: cachedThreadChannelsFromChannelCaches()
+        )
+        if !merged.isEmpty {
+            allThreads = Self.filterPrivateThreads(merged)
             cachedClanMembersList = nil
         }
     }
@@ -359,13 +376,30 @@ final class ThreadListViewController: ViewController {
             }
             guard let token = await self.context.getToken() else { return }
             do {
-                let list = try await self.context.account.network.listThreadDescs(
-                    parentChannelId: self.parentChannelId,
-                    clanId: self.clanId,
-                    page: 1,
-                    token: token
+                var accumulated: [Mezon_Api_ChannelDescription] = []
+                var seenChannelIds = Set<Int64>()
+                var page: Int32 = 1
+                while page <= Self.threadsMaxPages {
+                    let list = try await self.context.account.network.listThreadDescs(
+                        parentChannelId: self.parentChannelId,
+                        clanId: self.clanId,
+                        page: page,
+                        limit: Self.threadsPageLimit,
+                        token: token
+                    )
+                    let seenBeforePage = seenChannelIds.count
+                    for ch in list.channeldesc where seenChannelIds.insert(ch.channelID).inserted {
+                        accumulated.append(ch)
+                    }
+                    if list.channeldesc.count < Int(Self.threadsPageLimit) { break }
+                    if seenChannelIds.count == seenBeforePage { break }
+                    page += 1
+                }
+                let merged = Self.mergeThreads(
+                    accumulated,
+                    withFallback: self.cachedThreadChannelsFromChannelCaches()
                 )
-                self.allThreads = Self.filterPrivateThreads(list.channeldesc)
+                self.allThreads = Self.filterPrivateThreads(merged)
                 self.cachedClanMembersList = nil
                 self.persistThreadsCache()
                 self.rebuildSections()
@@ -386,9 +420,10 @@ final class ThreadListViewController: ViewController {
             return
         }
 
-        let joined = Self.getJoinedThreadsRecent(allThreads)
-        let active = Self.getActivePublicThreadsRecent(allThreads)
-        let older = Self.getThreadsOlderThan30Days(allThreads)
+        let grouped = Self.groupThreads(allThreads)
+        let joined = grouped.joined
+        let active = grouped.active
+        let older = grouped.older
 
         var sections: [(String, [Mezon_Api_ChannelDescription])] = []
         if !joined.isEmpty {
@@ -437,41 +472,137 @@ final class ThreadListViewController: ViewController {
         }
     }
 
-    private static func sortedByLastSent(_ threads: [Mezon_Api_ChannelDescription]) -> [Mezon_Api_ChannelDescription] {
+    private static func sortedByLastActivity(_ threads: [Mezon_Api_ChannelDescription]) -> [Mezon_Api_ChannelDescription] {
         threads.sorted { a, b in
-            let ta: Int64 = a.hasLastSentMessage ? Int64(a.lastSentMessage.timestampSeconds) : 0
-            let tb: Int64 = b.hasLastSentMessage ? Int64(b.lastSentMessage.timestampSeconds) : 0
+            let ta = Int64(activityTimestamp(a) ?? 0)
+            let tb = Int64(activityTimestamp(b) ?? 0)
+            if ta == tb {
+                return String(a.channelID) < String(b.channelID)
+            }
             return ta > tb
         }
     }
 
-    private static func getActivePublicThreadsRecent(_ threads: [Mezon_Api_ChannelDescription]) -> [Mezon_Api_ChannelDescription] {
+    private static func groupThreads(_ threads: [Mezon_Api_ChannelDescription])
+        -> (joined: [Mezon_Api_ChannelDescription], active: [Mezon_Api_ChannelDescription], older: [Mezon_Api_ChannelDescription])
+    {
         let now = Date().timeIntervalSince1970
-        return sortedByLastSent(threads.filter { ch in
-            guard ch.channelPrivate == 0, ch.active == activePublicStatus else { return false }
-            guard ch.hasLastSentMessage else { return false }
-            let ts = TimeInterval(ch.lastSentMessage.timestampSeconds)
-            return now - ts < thirtyDays
-        })
+        var joined: [Mezon_Api_ChannelDescription] = []
+        var active: [Mezon_Api_ChannelDescription] = []
+        var older: [Mezon_Api_ChannelDescription] = []
+
+        for ch in sortedByLastActivity(threads) {
+            if isJoinedThread(ch), isRecentThread(ch, now: now) {
+                joined.append(ch)
+            } else if ch.channelPrivate == 0, ch.active == activePublicStatus, isRecentThread(ch, now: now) {
+                active.append(ch)
+            } else {
+                older.append(ch)
+            }
+        }
+
+        return (joined, active, older)
     }
 
-    private static func getJoinedThreadsRecent(_ threads: [Mezon_Api_ChannelDescription]) -> [Mezon_Api_ChannelDescription] {
-        let now = Date().timeIntervalSince1970
-        return sortedByLastSent(threads.filter { ch in
-            guard ch.active == joinedStatus else { return false }
-            guard ch.hasLastSentMessage else { return false }
-            let ts = TimeInterval(ch.lastSentMessage.timestampSeconds)
-            return now - ts < thirtyDays
-        })
+    private static func isJoinedThread(_ ch: Mezon_Api_ChannelDescription) -> Bool {
+        ch.active == joinedStatus || (ch.channelPrivate != 0 && ch.active == activePrivateStatus)
     }
 
-    private static func getThreadsOlderThan30Days(_ threads: [Mezon_Api_ChannelDescription]) -> [Mezon_Api_ChannelDescription] {
-        let now = Date().timeIntervalSince1970
-        return sortedByLastSent(threads.filter { ch in
-            guard ch.hasLastSentMessage else { return false }
-            let ts = TimeInterval(ch.lastSentMessage.timestampSeconds)
-            return now - ts >= thirtyDays
-        })
+    private static func isRecentThread(_ ch: Mezon_Api_ChannelDescription, now: TimeInterval) -> Bool {
+        guard let ts = activityTimestamp(ch) else { return false }
+        return now - TimeInterval(ts) < thirtyDays
+    }
+
+    private static func activityTimestamp(_ ch: Mezon_Api_ChannelDescription) -> UInt32? {
+        if ch.hasLastSentMessage, ch.lastSentMessage.timestampSeconds > 0 {
+            return ch.lastSentMessage.timestampSeconds
+        }
+        if ch.createTimeSeconds > 0 { return ch.createTimeSeconds }
+        if ch.updateTimeSeconds > 0 { return ch.updateTimeSeconds }
+        return nil
+    }
+
+    private static func mergeThreads(
+        _ primary: [Mezon_Api_ChannelDescription],
+        withFallback fallback: [Mezon_Api_ChannelDescription]
+    ) -> [Mezon_Api_ChannelDescription] {
+        var byId: [Int64: Mezon_Api_ChannelDescription] = [:]
+
+        func upsert(_ incoming: Mezon_Api_ChannelDescription) {
+            guard incoming.channelID != 0 else { return }
+            if let existing = byId[incoming.channelID] {
+                byId[incoming.channelID] = mergeThread(existing, with: incoming)
+            } else {
+                byId[incoming.channelID] = incoming
+            }
+        }
+
+        fallback.forEach(upsert)
+        primary.forEach(upsert)
+        return sortedByLastActivity(Array(byId.values))
+    }
+
+    private static func mergeThread(
+        _ existing: Mezon_Api_ChannelDescription,
+        with incoming: Mezon_Api_ChannelDescription
+    ) -> Mezon_Api_ChannelDescription {
+        var result = incoming
+        if result.clanID == 0 { result.clanID = existing.clanID }
+        if result.parentID == 0 { result.parentID = existing.parentID }
+        if result.categoryID == 0 { result.categoryID = existing.categoryID }
+        if result.type == 0 { result.type = existing.type }
+        if result.channelLabel.isEmpty { result.channelLabel = existing.channelLabel }
+        if result.active == 0 { result.active = existing.active }
+        if result.channelPrivate == 0,
+           existing.channelPrivate != 0,
+           result.active == activePrivateStatus {
+            result.channelPrivate = existing.channelPrivate
+        }
+        if result.createTimeSeconds == 0 { result.createTimeSeconds = existing.createTimeSeconds }
+        if result.updateTimeSeconds == 0 { result.updateTimeSeconds = existing.updateTimeSeconds }
+
+        if shouldUseFallbackLastMessage(result, fallback: existing) {
+            result.lastSentMessage = existing.lastSentMessage
+        }
+        if !result.hasLastSeenMessage, existing.hasLastSeenMessage {
+            result.lastSeenMessage = existing.lastSeenMessage
+        }
+        return result
+    }
+
+    private static func shouldUseFallbackLastMessage(
+        _ result: Mezon_Api_ChannelDescription,
+        fallback: Mezon_Api_ChannelDescription
+    ) -> Bool {
+        guard fallback.hasLastSentMessage else { return false }
+        if !result.hasLastSentMessage { return true }
+        return fallback.lastSentMessage.timestampSeconds > result.lastSentMessage.timestampSeconds
+    }
+
+    private func cachedThreadChannelsFromChannelCaches() -> [Mezon_Api_ChannelDescription] {
+        var candidates: [Mezon_Api_ChannelDescription] = []
+        if let data = context.account.postbox.getPreferenceData(key: PreferencesKeys.channelList(clanId: clanId)) {
+            candidates.append(contentsOf: ChannelPreferenceListCodec.decode(data))
+        }
+        if let allChannelsByUser = context.engine.clanData.getAllChannelsByUser()?.channeldesc {
+            candidates.append(contentsOf: allChannelsByUser)
+        }
+        return Self.mergeThreads(
+            Self.threadChildren(candidates, parentChannelId: parentChannelId, clanId: clanId),
+            withFallback: []
+        )
+    }
+
+    private static func threadChildren(
+        _ channels: [Mezon_Api_ChannelDescription],
+        parentChannelId: Int64,
+        clanId: Int64
+    ) -> [Mezon_Api_ChannelDescription] {
+        channels.filter { ch in
+            ch.parentID == parentChannelId
+                && ch.channelID != 0
+                && (ch.clanID == 0 || ch.clanID == clanId)
+        }
     }
 
     private static func encodeThreadListCache(_ channels: [Mezon_Api_ChannelDescription]) -> Data {

--- a/MezonChat/Features/ChannelSettings/Permissions/ChannelPermissionsRepository.swift
+++ b/MezonChat/Features/ChannelSettings/Permissions/ChannelPermissionsRepository.swift
@@ -43,6 +43,10 @@ final class ChannelPermissionsRepository {
         role.slug == "everyone-\(role.clanID)"
     }
 
+    func roleIsInChannel(_ role: Mezon_Api_Role, channelId: Int64) -> Bool {
+        role.channelIds.contains(channelId)
+    }
+
     func clanOwnerId(clanId: Int64) -> String? {
         context.engine.account.postbox.read { tx in
             tx.getClan(id: clanId)?.ownerId
@@ -153,7 +157,7 @@ final class ChannelPermissionsRepository {
     }
 
     func channelRoles(clanId: Int64, channelId: Int64) -> [Mezon_Api_Role] {
-        roles(clanId: clanId).filter { $0.roleChannelActive == 1 && !isEveryone($0) }
+        roles(clanId: clanId).filter { roleIsInChannel($0, channelId: channelId) && !isEveryone($0) }
     }
 
     // MARK: - Mutations
@@ -167,6 +171,7 @@ final class ChannelPermissionsRepository {
             throw NSError(domain: "session", code: -1)
         }
         let uid: Int64 = (context.currentUser?.id).flatMap(Int64.init) ?? 0
+        // UpdateChannelPrivate uses an action flag: 0 makes private, 1 publishes.
         try await context.engine.account.network.changeChannelPrivate(
             clanId: clanId,
             channelId: channelId,
@@ -175,6 +180,9 @@ final class ChannelPermissionsRepository {
             roleIds: [],
             token: token
         )
+        if makePrivate {
+            clearLocalRoleChannels(clanId: clanId, channelId: channelId)
+        }
         context.engine.clanData.updateChannelPrivateLocally(
             clanId: clanId, channelId: channelId, isPrivate: makePrivate
         )
@@ -197,7 +205,7 @@ final class ChannelPermissionsRepository {
             channelId: channelId,
             token: token
         )
-        mutateLocalRoleChannelActive(clanId: clanId, roleId: roleId, active: 0)
+        removeLocalRoleChannel(clanId: clanId, roleId: roleId, channelId: channelId)
     }
 
     func addChannelMembers(channelId: Int64, userIds: [Int64]) async throws {
@@ -217,7 +225,7 @@ final class ChannelPermissionsRepository {
             token: token
         )
         for roleId in roleIds {
-            mutateLocalRoleChannelActive(clanId: clanId, roleId: roleId, active: 1)
+            addLocalRoleChannel(clanId: clanId, roleId: roleId, channelId: channelId)
         }
     }
 
@@ -271,12 +279,41 @@ final class ChannelPermissionsRepository {
 
     // MARK: - Local cache mutation
 
-    private func mutateLocalRoleChannelActive(clanId: Int64, roleId: Int64, active: Int32) {
+    private func addLocalRoleChannel(clanId: Int64, roleId: Int64, channelId: Int64) {
         var container = context.engine.clanData.getClanRoles(clanId: clanId) ?? Mezon_Api_RoleListEventResponse()
         guard let idx = container.roles.roles.firstIndex(where: { $0.id == roleId }) else { return }
         var role = container.roles.roles[idx]
-        role.roleChannelActive = active
+        if !role.channelIds.contains(channelId) {
+            role.channelIds.append(channelId)
+        }
         container.roles.roles[idx] = role
+        persistLocalRoles(container, clanId: clanId)
+    }
+
+    private func removeLocalRoleChannel(clanId: Int64, roleId: Int64, channelId: Int64) {
+        var container = context.engine.clanData.getClanRoles(clanId: clanId) ?? Mezon_Api_RoleListEventResponse()
+        guard let idx = container.roles.roles.firstIndex(where: { $0.id == roleId }) else { return }
+        var role = container.roles.roles[idx]
+        role.channelIds.removeAll { $0 == channelId }
+        container.roles.roles[idx] = role
+        persistLocalRoles(container, clanId: clanId)
+    }
+
+    private func clearLocalRoleChannels(clanId: Int64, channelId: Int64) {
+        var container = context.engine.clanData.getClanRoles(clanId: clanId) ?? Mezon_Api_RoleListEventResponse()
+        var changed = false
+        for idx in container.roles.roles.indices {
+            let before = container.roles.roles[idx].channelIds.count
+            container.roles.roles[idx].channelIds.removeAll { $0 == channelId }
+            if container.roles.roles[idx].channelIds.count != before {
+                changed = true
+            }
+        }
+        guard changed else { return }
+        persistLocalRoles(container, clanId: clanId)
+    }
+
+    private func persistLocalRoles(_ container: Mezon_Api_RoleListEventResponse, clanId: Int64) {
         if let data = try? container.serializedData() {
             context.engine.account.postbox.setPreferenceDataSync(
                 key: PreferencesKeys.clanRoles(clanId: clanId), value: data)

--- a/MezonChat/Features/ChannelSettings/Permissions/ChannelPermissionsViewController.swift
+++ b/MezonChat/Features/ChannelSettings/Permissions/ChannelPermissionsViewController.swift
@@ -20,6 +20,7 @@ final class ChannelPermissionsViewController: BaseViewController {
     private var channelMembers: [ClanMemberRecord] = []
 
     private var fetchMembersTask: Task<Void, Never>?
+    private var privacyUpdateInFlight = false
 
     private var currentTab: Tab = .basic
 
@@ -210,6 +211,7 @@ final class ChannelPermissionsViewController: BaseViewController {
         privateToggleCard.translatesAutoresizingMaskIntoConstraints = false
 
         let tap = UITapGestureRecognizer(target: self, action: #selector(privateCardTapped))
+        tap.delegate = self
         privateToggleCard.addGestureRecognizer(tap)
         privateToggleCard.isUserInteractionEnabled = true
 
@@ -236,6 +238,7 @@ final class ChannelPermissionsViewController: BaseViewController {
     }
 
     @objc private func privateCardTapped() {
+        guard !privacyUpdateInFlight else { return }
         privateSwitch.setOn(!privateSwitch.isOn, animated: true)
         privateSwitchChanged()
     }
@@ -480,8 +483,15 @@ final class ChannelPermissionsViewController: BaseViewController {
     // MARK: - Toggle private
 
     @objc private func privateSwitchChanged() {
+        guard !privacyUpdateInFlight else {
+            privateSwitch.setOn(isPrivate, animated: true)
+            return
+        }
         let newPrivate = privateSwitch.isOn
+        guard newPrivate != isPrivate else { return }
         let previous = isPrivate
+        privacyUpdateInFlight = true
+        privateSwitch.isEnabled = false
         fetchMembersTask?.cancel()
         fetchMembersTask = nil
         Task { [weak self] in
@@ -499,9 +509,14 @@ final class ChannelPermissionsViewController: BaseViewController {
                 Toast.success(L(L10n.ChannelPermission.toastSuccess))
                 await self.refresh()
             } catch {
+                self.isPrivate = previous
                 self.privateSwitch.setOn(previous, animated: true)
+                self.refreshVisibility()
+                self.rebuildList()
                 Toast.error(L(L10n.ChannelPermission.toastFailed))
             }
+            self.privacyUpdateInFlight = false
+            self.privateSwitch.isEnabled = true
         }
     }
 
@@ -512,7 +527,7 @@ final class ChannelPermissionsViewController: BaseViewController {
         let allRoles = repository.roles(clanId: clanId)
         let memberPool = allMembers.filter { !channelMemberIds.contains($0.userId) }
         let rolePool = allRoles.filter { role in
-            !repository.isEveryone(role) && role.roleChannelActive != 1
+            !repository.isEveryone(role) && !repository.roleIsInChannel(role, channelId: channelId)
         }
         let sheet = AddMemberOrRoleSheetController(
             availableMembers: memberPool,
@@ -654,5 +669,18 @@ final class ChannelPermissionsViewController: BaseViewController {
             } : nil
         )
         return row
+    }
+}
+
+extension ChannelPermissionsViewController: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        var view: UIView? = touch.view
+        while let current = view {
+            if current is UIControl {
+                return false
+            }
+            view = current.superview
+        }
+        return true
     }
 }

--- a/MezonChat/Features/ChannelSettings/Permissions/Components/AddMemberOrRoleSheetController.swift
+++ b/MezonChat/Features/ChannelSettings/Permissions/Components/AddMemberOrRoleSheetController.swift
@@ -254,7 +254,9 @@ extension AddMemberOrRoleSheetController: UITableViewDataSource, UITableViewDele
             } else {
                 selectedRoleIds.insert(role.id)
             }
-            tableView.reloadRows(at: [indexPath], with: .none)
+            if let cell = tableView.cellForRow(at: indexPath) as? ChannelPermissionRowCell {
+                cell.setTrailing(.checkbox(checked: selectedRoleIds.contains(role.id)))
+            }
             refreshAddButton()
         case .member(let member):
             if selectedMemberIds.contains(member.userId) {
@@ -262,7 +264,9 @@ extension AddMemberOrRoleSheetController: UITableViewDataSource, UITableViewDele
             } else {
                 selectedMemberIds.insert(member.userId)
             }
-            tableView.reloadRows(at: [indexPath], with: .none)
+            if let cell = tableView.cellForRow(at: indexPath) as? ChannelPermissionRowCell {
+                cell.setTrailing(.checkbox(checked: selectedMemberIds.contains(member.userId)))
+            }
             refreshAddButton()
         case .sectionHeader:
             break

--- a/MezonChat/Features/ChannelSettings/Permissions/Components/ChannelPermissionRowCell.swift
+++ b/MezonChat/Features/ChannelSettings/Permissions/Components/ChannelPermissionRowCell.swift
@@ -22,6 +22,7 @@ final class ChannelPermissionRowCell: UITableViewCell {
     private let checkboxView = UIImageView()
     private let chevron = UIImageView()
     private var imageTask: URLSessionDataTask?
+    private var configuredAvatarURL: String?
 
     var onRemoveTapped: (() -> Void)?
 
@@ -144,13 +145,17 @@ final class ChannelPermissionRowCell: UITableViewCell {
         avatarInitials.isHidden = false
 
         imageTask?.cancel()
+        imageTask = nil
+        configuredAvatarURL = nil
         avatarView.image = nil
         avatarView.backgroundColor = UIColor.theme.tertiary
         if let urlString = avatarURL, !urlString.isEmpty {
             let resolved = ImgproxyURL.create(from: urlString, width: 100, height: 100)
+            configuredAvatarURL = resolved
             imageTask = ImageCache.shared.loadImage(urlString: resolved) { [weak self] image in
                 guard let self else { return }
                 DispatchQueue.main.async {
+                    guard self.configuredAvatarURL == resolved else { return }
                     if let image {
                         self.avatarView.image = image
                         self.avatarInitials.isHidden = true
@@ -170,6 +175,9 @@ final class ChannelPermissionRowCell: UITableViewCell {
         nameLabel.text = title
         subLabel.text = L(L10n.ChannelPermission.role)
         subLabel.isHidden = false
+        imageTask?.cancel()
+        imageTask = nil
+        configuredAvatarURL = nil
         avatarInitials.isHidden = true
         ownerIcon.isHidden = true
 
@@ -178,6 +186,10 @@ final class ChannelPermissionRowCell: UITableViewCell {
         roleIconView.isHidden = false
         roleIconView.tintColor = color
 
+        applyTrailing(trailing)
+    }
+
+    func setTrailing(_ trailing: Trailing) {
         applyTrailing(trailing)
     }
 
@@ -213,9 +225,20 @@ final class ChannelPermissionRowCell: UITableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         imageTask?.cancel()
+        imageTask = nil
+        configuredAvatarURL = nil
         avatarView.image = nil
+        avatarView.isHidden = false
+        avatarView.backgroundColor = UIColor.theme.tertiary
         avatarInitials.isHidden = false
+        roleIconView.isHidden = true
         ownerIcon.isHidden = true
+        trailingButton.isHidden = true
+        trailingButton.isEnabled = true
+        trailingButton.setImage(nil, for: .normal)
+        checkboxView.isHidden = true
+        checkboxView.image = nil
+        chevron.isHidden = true
         onRemoveTapped = nil
     }
 }

--- a/MezonChat/Features/Chat/ChatViewController.swift
+++ b/MezonChat/Features/Chat/ChatViewController.swift
@@ -419,6 +419,8 @@ final class ChatViewController: ViewController {
     private var isKeyboardVisible = false
     private var trackedKeyboardHeight: CGFloat = 0
     private var suppressScrollToBottomForNextKeyboardInset = false
+    private var shouldReconcileKeyboardAfterNotificationNavigation = false
+    private var notificationKeyboardReconcileWorkItem: DispatchWorkItem?
     private lazy var shouldScrollToBottom: Bool = lastSeenMessageId == nil
     private var pendingScrollToBottom = false
     private var hasMarkedAsRead = false
@@ -1015,8 +1017,15 @@ final class ChatViewController: ViewController {
         let bottomInset = max(layout.intrinsicInsets.bottom, layout.safeInsets.bottom)
         let layoutInputH = layout.inputHeight ?? 0
         let composerHasKeyboardFocus = sendInputViewController.view.findFirstResponder() != nil
+        let shouldIgnoreNotificationKeyboardInset =
+            shouldReconcileKeyboardAfterNotificationNavigation
+            && layoutInputH > bottomInset + 1
+            && !isKeyboardVisible
+            && trackedKeyboardHeight <= 0.5
         let rawInputH: CGFloat
-        if layoutInputH > 1 {
+        if shouldIgnoreNotificationKeyboardInset {
+            rawInputH = 0
+        } else if layoutInputH > 1 {
             rawInputH = layoutInputH
         } else if (isKeyboardVisible || composerHasKeyboardFocus), trackedKeyboardHeight > 0.5 {
             rawInputH = trackedKeyboardHeight
@@ -1153,10 +1162,73 @@ final class ChatViewController: ViewController {
             isKeyboardVisible = false
             trackedKeyboardHeight = 0
         }
+        reconcileKeyboardAfterNotificationNavigationIfNeeded()
         if let layout = lastLayout {
             containerLayoutUpdated(layout, transition: .immediate)
         }
         presentLicenseAgreementIfNeeded()
+    }
+
+    private func collapseNotificationNavigationComposerOverlays() {
+        guard isViewLoaded else { return }
+        sendInputViewController.hideEmojiPickerIfNeeded()
+        sendInputViewController.hideAdvancePanelIfNeeded()
+        if emojiPicker.panelHeightForChatLayout > 0 {
+            emojiPicker.setVisible(false, collapsedHeight: 0)
+        }
+        if advancePanelCollapsedHeight > 0 {
+            handleAdvancePanelToggle(visible: false, collapsedHeight: 0)
+        }
+    }
+
+    private func reconcileKeyboardAfterNotificationNavigationIfNeeded() {
+        guard shouldReconcileKeyboardAfterNotificationNavigation, isViewLoaded else { return }
+        collapseNotificationNavigationComposerOverlays()
+
+        let wasTextInputFocused = sendInputViewController.isTextInputFocused
+        if !isKeyboardVisible && trackedKeyboardHeight <= 0.5 {
+            currentKeyboardOffset = 0
+            suppressScrollToBottomForNextKeyboardInset = false
+            if !wasTextInputFocused {
+                view.endEditing(true)
+            }
+            if let layout = lastLayout, (layout.inputHeight ?? 0) > 1 {
+                containerLayoutUpdated(layout.withUpdatedInputHeight(nil), transition: .immediate)
+            }
+        }
+
+        scheduleNotificationKeyboardReconcileRetry(wasTextInputFocused: wasTextInputFocused, attempt: 0)
+    }
+
+    private func scheduleNotificationKeyboardReconcileRetry(wasTextInputFocused: Bool, attempt: Int) {
+        notificationKeyboardReconcileWorkItem?.cancel()
+        let delay: TimeInterval = attempt == 0 ? 0.08 : 0.25
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.finishNotificationKeyboardReconcile(wasTextInputFocused: wasTextInputFocused, attempt: attempt)
+        }
+        notificationKeyboardReconcileWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+    }
+
+    private func finishNotificationKeyboardReconcile(wasTextInputFocused: Bool, attempt: Int) {
+        guard shouldReconcileKeyboardAfterNotificationNavigation, isViewLoaded else { return }
+        if !isKeyboardVisible && trackedKeyboardHeight <= 0.5 {
+            currentKeyboardOffset = 0
+            suppressScrollToBottomForNextKeyboardInset = false
+            if let layout = lastLayout, (layout.inputHeight ?? 0) > 1 {
+                containerLayoutUpdated(layout.withUpdatedInputHeight(nil), transition: .immediate)
+            }
+            if wasTextInputFocused {
+                if UIApplication.shared.applicationState == .active {
+                    sendInputViewController.refocusTextInputAfterNavigation()
+                } else if attempt < 3 {
+                    scheduleNotificationKeyboardReconcileRetry(wasTextInputFocused: wasTextInputFocused, attempt: attempt + 1)
+                    return
+                }
+            }
+        }
+        shouldReconcileKeyboardAfterNotificationNavigation = false
+        notificationKeyboardReconcileWorkItem = nil
     }
 
     private func presentLicenseAgreementIfNeeded() {
@@ -1335,6 +1407,7 @@ final class ChatViewController: ViewController {
     deinit {
         typingPruneTimer?.invalidate()
         sendingFeedbackRefreshWorkItem?.cancel()
+        notificationKeyboardReconcileWorkItem?.cancel()
         stateDisposables.dispose()
         NotificationCenter.default.removeObserver(self)
     }
@@ -1692,6 +1765,7 @@ final class ChatViewController: ViewController {
     }
 
     func handleBroughtForwardFromNotificationDeepLink() {
+        prepareForNotificationNavigation()
         hasMarkedAsRead = false
         if !messages.isEmpty {
             markChannelAsRead()
@@ -1699,12 +1773,18 @@ final class ChatViewController: ViewController {
         if context.account.socket.isConnected {
             joinChat()
         }
-        markNextFetchPrefersHTTPFirst()
         Task { @MainActor [weak self] in
             guard let self else { return }
             guard let token = await self.context.getTokenPreferringCachedSkipSessionReadyWait() else { return }
             self.fetchMessages(token: token)
         }
+    }
+
+    func prepareForNotificationNavigation() {
+        shouldReconcileKeyboardAfterNotificationNavigation = true
+        collapseNotificationNavigationComposerOverlays()
+        markNextFetchPrefersHTTPFirst()
+        reconcileKeyboardAfterNotificationNavigationIfNeeded()
     }
 
     func markNextFetchPrefersHTTPFirst() {

--- a/MezonChat/Features/ClanSettings/ClanRolesViewController.swift
+++ b/MezonChat/Features/ClanSettings/ClanRolesViewController.swift
@@ -50,13 +50,15 @@ final class ClanRolesViewController: BaseViewController {
         label.font = .systemFont(ofSize: 13.sf, weight: .regular)
         label.textColor = UIColor.theme.textDisabled
         label.numberOfLines = 0
+        label.textAlignment = .center
         v.addSubview(label)
         label.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            label.leadingAnchor.constraint(equalTo: v.leadingAnchor, constant: 10.sw),
-            label.trailingAnchor.constraint(equalTo: v.trailingAnchor, constant: -10.sw),
-            label.topAnchor.constraint(equalTo: v.topAnchor, constant: 12.sh),
-            label.bottomAnchor.constraint(equalTo: v.bottomAnchor, constant: -8.sh)
+            label.leadingAnchor.constraint(equalTo: v.leadingAnchor, constant: 16.sw),
+            label.trailingAnchor.constraint(equalTo: v.trailingAnchor, constant: -16.sw),
+            label.centerYAnchor.constraint(equalTo: v.centerYAnchor),
+            label.topAnchor.constraint(greaterThanOrEqualTo: v.topAnchor, constant: 8.sh),
+            label.bottomAnchor.constraint(lessThanOrEqualTo: v.bottomAnchor, constant: -8.sh)
         ])
         return v
     }()
@@ -259,8 +261,8 @@ extension ClanRolesViewController: UITableViewDataSource, UITableViewDelegate {
             label.translatesAutoresizingMaskIntoConstraints = false
             wrap.addSubview(label)
             NSLayoutConstraint.activate([
-                label.leadingAnchor.constraint(equalTo: wrap.leadingAnchor, constant: 10.sw),
-                label.trailingAnchor.constraint(equalTo: wrap.trailingAnchor, constant: -10.sw),
+                label.leadingAnchor.constraint(equalTo: wrap.leadingAnchor, constant: 16.sw),
+                label.trailingAnchor.constraint(equalTo: wrap.trailingAnchor, constant: -16.sw),
                 label.topAnchor.constraint(equalTo: wrap.topAnchor, constant: 10.sh),
                 label.bottomAnchor.constraint(equalTo: wrap.bottomAnchor, constant: -6.sh)
             ])
@@ -333,6 +335,8 @@ extension ClanRolesViewController: UITableViewDataSource, UITableViewDelegate {
 private final class ClanRoleCell: UITableViewCell {
 
     static let reuseId = "ClanRoleCell"
+    private static let horizontalInset: CGFloat = 16
+    private static let iconSize: CGFloat = 28
 
     private let iconView = UIImageView()
     private let roleIconView = UIImageView()
@@ -374,19 +378,24 @@ private final class ClanRoleCell: UITableViewCell {
         titleLabel.font = .systemFont(ofSize: 15.sf, weight: .semibold)
         titleLabel.textColor = .mezonTextPrimary
         titleLabel.numberOfLines = 1
+        titleLabel.lineBreakMode = .byTruncatingTail
+        titleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
         subtitleLabel.font = .systemFont(ofSize: 12.sf, weight: .regular)
         subtitleLabel.textColor = UIColor.theme.textDisabled
         subtitleLabel.numberOfLines = 1
+        subtitleLabel.lineBreakMode = .byTruncatingTail
 
         lockIcon.image = UIImage(systemName: "lock.fill")?.withRenderingMode(.alwaysTemplate)
         lockIcon.tintColor = UIColor.theme.textDisabled
         lockIcon.contentMode = .scaleAspectFit
         lockIcon.isHidden = true
+        lockIcon.setContentCompressionResistancePriority(.required, for: .horizontal)
 
         chevron.image = UIImage(systemName: "chevron.right")?.withRenderingMode(.alwaysTemplate)
         chevron.tintColor = UIColor.theme.textDisabled
         chevron.contentMode = .scaleAspectFit
+        chevron.setContentCompressionResistancePriority(.required, for: .horizontal)
 
         [iconView, roleIconView, colorIndicator, titleLabel, subtitleLabel, lockIcon, chevron].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
@@ -394,15 +403,15 @@ private final class ClanRoleCell: UITableViewCell {
         }
 
         NSLayoutConstraint.activate([
-            iconView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 6.sw),
+            iconView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Self.horizontalInset),
             iconView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            iconView.widthAnchor.constraint(equalToConstant: 28.swh),
-            iconView.heightAnchor.constraint(equalToConstant: 28.swh),
+            iconView.widthAnchor.constraint(equalToConstant: Self.iconSize),
+            iconView.heightAnchor.constraint(equalToConstant: Self.iconSize),
 
             roleIconView.centerXAnchor.constraint(equalTo: iconView.centerXAnchor),
             roleIconView.centerYAnchor.constraint(equalTo: iconView.centerYAnchor),
-            roleIconView.widthAnchor.constraint(equalToConstant: 28.swh),
-            roleIconView.heightAnchor.constraint(equalToConstant: 28.swh),
+            roleIconView.widthAnchor.constraint(equalToConstant: Self.iconSize),
+            roleIconView.heightAnchor.constraint(equalToConstant: Self.iconSize),
 
             colorIndicator.centerXAnchor.constraint(equalTo: iconView.centerXAnchor),
             colorIndicator.bottomAnchor.constraint(equalTo: iconView.bottomAnchor, constant: 2.sh),
@@ -415,13 +424,14 @@ private final class ClanRoleCell: UITableViewCell {
             lockIcon.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
             lockIcon.widthAnchor.constraint(equalToConstant: 14.swh),
             lockIcon.heightAnchor.constraint(equalToConstant: 14.swh),
+            lockIcon.trailingAnchor.constraint(lessThanOrEqualTo: chevron.leadingAnchor, constant: -6.sw),
 
             subtitleLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
             subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 2.sh),
             subtitleLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -10.sh),
             subtitleLabel.trailingAnchor.constraint(lessThanOrEqualTo: chevron.leadingAnchor, constant: -6.sw),
 
-            chevron.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -6.sw),
+            chevron.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -Self.horizontalInset),
             chevron.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             chevron.widthAnchor.constraint(equalToConstant: 10.swh),
             chevron.heightAnchor.constraint(equalToConstant: 14.swh)
@@ -429,11 +439,11 @@ private final class ClanRoleCell: UITableViewCell {
         titleLeadingToIcon = titleLabel.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 10.sw)
         titleLeadingToContent = titleLabel.leadingAnchor.constraint(
             equalTo: contentView.leadingAnchor,
-            constant: 6.sw + 28.swh + 10.sw)
+            constant: Self.horizontalInset + Self.iconSize + 10.sw)
         titleLeadingToContent.isActive = false
         titleLeadingToIcon.isActive = true
         titleTrailingMaxEmpty = titleLabel.trailingAnchor.constraint(
-            lessThanOrEqualTo: contentView.trailingAnchor, constant: -14.sw)
+            lessThanOrEqualTo: contentView.trailingAnchor, constant: -Self.horizontalInset)
         titleTrailingMaxEmpty.isActive = false
     }
 
@@ -474,10 +484,15 @@ private final class ClanRoleCell: UITableViewCell {
         titleLabel.text = role.title
         titleLabel.textColor = .mezonTextPrimary
         titleLabel.font = .systemFont(ofSize: 15.sf, weight: .semibold)
-        subtitleLabel.text = "\(memberCount) \(L(L10n.ClanRoles.members))"
+        subtitleLabel.text = Self.memberCountText(memberCount)
         lockIcon.isHidden = !isLocked
         chevron.isHidden = false
         isUserInteractionEnabled = true
+    }
+
+    private static func memberCountText(_ count: Int) -> String {
+        let key = count <= 1 ? L10n.ClanRoles.member : L10n.ClanRoles.members
+        return "\(count) \(L(key))"
     }
 
     func configureEmpty(text: String) {

--- a/MezonChat/Features/ClanSettings/ClanSettingsContainerNode.swift
+++ b/MezonChat/Features/ClanSettings/ClanSettingsContainerNode.swift
@@ -10,18 +10,21 @@ final class ClanSettingsContainerNode: ASDisplayNode {
     private let clanId: Int64
     private let clanName: String
     private let avatarURL: String
+    private var canShowRoles: Bool
 
     private let scrollView = UIScrollView()
     private let stackView = UIStackView()
+    private var validLayout: ContainerViewLayout?
 
     private let headerH: CGFloat = 64.sh
     private let padH: CGFloat = 12.sw
 
-    init(context: AccountContext, clanId: Int64, clanName: String, avatarURL: String) {
+    init(context: AccountContext, clanId: Int64, clanName: String, avatarURL: String, canShowRoles: Bool) {
         self.context = context
         self.clanId = clanId
         self.clanName = clanName
         self.avatarURL = avatarURL
+        self.canShowRoles = canShowRoles
         super.init()
         backgroundColor = .mezonSecondary
     }
@@ -45,6 +48,7 @@ final class ClanSettingsContainerNode: ASDisplayNode {
     }
 
     func updateLayout(layout: ContainerViewLayout, transition: ContainedViewLayoutTransition) {
+        validLayout = layout
         let size = layout.size
         let safeTop = layout.safeInsets.top
 
@@ -91,17 +95,37 @@ final class ClanSettingsContainerNode: ASDisplayNode {
         stackView.addArrangedSubview(userMgmtHeader)
         stackView.setCustomSpacing(10.sh, after: userMgmtHeader)
 
-        let userActions: [SettingAction] = [
+        var userActions: [SettingAction] = [
             .init(title: L(L10n.Clan.members), icon: "ClanSetting/MemberIcon"),
-            .init(title: L(L10n.ClanSetting.roles), icon: "ClanSetting/RolesIcon", navigate: .roles),
-            .init(title: L(L10n.ClanSetting.invites), icon: "ClanSetting/Invite"),
         ]
+        if canShowRoles {
+            userActions.append(.init(title: L(L10n.ClanSetting.roles), icon: "ClanSetting/RolesIcon", navigate: .roles))
+        }
+        userActions.append(.init(title: L(L10n.ClanSetting.invites), icon: "ClanSetting/Invite"))
         let userGroup = createGroup(actions: userActions)
         stackView.addArrangedSubview(userGroup)
 
         let footerSpacer = UIView()
         footerSpacer.heightAnchor.constraint(equalToConstant: 40.sh).isActive = true
         stackView.addArrangedSubview(footerSpacer)
+    }
+
+    func updateCanShowRoles(_ canShowRoles: Bool) {
+        guard self.canShowRoles != canShowRoles else { return }
+        self.canShowRoles = canShowRoles
+        guard isNodeLoaded else { return }
+        rebuildContent()
+    }
+
+    private func rebuildContent() {
+        for view in stackView.arrangedSubviews {
+            stackView.removeArrangedSubview(view)
+            view.removeFromSuperview()
+        }
+        buildContent()
+        if let validLayout {
+            updateLayout(layout: validLayout, transition: .immediate)
+        }
     }
 
     private func createHeader() -> UIView {

--- a/MezonChat/Features/ClanSettings/ClanSettingsViewController.swift
+++ b/MezonChat/Features/ClanSettings/ClanSettingsViewController.swift
@@ -29,7 +29,8 @@ final class ClanSettingsViewController: BaseViewController {
             context: context,
             clanId: clanId,
             clanName: clanName,
-            avatarURL: avatarURL
+            avatarURL: avatarURL,
+            canShowRoles: canShowRolesSection()
         )
         node.onClose = { [weak self] in
             if let nav = self?.navigationController {
@@ -40,6 +41,7 @@ final class ClanSettingsViewController: BaseViewController {
         }
         node.onSelectRoles = { [weak self] in
             guard let self else { return }
+            guard self.canShowRolesSection() else { return }
             let vc = ClanRolesViewController(context: self.context, clanId: self.clanId)
             self.navigationController?.pushViewController(vc, animated: true)
         }
@@ -48,11 +50,27 @@ final class ClanSettingsViewController: BaseViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+    }
 
+    override func setupBindings() {
+        disposables.add((context.engine.clanData.clanPermissionsUpdated.signal()
+            |> deliverOnMainQueue).start(next: { [weak self] updatedClanId in
+                guard let self, updatedClanId == self.clanId else { return }
+                self.settingsNode.updateCanShowRoles(self.canShowRolesSection())
+            }))
+        disposables.add((context.engine.clanData.clanRolesUpdated.signal()
+            |> deliverOnMainQueue).start(next: { [weak self] updatedClanId in
+                guard let self, updatedClanId == self.clanId else { return }
+                self.settingsNode.updateCanShowRoles(self.canShowRolesSection())
+            }))
     }
 
     override func containerLayoutUpdated(_ layout: ContainerViewLayout, transition: ContainedViewLayoutTransition) {
         super.containerLayoutUpdated(layout, transition: transition)
         settingsNode.updateLayout(layout: layout, transition: transition)
+    }
+
+    private func canShowRolesSection() -> Bool {
+        context.rolePermissions.canManageRoles(clanId: clanId)
     }
 }

--- a/MezonChat/Features/ClanSettings/Roles/Components/AddMembersSheetController.swift
+++ b/MezonChat/Features/ClanSettings/Roles/Components/AddMembersSheetController.swift
@@ -153,8 +153,8 @@ final class AddMembersSheetController: UIViewController {
         tableView.dataSource = self
         tableView.delegate = self
         tableView.separatorStyle = .none
-        tableView.estimatedRowHeight = 64.sh
-        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = MemberRowCell.rowHeight
+        tableView.rowHeight = MemberRowCell.rowHeight
         tableView.register(MemberRowCell.self, forCellReuseIdentifier: MemberRowCell.reuseId)
         view.addSubview(tableView)
 
@@ -230,7 +230,9 @@ extension AddMembersSheetController: UITableViewDataSource, UITableViewDelegate 
         } else {
             selectedIds.insert(member.userId)
         }
-        tableView.reloadRows(at: [indexPath], with: .none)
+        if let cell = tableView.cellForRow(at: indexPath) as? MemberRowCell {
+            cell.setAccessory(.checkbox(checked: selectedIds.contains(member.userId)))
+        }
         refreshDone()
     }
 }

--- a/MezonChat/Features/ClanSettings/Roles/Components/MemberRowCell.swift
+++ b/MezonChat/Features/ClanSettings/Roles/Components/MemberRowCell.swift
@@ -4,6 +4,7 @@ import UIKit
 final class MemberRowCell: UITableViewCell {
 
     static let reuseId = "MemberRowCell"
+    static let rowHeight: CGFloat = 56
 
     enum Accessory {
         case none
@@ -18,12 +19,14 @@ final class MemberRowCell: UITableViewCell {
     private let accessoryButton = UIButton(type: .system)
     private let checkboxView = UIImageView()
     private var imageTask: URLSessionDataTask?
+    private var configuredAvatarURL: String?
 
     var onAccessoryTapped: (() -> Void)?
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: .default, reuseIdentifier: reuseIdentifier)
         backgroundColor = .clear
+        selectionStyle = .none
         let bg = UIView()
         bg.backgroundColor = UIColor.theme.tertiary.withAlphaComponent(0.6)
         selectedBackgroundView = bg
@@ -62,34 +65,37 @@ final class MemberRowCell: UITableViewCell {
             $0.translatesAutoresizingMaskIntoConstraints = false
             contentView.addSubview($0)
         }
+        let minHeight = contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: Self.rowHeight)
+        minHeight.priority = .required
 
         NSLayoutConstraint.activate([
+            minHeight,
             avatarView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 14.sw),
             avatarView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            avatarView.widthAnchor.constraint(equalToConstant: 36.swh),
-            avatarView.heightAnchor.constraint(equalToConstant: 36.swh),
+            avatarView.widthAnchor.constraint(equalToConstant: 36),
+            avatarView.heightAnchor.constraint(equalToConstant: 36),
 
             avatarInitials.centerXAnchor.constraint(equalTo: avatarView.centerXAnchor),
             avatarInitials.centerYAnchor.constraint(equalTo: avatarView.centerYAnchor),
 
             nameLabel.leadingAnchor.constraint(equalTo: avatarView.trailingAnchor, constant: 12.sw),
-            nameLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 10.sh),
-            nameLabel.trailingAnchor.constraint(lessThanOrEqualTo: accessoryButton.leadingAnchor, constant: -8.sw),
+            nameLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8),
+            nameLabel.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -54.sw),
 
             subLabel.leadingAnchor.constraint(equalTo: nameLabel.leadingAnchor),
-            subLabel.topAnchor.constraint(equalTo: nameLabel.bottomAnchor, constant: 2.sh),
-            subLabel.trailingAnchor.constraint(lessThanOrEqualTo: accessoryButton.leadingAnchor, constant: -8.sw),
-            subLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -10.sh),
+            subLabel.topAnchor.constraint(equalTo: nameLabel.bottomAnchor, constant: 2),
+            subLabel.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -54.sw),
+            subLabel.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -8),
 
             accessoryButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -12.sw),
             accessoryButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            accessoryButton.widthAnchor.constraint(equalToConstant: 28.swh),
-            accessoryButton.heightAnchor.constraint(equalToConstant: 28.swh),
+            accessoryButton.widthAnchor.constraint(equalToConstant: 28),
+            accessoryButton.heightAnchor.constraint(equalToConstant: 28),
 
             checkboxView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16.sw),
             checkboxView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            checkboxView.widthAnchor.constraint(equalToConstant: 22.swh),
-            checkboxView.heightAnchor.constraint(equalToConstant: 22.swh)
+            checkboxView.widthAnchor.constraint(equalToConstant: 22),
+            checkboxView.heightAnchor.constraint(equalToConstant: 22)
         ])
     }
 
@@ -109,9 +115,11 @@ final class MemberRowCell: UITableViewCell {
         avatarInitials.isHidden = false
         if let urlString = avatarURL, !urlString.isEmpty {
             let resolved = ImgproxyURL.create(from: urlString, width: 100, height: 100)
+            configuredAvatarURL = resolved
             imageTask = ImageCache.shared.loadImage(urlString: resolved) { [weak self] image in
                 guard let self else { return }
                 DispatchQueue.main.async {
+                    guard self.configuredAvatarURL == resolved else { return }
                     if let image {
                         self.avatarView.image = image
                         self.avatarInitials.isHidden = true
@@ -120,6 +128,14 @@ final class MemberRowCell: UITableViewCell {
             }
         }
 
+        applyAccessory(accessory)
+    }
+
+    func setAccessory(_ accessory: Accessory) {
+        applyAccessory(accessory)
+    }
+
+    private func applyAccessory(_ accessory: Accessory) {
         switch accessory {
         case .none:
             accessoryButton.isHidden = true
@@ -147,8 +163,14 @@ final class MemberRowCell: UITableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         imageTask?.cancel()
+        imageTask = nil
+        configuredAvatarURL = nil
         avatarView.image = nil
         avatarInitials.isHidden = false
+        accessoryButton.isHidden = true
+        accessoryButton.setImage(nil, for: .normal)
+        checkboxView.isHidden = true
+        checkboxView.image = nil
         onAccessoryTapped = nil
     }
 }

--- a/MezonChat/Features/ClanSettings/Roles/CreateNewRoleViewController.swift
+++ b/MezonChat/Features/ClanSettings/Roles/CreateNewRoleViewController.swift
@@ -11,18 +11,23 @@ final class CreateNewRoleViewController: BaseViewController {
     private let headerView = UIView()
     private let backButton = UIButton(type: .system)
     private let titleLabel = UILabel()
-    private let headingLabel = UILabel()
     private let descriptionLabel = UILabel()
 
     private let inputContainer = UIView()
     private let inputLabel = UILabel()
     private let inputField = UITextField()
 
+    private let colorRow = UIControl()
+    private let colorTitleLabel = UILabel()
+    private let colorValueLabel = UILabel()
+    private let colorIndicator = UIView()
+
     private let createButton = UIButton(type: .system)
-    private let accessoryCreateButton = UIButton(type: .system)
+    private var createButtonBottomConstraint: NSLayoutConstraint?
 
     private let maxNameCharacters = 64
     private var name: String = "" { didSet { refreshCreateButton() } }
+    private var selectedColor: String = ""
     private var isCreating: Bool = false
 
     init(context: AccountContext, clanId: Int64) {
@@ -34,12 +39,23 @@ final class CreateNewRoleViewController: BaseViewController {
 
     required init(coder aDecoder: NSCoder) { fatalError() }
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleKeyboardFrameChange(_:)),
+            name: UIResponder.keyboardWillChangeFrameNotification,
+            object: nil
+        )
+    }
+
     override func setupUI() {
         view.backgroundColor = .mezonSecondary
         navigationController?.setNavigationBarHidden(true, animated: false)
         setupHeader()
         setupCopy()
         setupInput()
+        setupColorRow()
         setupCreateButton()
     }
 
@@ -52,6 +68,7 @@ final class CreateNewRoleViewController: BaseViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         navigationController?.setNavigationBarHidden(false, animated: animated)
+        inputField.resignFirstResponder()
     }
 
     // MARK: - Setup
@@ -93,26 +110,15 @@ final class CreateNewRoleViewController: BaseViewController {
     }
 
     private func setupCopy() {
-        headingLabel.text = L(L10n.ClanRoles.createHeading)
-        headingLabel.font = .systemFont(ofSize: 22.sf, weight: .bold)
-        headingLabel.textColor = .mezonTextPrimary
-
         descriptionLabel.text = L(L10n.ClanRoles.createDescription)
         descriptionLabel.font = .systemFont(ofSize: 13.sf, weight: .regular)
         descriptionLabel.textColor = UIColor.theme.textDisabled
         descriptionLabel.numberOfLines = 0
-
-        [headingLabel, descriptionLabel].forEach {
-            $0.translatesAutoresizingMaskIntoConstraints = false
-            view.addSubview($0)
-        }
+        descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(descriptionLabel)
 
         NSLayoutConstraint.activate([
-            headingLabel.topAnchor.constraint(equalTo: headerView.bottomAnchor, constant: 24.sh),
-            headingLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16.sw),
-            headingLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16.sw),
-
-            descriptionLabel.topAnchor.constraint(equalTo: headingLabel.bottomAnchor, constant: 10.sh),
+            descriptionLabel.topAnchor.constraint(equalTo: headerView.bottomAnchor, constant: 10.sh),
             descriptionLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16.sw),
             descriptionLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16.sw)
         ])
@@ -156,37 +162,58 @@ final class CreateNewRoleViewController: BaseViewController {
             inputField.bottomAnchor.constraint(equalTo: inputContainer.bottomAnchor, constant: -12.sh),
             inputField.heightAnchor.constraint(equalToConstant: 24.sh)
         ])
-        setupInputAccessory()
     }
 
-    private func setupInputAccessory() {
-        let container = UIView()
-        container.backgroundColor = .mezonSecondary
+    private func setupColorRow() {
+        colorRow.backgroundColor = UIColor.theme.tertiary
+        colorRow.layer.cornerRadius = 12.swh
+        colorRow.addTarget(self, action: #selector(colorRowTapped), for: .touchUpInside)
+        colorRow.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(colorRow)
 
-        accessoryCreateButton.setTitle(L(L10n.ClanRoles.createButton), for: .normal)
-        accessoryCreateButton.setTitleColor(.white, for: .normal)
-        accessoryCreateButton.titleLabel?.font = .systemFont(ofSize: 15.sf, weight: .semibold)
-        accessoryCreateButton.backgroundColor = UIColor.theme.bgViolet
-        accessoryCreateButton.layer.cornerRadius = 12.swh
-        accessoryCreateButton.clipsToBounds = true
-        accessoryCreateButton.addTarget(self, action: #selector(createTapped), for: .touchUpInside)
-        accessoryCreateButton.translatesAutoresizingMaskIntoConstraints = false
-        container.addSubview(accessoryCreateButton)
+        colorTitleLabel.text = L(L10n.ClanRoles.colorRow)
+        colorTitleLabel.font = .systemFont(ofSize: 14.sf, weight: .medium)
+        colorTitleLabel.textColor = .mezonTextPrimary
 
-        let topPad: CGFloat = 8.sh
-        let bottomPad: CGFloat = 8.sh
+        colorValueLabel.font = .systemFont(ofSize: 13.sf, weight: .regular)
+        colorValueLabel.textColor = UIColor.theme.textDisabled
+
+        colorIndicator.layer.cornerRadius = 8.swh
+        colorIndicator.layer.borderWidth = 1
+        colorIndicator.layer.borderColor = UIColor.theme.borderDim.cgColor
+
+        let chevron = UIImageView(image: UIImage(systemName: "chevron.right")?.withRenderingMode(.alwaysTemplate))
+        chevron.tintColor = UIColor.theme.textDisabled
+        chevron.contentMode = .scaleAspectFit
+
+        [colorTitleLabel, colorValueLabel, colorIndicator, chevron].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            colorRow.addSubview($0)
+        }
+
         NSLayoutConstraint.activate([
-            accessoryCreateButton.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16.sw),
-            accessoryCreateButton.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -16.sw),
-            accessoryCreateButton.topAnchor.constraint(equalTo: container.topAnchor, constant: topPad),
-            accessoryCreateButton.heightAnchor.constraint(equalToConstant: 50.sh),
-            accessoryCreateButton.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -bottomPad),
-        ])
+            colorRow.topAnchor.constraint(equalTo: inputContainer.bottomAnchor, constant: 12.sh),
+            colorRow.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16.sw),
+            colorRow.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16.sw),
+            colorRow.heightAnchor.constraint(equalToConstant: 56.sh),
 
-        let h = topPad + 50.sh + bottomPad
-        let w = max(view.bounds.width, UIScreen.main.bounds.width)
-        container.frame = CGRect(x: 0, y: 0, width: w, height: h)
-        inputField.inputAccessoryView = container
+            colorTitleLabel.leadingAnchor.constraint(equalTo: colorRow.leadingAnchor, constant: 14.sw),
+            colorTitleLabel.centerYAnchor.constraint(equalTo: colorRow.centerYAnchor),
+
+            chevron.trailingAnchor.constraint(equalTo: colorRow.trailingAnchor, constant: -12.sw),
+            chevron.centerYAnchor.constraint(equalTo: colorRow.centerYAnchor),
+            chevron.widthAnchor.constraint(equalToConstant: 10.swh),
+            chevron.heightAnchor.constraint(equalToConstant: 14.swh),
+
+            colorIndicator.trailingAnchor.constraint(equalTo: chevron.leadingAnchor, constant: -10.sw),
+            colorIndicator.centerYAnchor.constraint(equalTo: colorRow.centerYAnchor),
+            colorIndicator.widthAnchor.constraint(equalToConstant: 16.swh),
+            colorIndicator.heightAnchor.constraint(equalToConstant: 16.swh),
+
+            colorValueLabel.trailingAnchor.constraint(equalTo: colorIndicator.leadingAnchor, constant: -8.sw),
+            colorValueLabel.centerYAnchor.constraint(equalTo: colorRow.centerYAnchor)
+        ])
+        refreshColorRow()
     }
 
     private func setupCreateButton() {
@@ -199,32 +226,29 @@ final class CreateNewRoleViewController: BaseViewController {
         createButton.addTarget(self, action: #selector(createTapped), for: .touchUpInside)
         view.addSubview(createButton)
 
+        let bottomConstraint = createButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -12.sh)
+        createButtonBottomConstraint = bottomConstraint
         NSLayoutConstraint.activate([
             createButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16.sw),
             createButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16.sw),
-            createButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -12.sh),
+            bottomConstraint,
             createButton.heightAnchor.constraint(equalToConstant: 50.sh)
         ])
         refreshCreateButton()
     }
 
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        guard let acc = inputField.inputAccessoryView else { return }
-        let w = view.bounds.width
-        guard w > 0.5, abs(acc.bounds.width - w) > 0.5 else { return }
-        acc.frame.size.width = w
-        acc.layoutIfNeeded()
+    private func refreshColorRow() {
+        let hex = selectedColor.isEmpty ? RolePermissionConstants.defaultRoleColor : selectedColor
+        colorIndicator.backgroundColor = UIColor(hexString: hex) ?? .systemGray
+        colorValueLabel.text = selectedColor.isEmpty ? "" : selectedColor.uppercased()
     }
 
     private func refreshCreateButton() {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
         let enabled = !trimmed.isEmpty && !isCreating
-        for btn in [createButton, accessoryCreateButton] {
-            btn.isEnabled = enabled
-            btn.backgroundColor = enabled ? UIColor.theme.bgViolet : UIColor(white: 0.4, alpha: 1.0)
-            btn.alpha = enabled ? 1.0 : 0.8
-        }
+        createButton.isEnabled = enabled
+        createButton.backgroundColor = enabled ? UIColor.theme.bgViolet : UIColor(white: 0.4, alpha: 1.0)
+        createButton.alpha = enabled ? 1.0 : 0.8
     }
 
     // MARK: - Actions
@@ -242,6 +266,35 @@ final class CreateNewRoleViewController: BaseViewController {
         name = trimmed
     }
 
+    @objc private func colorRowTapped() {
+        inputField.resignFirstResponder()
+        let picker = RoleColorPickerSheetController(initialColor: selectedColor) { [weak self] hex in
+            self?.selectedColor = hex
+            self?.refreshColorRow()
+        }
+        present(picker, animated: true)
+    }
+
+    @objc private func handleKeyboardFrameChange(_ notification: Notification) {
+        guard let info = notification.userInfo,
+            let frame = info[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect
+        else { return }
+
+        let converted = view.convert(frame, from: nil)
+        let overlap = max(0, view.bounds.maxY - converted.minY)
+        let keyboardOffset = max(0, overlap - view.safeAreaInsets.bottom)
+        createButtonBottomConstraint?.constant = -12.sh - keyboardOffset
+
+        let duration = (info[UIResponder.keyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue ?? 0.25
+        let curveValue = (info[UIResponder.keyboardAnimationCurveUserInfoKey] as? NSNumber)?.uintValue ?? 0
+        UIView.animate(
+            withDuration: duration,
+            delay: 0,
+            options: UIView.AnimationOptions(rawValue: curveValue << 16),
+            animations: { self.view.layoutIfNeeded() }
+        )
+    }
+
     @objc private func createTapped() {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, !isCreating else { return }
@@ -255,7 +308,7 @@ final class CreateNewRoleViewController: BaseViewController {
                 let role = try await self.repository.createRole(
                     clanId: self.clanId,
                     title: trimmed,
-                    color: "",
+                    color: self.selectedColor,
                     roleIcon: "",
                     addUserIds: [],
                     activePermissionIds: []

--- a/MezonChat/Features/ClanSettings/Roles/Helpers/RolesRepository.swift
+++ b/MezonChat/Features/ClanSettings/Roles/Helpers/RolesRepository.swift
@@ -250,10 +250,7 @@ final class RolesRepository {
     }
 
     func canManageRoles(clanId: Int64) -> Bool {
-        if isClanOwner(clanId: clanId) { return true }
-        if hasClanPermission(.administrator, clanId: clanId) { return true }
-        if hasClanPermission(.manageClan, clanId: clanId) { return true }
-        return false
+        context.rolePermissions.canManageRoles(clanId: clanId)
     }
 
     func canEditRole(_ role: Mezon_Api_Role, clanId: Int64) -> Bool {

--- a/MezonChat/Features/ClanSettings/Roles/RoleDetailViewController.swift
+++ b/MezonChat/Features/ClanSettings/Roles/RoleDetailViewController.swift
@@ -146,20 +146,26 @@ final class RoleDetailViewController: BaseViewController {
             for: .normal)
         backButton.tintColor = UIColor.theme.textStrong
         backButton.addTarget(self, action: #selector(backTapped), for: .touchUpInside)
+        backButton.setContentCompressionResistancePriority(.required, for: .horizontal)
 
         headerTitleLabel.font = .systemFont(ofSize: 16.sf, weight: .bold)
         headerTitleLabel.textColor = .mezonTextPrimary
         headerTitleLabel.textAlignment = .center
+        headerTitleLabel.numberOfLines = 1
+        headerTitleLabel.lineBreakMode = .byTruncatingTail
+        headerTitleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
         headerSubtitleLabel.text = L(L10n.ClanRoles.role)
         headerSubtitleLabel.font = .systemFont(ofSize: 12.sf, weight: .regular)
         headerSubtitleLabel.textColor = UIColor.theme.textDisabled
         headerSubtitleLabel.textAlignment = .center
+        headerSubtitleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
         saveButton.setTitle(L(L10n.ClanRoles.save), for: .normal)
         saveButton.setTitleColor(UIColor.theme.bgViolet, for: .normal)
         saveButton.titleLabel?.font = .systemFont(ofSize: 14.sf, weight: .semibold)
         saveButton.addTarget(self, action: #selector(saveTapped), for: .touchUpInside)
+        saveButton.setContentCompressionResistancePriority(.required, for: .horizontal)
 
         [backButton, headerTitleLabel, headerSubtitleLabel, saveButton].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
@@ -176,9 +182,13 @@ final class RoleDetailViewController: BaseViewController {
 
             headerTitleLabel.centerXAnchor.constraint(equalTo: headerView.centerXAnchor),
             headerTitleLabel.topAnchor.constraint(equalTo: headerView.topAnchor, constant: 6.sh),
+            headerTitleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: backButton.trailingAnchor, constant: 8.sw),
+            headerTitleLabel.trailingAnchor.constraint(lessThanOrEqualTo: saveButton.leadingAnchor, constant: -8.sw),
 
             headerSubtitleLabel.centerXAnchor.constraint(equalTo: headerView.centerXAnchor),
             headerSubtitleLabel.topAnchor.constraint(equalTo: headerTitleLabel.bottomAnchor, constant: 2.sh),
+            headerSubtitleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: backButton.trailingAnchor, constant: 8.sw),
+            headerSubtitleLabel.trailingAnchor.constraint(lessThanOrEqualTo: saveButton.leadingAnchor, constant: -8.sw),
 
             saveButton.trailingAnchor.constraint(equalTo: headerView.trailingAnchor, constant: -16.sw),
             saveButton.centerYAnchor.constraint(equalTo: headerView.centerYAnchor)

--- a/MezonChat/Features/ClanSettings/Roles/SetupMembersViewController.swift
+++ b/MezonChat/Features/ClanSettings/Roles/SetupMembersViewController.swift
@@ -38,8 +38,8 @@ final class SetupMembersViewController: BaseViewController {
     private let bottomBar = UIStackView()
     private let finishButton = UIButton(type: .custom)
     private let skipButton = UIButton(type: .system)
+    private var tableBottomConstraint: NSLayoutConstraint?
     private var bottomBarBottomConstraint: NSLayoutConstraint?
-    private let tableBottomInsetWithBar: CGFloat = 130.sh
 
     private var roleId: Int64 {
         switch mode {
@@ -272,11 +272,13 @@ final class SetupMembersViewController: BaseViewController {
         tableView.register(MemberRowCell.self, forCellReuseIdentifier: MemberRowCell.reuseId)
         view.addSubview(tableView)
 
+        let bottomConstraint = tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        tableBottomConstraint = bottomConstraint
         NSLayoutConstraint.activate([
             tableView.topAnchor.constraint(equalTo: addMemberButton.bottomAnchor, constant: 8.sh),
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            bottomConstraint
         ])
     }
 
@@ -313,8 +315,12 @@ final class SetupMembersViewController: BaseViewController {
             bottomBar.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16.sw),
             bottomC,
         ])
-        tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: tableBottomInsetWithBar, right: 0)
-        tableView.verticalScrollIndicatorInsets.bottom = tableBottomInsetWithBar
+        tableBottomConstraint?.isActive = false
+        let bottomConstraint = tableView.bottomAnchor.constraint(equalTo: bottomBar.topAnchor, constant: -8.sh)
+        tableBottomConstraint = bottomConstraint
+        bottomConstraint.isActive = true
+        tableView.contentInset = .zero
+        tableView.verticalScrollIndicatorInsets.bottom = 0
     }
 
     @objc private func handleKeyboardFrameChange(_ notification: Notification) {
@@ -325,9 +331,8 @@ final class SetupMembersViewController: BaseViewController {
         let converted = view.convert(frame, from: nil)
         let overlap = max(0, view.bounds.maxY - converted.minY)
         bottomBarBottomConstraint.constant = -12.sh - overlap
-        let insetBottom = tableBottomInsetWithBar + overlap
-        tableView.contentInset.bottom = insetBottom
-        tableView.verticalScrollIndicatorInsets.bottom = insetBottom
+        tableView.contentInset.bottom = 0
+        tableView.verticalScrollIndicatorInsets.bottom = 0
         let duration = (info[UIResponder.keyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue ?? 0.25
         let curveValue = (info[UIResponder.keyboardAnimationCurveUserInfoKey] as? NSNumber)?.uintValue ?? 0
         UIView.animate(

--- a/MezonChat/Features/ClanSettings/Roles/SetupPermissionsViewController.swift
+++ b/MezonChat/Features/ClanSettings/Roles/SetupPermissionsViewController.swift
@@ -36,12 +36,14 @@ final class SetupPermissionsViewController: BaseViewController {
     private let searchContainer = UIView()
     private let headingLabel = UILabel()
 
-    private let tableView = UITableView(frame: .zero, style: .insetGrouped)
+    private let tableView = UITableView(frame: .zero, style: .plain)
+    private let emptyStateLabel = UILabel()
 
     private let bottomBar = UIStackView()
     private let nextButton = UIButton(type: .custom)
     private let skipButton = UIButton(type: .system)
     private var bottomBarBottomConstraint: NSLayoutConstraint?
+    private var emptyStateCenterYConstraint: NSLayoutConstraint?
     private let tableBottomInsetWithBar: CGFloat = 130.sh
 
     private var roleId: Int64 {
@@ -222,14 +224,35 @@ final class SetupPermissionsViewController: BaseViewController {
         tableView.rowHeight = UITableView.automaticDimension
         tableView.keyboardDismissMode = .interactive
         tableView.cellLayoutMarginsFollowReadableWidth = false
+        tableView.tableFooterView = UIView()
+        tableView.contentInset = .zero
+        if #available(iOS 15.0, *) {
+            tableView.sectionHeaderTopPadding = 0
+        }
         tableView.register(PermissionRowCell.self, forCellReuseIdentifier: PermissionRowCell.reuseId)
         view.addSubview(tableView)
 
+        emptyStateLabel.text = L(L10n.ClanRoles.permissionsNotFound)
+        emptyStateLabel.font = .systemFont(ofSize: 14.sf, weight: .medium)
+        emptyStateLabel.textColor = UIColor.theme.textDisabled
+        emptyStateLabel.textAlignment = .center
+        emptyStateLabel.numberOfLines = 0
+        emptyStateLabel.isHidden = true
+        emptyStateLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(emptyStateLabel)
+
+        let emptyCenterY = emptyStateLabel.centerYAnchor.constraint(equalTo: tableView.centerYAnchor, constant: -24.sh)
+        emptyStateCenterYConstraint = emptyCenterY
+
         NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: searchContainer.bottomAnchor, constant: 8.sh),
+            tableView.topAnchor.constraint(equalTo: searchContainer.bottomAnchor, constant: 2.sh),
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            emptyStateLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24.sw),
+            emptyStateLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24.sw),
+            emptyCenterY
         ])
     }
 
@@ -282,6 +305,7 @@ final class SetupPermissionsViewController: BaseViewController {
         let insetBottom = baseInset + overlap
         tableView.contentInset.bottom = insetBottom
         tableView.verticalScrollIndicatorInsets.bottom = insetBottom
+        emptyStateCenterYConstraint?.constant = overlap > 0 ? -(overlap / 2 + 24.sh) : -24.sh
         let duration = (info[UIResponder.keyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue ?? 0.25
         let curveValue = (info[UIResponder.keyboardAnimationCurveUserInfoKey] as? NSNumber)?.uintValue ?? 0
         UIView.animate(
@@ -340,6 +364,14 @@ final class SetupPermissionsViewController: BaseViewController {
             }
         }
         tableView.reloadData()
+        updateEmptyState()
+    }
+
+    private func updateEmptyState() {
+        let hasQuery = !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let shouldShowEmptyState = hasQuery && filteredPermissions.isEmpty
+        tableView.isHidden = shouldShowEmptyState
+        emptyStateLabel.isHidden = !shouldShowEmptyState
     }
 
     private func refreshSaveButton() {
@@ -696,20 +728,30 @@ private final class FlatPermissionSwitch: UIControl {
 
         let trackColor: UIColor
         let thumbColor: UIColor
+        let trackBorderColor: UIColor
+        let thumbBorderColor: UIColor
         if isEnabled {
-            trackColor = isOn ? UIColor.theme.bgViolet : UIColor.theme.tertiary.withAlphaComponent(0.72)
+            trackColor = isOn ? UIColor.theme.bgViolet : UIColor.theme.textDisabled.withAlphaComponent(0.24)
             thumbColor = .white
+            trackBorderColor = isOn ? .clear : UIColor.theme.textDisabled.withAlphaComponent(0.42)
+            thumbBorderColor = isOn ? .clear : UIColor.theme.borderDim
         } else {
-            trackColor = isOn ? UIColor.theme.bgViolet.withAlphaComponent(0.38) : UIColor.theme.tertiary.withAlphaComponent(0.55)
-            thumbColor = UIColor.theme.textDisabled
+            trackColor = isOn ? UIColor.theme.bgViolet.withAlphaComponent(0.42) : UIColor.theme.textDisabled.withAlphaComponent(0.16)
+            thumbColor = UIColor.theme.secondary
+            trackBorderColor = isOn ? .clear : UIColor.theme.textDisabled.withAlphaComponent(0.28)
+            thumbBorderColor = UIColor.theme.borderDim.withAlphaComponent(0.85)
         }
 
         let changes = {
             self.trackView.frame = trackFrame
             self.trackView.layer.cornerRadius = trackHeight / 2
+            self.trackView.layer.borderWidth = self.isOn ? 0 : 1
+            self.trackView.layer.borderColor = trackBorderColor.cgColor
             self.trackView.backgroundColor = trackColor
             self.thumbView.frame = thumbFrame
             self.thumbView.layer.cornerRadius = thumbDiameter / 2
+            self.thumbView.layer.borderWidth = self.isOn ? 0 : 1
+            self.thumbView.layer.borderColor = thumbBorderColor.cgColor
             self.thumbView.backgroundColor = thumbColor
         }
 

--- a/MezonChat/Features/DirectMessages/DirectMessagesContainerNode.swift
+++ b/MezonChat/Features/DirectMessages/DirectMessagesContainerNode.swift
@@ -26,16 +26,14 @@ final class DirectMessagesContainerNode: ASDisplayNode {
     private var state: DirectMessagesState = .empty
     private let interaction: DirectMessagesInteraction
     private let disposables = DisposableSet()
-    private let context: AccountContext
     private var needsReloadOnLayout = false
 
     private let refreshControl = UIRefreshControl()
     private var validLayout: (size: CGSize, safeTop: CGFloat, bottomInset: CGFloat)?
 
-    init(signal: Signal<DirectMessagesState, NoError>, interaction: DirectMessagesInteraction, context: AccountContext) {
+    init(signal: Signal<DirectMessagesState, NoError>, interaction: DirectMessagesInteraction) {
         tableView = UITableView(frame: .zero, style: .plain)
         self.interaction = interaction
-        self.context = context
         super.init()
         let t0 = UIColor.theme
         backgroundColor = t0.secondary
@@ -43,28 +41,42 @@ final class DirectMessagesContainerNode: ASDisplayNode {
         disposables.add(
             (signal |> deliverOnMainQueue).start(next: { [weak self] newState in
                 guard let self else { return }
+                let previousState = self.state
+                let directMessagesChanged = previousState.directMessages != newState.directMessages
+                let activityRowsChanged = previousState.messageActivityRows != newState.messageActivityRows
+                let avatarURLCacheChanged = previousState.resolvedAvatarURLByChannelId != newState.resolvedAvatarURLByChannelId
+                let activityHeaderVisibilityChanged = previousState.messageActivityRows.isEmpty != newState.messageActivityRows.isEmpty
+                let incomingCountChanged = previousState.incomingFriendRequestCount != newState.incomingFriendRequestCount
                 self.state = newState
 
-                self.activityStrip.setItems(newState.messageActivityRows)
-                if self.validLayout != nil {
-                    self.applyLayout(transition: .immediate)
+                if activityRowsChanged {
+                    self.activityStrip.setItems(newState.messageActivityRows)
                 }
 
+                let previousBadgeHidden = self.badgeLabel.isHidden
                 if newState.incomingFriendRequestCount > 0 {
                     self.badgeLabel.text = "\(newState.incomingFriendRequestCount)"
                     self.badgeLabel.isHidden = false
-                    self.view.setNeedsLayout() // ensure it layouts if intrinsic content size changes
                 } else {
                     self.badgeLabel.isHidden = true
                 }
+                let badgeNeedsLayout = incomingCountChanged || previousBadgeHidden != self.badgeLabel.isHidden
+
+                if self.validLayout != nil, activityHeaderVisibilityChanged || badgeNeedsLayout {
+                    self.applyLayout(transition: .immediate)
+                }
                 
-                if self.tableView.frame.width > 0 {
-                    self.tableView.reloadData()
-                    if !self.badgeLabel.isHidden {
-                        self.applyLayout(transition: .immediate)
+                if directMessagesChanged || avatarURLCacheChanged {
+                    self.prefetchAvatarImages(for: Array(newState.directMessages.prefix(16)))
+                    if self.tableView.frame.width > 0 {
+                        if Self.channelIdOrder(previousState.directMessages) == Self.channelIdOrder(newState.directMessages) {
+                            self.reconfigureVisibleCells()
+                        } else {
+                            self.tableView.reloadData()
+                        }
+                    } else {
+                        self.needsReloadOnLayout = true
                     }
-                } else {
-                    self.needsReloadOnLayout = true
                 }
             })
         )
@@ -83,11 +95,12 @@ final class DirectMessagesContainerNode: ASDisplayNode {
 
         tableView.backgroundColor = .clear
         tableView.separatorStyle = .none
-        tableView.rowHeight = UITableView.automaticDimension
+        tableView.rowHeight = 62.sh
         tableView.estimatedRowHeight = 62.sh
         tableView.register(DmListItemCell.self, forCellReuseIdentifier: DmListItemCell.reuseId)
         tableView.dataSource = self
         tableView.delegate = self
+        tableView.prefetchDataSource = self
 
         refreshControl.tintColor = .mezonTextPrimary
         refreshControl.addTarget(self, action: #selector(handleRefresh), for: .valueChanged)
@@ -99,7 +112,12 @@ final class DirectMessagesContainerNode: ASDisplayNode {
         badgeLabel.textAlignment = .center
         badgeLabel.layer.cornerRadius = 10.sh
         badgeLabel.clipsToBounds = true
-        badgeLabel.isHidden = true
+        if state.incomingFriendRequestCount > 0 {
+            badgeLabel.text = "\(state.incomingFriendRequestCount)"
+            badgeLabel.isHidden = false
+        } else {
+            badgeLabel.isHidden = true
+        }
 
         titleLabel.text = L(L10n.Tab.messages)
         titleLabel.font = .systemFont(ofSize: 18.sf, weight: .bold)
@@ -314,6 +332,40 @@ final class DirectMessagesContainerNode: ASDisplayNode {
     func resetMessageActivityStripScroll(animated: Bool) {
         activityStrip.resetScrollToStart(animated: animated)
     }
+
+    private func prefetchAvatarImages(for channels: [Mezon_Api_ChannelDescription]) {
+        guard !channels.isEmpty else { return }
+        for channel in channels {
+            prefetchAvatarImage(for: channel)
+        }
+    }
+
+    private func prefetchAvatarImage(for channel: Mezon_Api_ChannelDescription) {
+        guard let avatarURL = state.resolvedAvatarURLByChannelId[channel.channelID],
+              !avatarURL.isEmpty else {
+            return
+        }
+        let proxied = ImgproxyURL.avatarProxyURL(from: avatarURL, width: 100, height: 100)
+        guard ImageCache.shared.memoryImage(forKey: proxied) == nil else { return }
+        ImageCache.shared.loadAvatar(urlString: proxied) { _ in }
+    }
+
+    private static func channelIdOrder(_ channels: [Mezon_Api_ChannelDescription]) -> [Int64] {
+        channels.map(\.channelID)
+    }
+
+    private func reconfigureVisibleCells() {
+        guard let visibleIndexPaths = tableView.indexPathsForVisibleRows else { return }
+        for indexPath in visibleIndexPaths {
+            guard indexPath.row >= 0,
+                  indexPath.row < state.directMessages.count,
+                  let cell = tableView.cellForRow(at: indexPath) as? DmListItemCell else {
+                continue
+            }
+            let channel = state.directMessages[indexPath.row]
+            cell.configure(channel: channel, resolvedAvatarURL: state.resolvedAvatarURLByChannelId[channel.channelID])
+        }
+    }
 }
 
 private extension DirectMessagesContainerNode {
@@ -327,7 +379,7 @@ private extension DirectMessagesContainerNode {
     }
 }
 
-extension DirectMessagesContainerNode: UITableViewDataSource, UITableViewDelegate {
+extension DirectMessagesContainerNode: UITableViewDataSource, UITableViewDelegate, UITableViewDataSourcePrefetching {
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         state.directMessages.count
@@ -335,12 +387,21 @@ extension DirectMessagesContainerNode: UITableViewDataSource, UITableViewDelegat
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: DmListItemCell.reuseId, for: indexPath) as! DmListItemCell
-        cell.configure(channel: state.directMessages[indexPath.row], context: context)
+        let channel = state.directMessages[indexPath.row]
+        cell.configure(channel: channel, resolvedAvatarURL: state.resolvedAvatarURLByChannelId[channel.channelID])
         return cell
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         interaction.onSelectDirectMessage(state.directMessages[indexPath.row])
+    }
+
+    func tableView(_ tableView: UITableView, prefetchRowsAt indexPaths: [IndexPath]) {
+        let channels = indexPaths.compactMap { indexPath -> Mezon_Api_ChannelDescription? in
+            guard indexPath.row >= 0, indexPath.row < state.directMessages.count else { return nil }
+            return state.directMessages[indexPath.row]
+        }
+        prefetchAvatarImages(for: channels)
     }
 }

--- a/MezonChat/Features/DirectMessages/DirectMessagesViewController.swift
+++ b/MezonChat/Features/DirectMessages/DirectMessagesViewController.swift
@@ -7,10 +7,11 @@ struct DirectMessagesState {
     var errorMessage: String?
     var incomingFriendRequestCount: Int
     var messageActivityRows: [DmMessageActivityItem]
+    var resolvedAvatarURLByChannelId: [Int64: String]
 
     static let empty = DirectMessagesState(
         directMessages: [], isEmpty: true, isLoading: false, errorMessage: nil,
-        incomingFriendRequestCount: 0, messageActivityRows: [])
+        incomingFriendRequestCount: 0, messageActivityRows: [], resolvedAvatarURLByChannelId: [:])
 }
 
 final class DirectMessagesViewController: ViewController {
@@ -29,6 +30,7 @@ final class DirectMessagesViewController: ViewController {
     private(set) var errorMessage: String?
     private(set) var incomingFriendRequestCount: Int = 0
     private var userActivities: [Mezon_Api_UserActivity] = []
+    private var didRefreshForCurrentAppearance = false
 
     private var directMessagesNode: DirectMessagesContainerNode { displayNode as! DirectMessagesContainerNode }
 
@@ -69,12 +71,13 @@ final class DirectMessagesViewController: ViewController {
                 self?.openDirectMessageFromActivity(item)
             }
         )
-        displayNode = DirectMessagesContainerNode(signal: stateSignal(), interaction: interaction, context: context)
+        displayNode = DirectMessagesContainerNode(signal: stateSignal(), interaction: interaction)
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        if let layout = lastLayout {
+        didRefreshForCurrentAppearance = false
+        if !animated, let layout = lastLayout {
             directMessagesNode.updateLayout(
                 size: layout.size,
                 safeTop: resolvedSafeTop(for: layout),
@@ -82,9 +85,23 @@ final class DirectMessagesViewController: ViewController {
                 transition: .immediate
             )
         }
+        if !animated {
+            refreshDirectMessagesForAppearance()
+        }
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         if isNodeLoaded {
             directMessagesNode.resetMessageActivityStripScroll(animated: false)
         }
+        if !didRefreshForCurrentAppearance {
+            refreshDirectMessagesForAppearance()
+        }
+    }
+
+    private func refreshDirectMessagesForAppearance() {
+        didRefreshForCurrentAppearance = true
         fetchDirectMessages()
         syncIncomingFriendRequestCount()
     }
@@ -360,14 +377,32 @@ final class DirectMessagesViewController: ViewController {
     }
 
     private func setDirectMessages(_ v: [Mezon_Api_ChannelDescription]) {
+        guard directMessages != v else { return }
         directMessages = v
         directMessagesPipe.putNext(v)
         needsReloadPipe.putNext(())
     }
 
-    private func setIsEmpty(_ v: Bool) { isEmpty = v; isEmptyPipe.putNext(v); needsReloadPipe.putNext(()) }
-    private func setIsLoading(_ v: Bool) { isLoading = v; isLoadingPipe.putNext(v); needsReloadPipe.putNext(()) }
-    private func setErrorMessage(_ v: String?) { errorMessage = v; errorMessagePipe.putNext(v); needsReloadPipe.putNext(()) }
+    private func setIsEmpty(_ v: Bool) {
+        guard isEmpty != v else { return }
+        isEmpty = v
+        isEmptyPipe.putNext(v)
+        needsReloadPipe.putNext(())
+    }
+
+    private func setIsLoading(_ v: Bool) {
+        guard isLoading != v else { return }
+        isLoading = v
+        isLoadingPipe.putNext(v)
+        needsReloadPipe.putNext(())
+    }
+
+    private func setErrorMessage(_ v: String?) {
+        guard errorMessage != v else { return }
+        errorMessage = v
+        errorMessagePipe.putNext(v)
+        needsReloadPipe.putNext(())
+    }
 
     private func setIncomingFriendRequestCount(_ v: Int) {
         let changed = incomingFriendRequestCount != v
@@ -645,6 +680,88 @@ final class DirectMessagesViewController: ViewController {
         return rows
     }
 
+    private static func buildResolvedAvatarURLCache(
+        directMessages: [Mezon_Api_ChannelDescription],
+        friends: [Mezon_Api_Friend],
+        postboxAvatarURL: (Int64) -> String?
+    ) -> [Int64: String] {
+        let friendAvatarPairs = friends.compactMap { friend -> (Int64, String)? in
+            guard friend.hasUser, friend.user.id != 0 else { return nil }
+            guard let avatarURL = normalizedURLString(friend.user.avatarURL) else { return nil }
+            return (friend.user.id, avatarURL)
+        }
+        let friendAvatarByUserId = Dictionary(friendAvatarPairs, uniquingKeysWith: { first, _ in first })
+
+        var resolved: [Int64: String] = [:]
+        resolved.reserveCapacity(directMessages.count)
+
+        for channel in directMessages {
+            if let urlString = primaryAvatarURLString(for: channel) {
+                resolved[channel.channelID] = urlString
+                continue
+            }
+
+            guard channel.type != MezonConstants.ChannelType.group.rawValue else { continue }
+            let userId = channel.userIds.first ?? 0
+            guard userId != 0 else { continue }
+
+            if let friendAvatarURL = friendAvatarByUserId[userId] {
+                resolved[channel.channelID] = friendAvatarURL
+                continue
+            }
+
+            if let postboxAvatarURL = normalizedURLString(postboxAvatarURL(userId) ?? "") {
+                resolved[channel.channelID] = postboxAvatarURL
+            }
+        }
+
+        return resolved
+    }
+
+    private static func primaryAvatarURLString(for channel: Mezon_Api_ChannelDescription) -> String? {
+        if channel.type == MezonConstants.ChannelType.group.rawValue {
+            guard !channel.channelAvatar.isEmpty, !channel.channelAvatar.contains("avatar-group.png") else {
+                return nil
+            }
+            return normalizedURLString(channel.channelAvatar)
+        }
+        return normalizedURLString(channel.avatars.first ?? "")
+    }
+
+    private static func normalizedURLString(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if URL(string: trimmed) != nil {
+            return trimmed
+        }
+        if let encoded = trimmed.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+           URL(string: encoded) != nil {
+            return encoded
+        }
+        return nil
+    }
+
+    private static func avatarLookupUserIds(
+        directMessages: [Mezon_Api_ChannelDescription],
+        friends: [Mezon_Api_Friend]
+    ) -> [Int64] {
+        var ids = Set<Int64>()
+        for friend in friends where friend.hasUser && friend.user.id != 0
+            && friend.user.avatarURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            ids.insert(friend.user.id)
+        }
+        for channel in directMessages where channel.type != MezonConstants.ChannelType.group.rawValue {
+            let hasChannelAvatar = !(channel.avatars.first ?? "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .isEmpty
+            guard !hasChannelAvatar else { continue }
+            for userId in channel.userIds where userId != 0 {
+                ids.insert(userId)
+            }
+        }
+        return Array(ids)
+    }
+
     private func applyDmListFromCache() {
         let cached = context.account.postbox.getCachedDMChannelList()
         guard !cached.isEmpty else { return }
@@ -675,7 +792,9 @@ final class DirectMessagesViewController: ViewController {
     func fetchDirectMessages() {
         if fetchDirectMessagesTask != nil { return }
         if let last = lastFetchDirectMessagesAt, Date().timeIntervalSince(last) < fetchDirectMessagesCooldown {
-            applyDmListFromCache()
+            if directMessages.isEmpty {
+                applyDmListFromCache()
+            }
             return
         }
         applyDmListFromCache()
@@ -770,14 +889,32 @@ final class DirectMessagesViewController: ViewController {
     }
 
     var currentState: DirectMessagesState {
+        let friends = context.engine.friendsData.allFriends()
+        let avatarLookupIds = Self.avatarLookupUserIds(directMessages: directMessages, friends: friends)
+        let postboxAvatarURLByUserId: [Int64: String]
+        if avatarLookupIds.isEmpty {
+            postboxAvatarURLByUserId = [:]
+        } else {
+            postboxAvatarURLByUserId = context.account.postbox.read { tx -> [Int64: String] in
+                var result: [Int64: String] = [:]
+                result.reserveCapacity(avatarLookupIds.count)
+                for userId in avatarLookupIds {
+                    if let avatarURL = tx.getProfile(userId: "\(userId)")?.avatarUrl {
+                        result[userId] = avatarURL
+                    }
+                }
+                return result
+            }
+        }
+        let postboxAvatarURL: (Int64) -> String? = { userId in
+            postboxAvatarURLByUserId[userId]
+        }
         let rows = Self.buildMessageActivityRows(
             activities: userActivities,
-            friends: context.engine.friendsData.allFriends(),
+            friends: friends,
             directMessages: directMessages,
             myUserId: Int64(context.currentUser?.id ?? "") ?? 0,
-            postboxAvatarURL: { uid in
-                context.account.postbox.read { $0.getProfile(userId: "\(uid)") }?.avatarUrl
-            }
+            postboxAvatarURL: postboxAvatarURL
         )
         return DirectMessagesState(
             directMessages: directMessages,
@@ -785,7 +922,12 @@ final class DirectMessagesViewController: ViewController {
             isLoading: isLoading,
             errorMessage: errorMessage,
             incomingFriendRequestCount: incomingFriendRequestCount,
-            messageActivityRows: rows
+            messageActivityRows: rows,
+            resolvedAvatarURLByChannelId: Self.buildResolvedAvatarURLCache(
+                directMessages: directMessages,
+                friends: friends,
+                postboxAvatarURL: postboxAvatarURL
+            )
         )
     }
 

--- a/MezonChat/Features/DirectMessages/DmListItemCell.swift
+++ b/MezonChat/Features/DirectMessages/DmListItemCell.swift
@@ -60,11 +60,39 @@ final class DmListItemCell: UITableViewCell {
         return l
     }()
 
-    private var imageTask: URLSessionDataTask?
     private var avatarLoadGeneration: UInt = 0
     private var nameTopConstraint: NSLayoutConstraint?
     private var nameCenterYConstraint: NSLayoutConstraint?
     private var lastMessageZeroHeightConstraint: NSLayoutConstraint?
+    private var configuredAvatarURLString: String?
+    private var isAvatarLoadInFlight = false
+    private var hasPreviewLayout: Bool?
+
+    private static let unreadNameFont = UIFont.systemFont(ofSize: 14.sf, weight: .semibold)
+    private static let readNameFont = UIFont.systemFont(ofSize: 14.sf, weight: .medium)
+
+    private struct PreviewCacheKey: Hashable {
+        let channelId: Int64
+        let hasLastSentMessage: Bool
+        let messageId: Int64
+        let timestampSeconds: UInt32
+        let senderId: Int64
+        let content: String
+        let lastSeenTimestampSeconds: UInt32
+        let updateTimeSeconds: UInt32
+        let createTimeSeconds: UInt32
+        let relativeMinuteBucket: UInt32
+    }
+
+    private static var previewCache: [PreviewCacheKey: (String, String)] = [:]
+    private static var previewCacheOrder: [PreviewCacheKey] = []
+    private static let previewCacheLimit = 400
+    private static let urlDetector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+    private static let relativeDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "d/M/yy"
+        return formatter
+    }()
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -76,8 +104,9 @@ final class DmListItemCell: UITableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         avatarLoadGeneration += 1
-        imageTask?.cancel()
-        imageTask = nil
+        isAvatarLoadInFlight = false
+        configuredAvatarURLString = nil
+        hasPreviewLayout = nil
         avatarImageView.image = nil
         textAvatar.showImageMode()
         groupIconView.isHidden = true
@@ -154,7 +183,7 @@ final class DmListItemCell: UITableViewCell {
         ])
     }
 
-    func configure(channel: Mezon_Api_ChannelDescription, context: AccountContext? = nil) {
+    func configure(channel: Mezon_Api_ChannelDescription, resolvedAvatarURL: String? = nil) {
         groupIconView.tintColor = .mezonTextSecondary
 
         let isGroup = channel.type == MezonConstants.ChannelType.group.rawValue
@@ -163,25 +192,20 @@ final class DmListItemCell: UITableViewCell {
 
         nameLabel.text = displayName
         nameLabel.textColor = isUnread ? .mezonTextStrong : UIColor.theme.textDisabled
-        nameLabel.font = .systemFont(ofSize: 14.sf, weight: isUnread ? .semibold : .medium)
+        nameLabel.font = isUnread ? Self.unreadNameFont : Self.readNameFont
 
         onlineIndicator.layer.borderColor = UIColor.theme.primary.cgColor
 
         if isGroup {
             onlineIndicator.isHidden = true
-            if !channel.channelAvatar.isEmpty, !channel.channelAvatar.contains("avatar-group.png"),
-               let url = URL(string: channel.channelAvatar) {
-                groupIconView.isHidden = true
+            if let urlString = resolvedAvatarURL, let url = URL(string: urlString) {
                 loadImage(url: url, fallbackUsername: nil)
             } else {
                 avatarLoadGeneration += 1
-                imageTask?.cancel()
-                imageTask = nil
+                isAvatarLoadInFlight = false
+                configuredAvatarURLString = nil
                 avatarImageView.image = nil
-                textAvatar.showImageMode()
-                textAvatar.backgroundColor = .groupDMDefaultAvatar
-                groupIconView.tintColor = .white
-                groupIconView.isHidden = false
+                showGroupAvatarPlaceholder()
             }
         } else {
             groupIconView.isHidden = true
@@ -189,14 +213,13 @@ final class DmListItemCell: UITableViewCell {
             onlineIndicator.isHidden = !isOnline
 
             let username = channel.usernames.first ?? ""
-            let resolvedURLString = Self.resolveDmAvatarURL(channel: channel, context: context)
 
-            if let urlString = resolvedURLString, let url = URL(string: urlString) {
+            if let urlString = resolvedAvatarURL, let url = URL(string: urlString) {
                 loadImage(url: url, fallbackUsername: username)
             } else {
                 avatarLoadGeneration += 1
-                imageTask?.cancel()
-                imageTask = nil
+                isAvatarLoadInFlight = false
+                configuredAvatarURLString = nil
                 avatarImageView.image = nil
                 textAvatar.configure(username: username, fontSize: 16.sf)
             }
@@ -206,69 +229,55 @@ final class DmListItemCell: UITableViewCell {
         let hasPreview = !preview.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         lastMessageLabel.text = hasPreview ? preview : ""
         lastMessageLabel.isHidden = !hasPreview
-        if hasPreview {
-            nameCenterYConstraint?.isActive = false
-            lastMessageZeroHeightConstraint?.isActive = false
-            nameTopConstraint?.isActive = true
-        } else {
-            nameTopConstraint?.isActive = false
-            lastMessageZeroHeightConstraint?.isActive = true
-            nameCenterYConstraint?.isActive = true
+        if hasPreviewLayout != hasPreview {
+            hasPreviewLayout = hasPreview
+            nameTopConstraint?.isActive = hasPreview
+            lastMessageZeroHeightConstraint?.isActive = !hasPreview
+            nameCenterYConstraint?.isActive = !hasPreview
         }
         lastMessageLabel.textColor = isUnread ? UIColor.theme.textStrong : UIColor.theme.textDisabled
         timeLabel.text = time
         timeLabel.textColor = isUnread ? UIColor.theme.textStrong : UIColor.theme.textDisabled
     }
 
-    private static func resolveDmAvatarURL(
-        channel: Mezon_Api_ChannelDescription,
-        context: AccountContext?
-    ) -> String? {
-        if let server = channel.avatars.first {
-            let trimmed = server.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty {
-                if URL(string: trimmed) != nil {
-                    return trimmed
-                }
-                if let encoded = trimmed.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-                   URL(string: encoded) != nil {
-                    return encoded
-                }
-            }
-        }
-        let userId = channel.userIds.first ?? 0
-        guard userId != 0, let context else { return nil }
-        if let cached = context.account.postbox.read({ $0.getProfile(userId: "\(userId)") }),
-           let pbAvatar = cached.avatarUrl?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !pbAvatar.isEmpty,
-           URL(string: pbAvatar) != nil {
-            return pbAvatar
-        }
-        if let friendAvatar = context.engine.friendsData.allFriends().first(where: { $0.user.id == userId })?.user.avatarURL.trimmingCharacters(in: .whitespacesAndNewlines),
-           !friendAvatar.isEmpty,
-           URL(string: friendAvatar) != nil {
-            return friendAvatar
-        }
-        return nil
+    private func showGroupAvatarPlaceholder() {
+        textAvatar.showImageMode()
+        textAvatar.backgroundColor = .groupDMDefaultAvatar
+        groupIconView.tintColor = .white
+        groupIconView.isHidden = false
     }
 
     private func loadImage(url: URL, fallbackUsername: String?) {
-        imageTask?.cancel()
-        imageTask = nil
+        let source = url.absoluteString
+        if configuredAvatarURLString == source && (isAvatarLoadInFlight || avatarImageView.image != nil) {
+            return
+        }
+        configuredAvatarURLString = source
         avatarLoadGeneration += 1
         let gen = avatarLoadGeneration
         let proxied = ImgproxyURL.avatarProxyURL(from: url.absoluteString, width: 100, height: 100)
-        if let cached = ImageCache.shared.cachedImage(forURL: proxied) {
+        if let cached = ImageCache.shared.memoryImage(forKey: proxied) {
             guard gen == avatarLoadGeneration else { return }
+            isAvatarLoadInFlight = false
+            groupIconView.isHidden = true
             avatarImageView.image = cached
             textAvatar.showImageMode()
             return
         }
+
         avatarImageView.image = nil
-        textAvatar.showSkeleton()
-        imageTask = ImageCache.shared.loadImage(urlString: proxied) { [weak self] image in
+        isAvatarLoadInFlight = true
+        if let fallbackUsername {
+            textAvatar.configure(username: fallbackUsername, fontSize: 16.sf)
+        } else {
+            showGroupAvatarPlaceholder()
+        }
+
+        ImageCache.shared.loadAvatar(urlString: proxied) { [weak self] image in
             guard let self, gen == self.avatarLoadGeneration else { return }
+            self.isAvatarLoadInFlight = false
             if let image {
+                self.groupIconView.isHidden = true
                 self.avatarImageView.image = image
                 self.textAvatar.showImageMode()
             } else if let fallbackUsername {
@@ -276,7 +285,7 @@ final class DmListItemCell: UITableViewCell {
                 self.textAvatar.configure(username: fallbackUsername, fontSize: 16.sf)
             } else {
                 self.avatarImageView.image = nil
-                self.textAvatar.showImageMode()
+                self.showGroupAvatarPlaceholder()
             }
         }
     }
@@ -290,6 +299,42 @@ final class DmListItemCell: UITableViewCell {
     }
 
     private func lastMessagePreview(channel: Mezon_Api_ChannelDescription) -> (String, String) {
+        let msg = channel.lastSentMessage
+        let key = PreviewCacheKey(
+            channelId: channel.channelID,
+            hasLastSentMessage: channel.hasLastSentMessage,
+            messageId: msg.id,
+            timestampSeconds: msg.timestampSeconds,
+            senderId: msg.senderID,
+            content: msg.content,
+            lastSeenTimestampSeconds: channel.lastSeenMessage.timestampSeconds,
+            updateTimeSeconds: channel.updateTimeSeconds,
+            createTimeSeconds: channel.createTimeSeconds,
+            relativeMinuteBucket: UInt32(Date().timeIntervalSince1970 / 60)
+        )
+        if let cached = Self.previewCache[key] {
+            return cached
+        }
+        let value = computeLastMessagePreview(channel: channel)
+        Self.storePreviewCache(value, for: key)
+        return value
+    }
+
+    private static func storePreviewCache(_ value: (String, String), for key: PreviewCacheKey) {
+        guard previewCache[key] == nil else { return }
+        previewCache[key] = value
+        previewCacheOrder.append(key)
+        if previewCacheOrder.count > previewCacheLimit {
+            let overflow = previewCacheOrder.count - previewCacheLimit
+            let removed = previewCacheOrder.prefix(overflow)
+            for key in removed {
+                previewCache.removeValue(forKey: key)
+            }
+            previewCacheOrder.removeFirst(overflow)
+        }
+    }
+
+    private func computeLastMessagePreview(channel: Mezon_Api_ChannelDescription) -> (String, String) {
         let msg = channel.lastSentMessage
         let hasHeaderPayload =
             channel.hasLastSentMessage
@@ -544,7 +589,7 @@ final class DmListItemCell: UITableViewCell {
 
     private static func textContainsURL(_ text: String) -> Bool {
         guard !text.isEmpty else { return false }
-        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else { return false }
+        guard let detector = urlDetector else { return false }
         let range = NSRange(text.startIndex..., in: text)
         return detector.firstMatch(in: text, options: [], range: range) != nil
     }
@@ -567,8 +612,6 @@ final class DmListItemCell: UITableViewCell {
         if diff < 3600 { return "\(Int(diff / 60))m" }
         if diff < 86400 { return "\(Int(diff / 3600))h" }
         if diff < 604800 { return "\(Int(diff / 86400))d" }
-        let formatter = DateFormatter()
-        formatter.dateFormat = "d/M/yy"
-        return formatter.string(from: date)
+        return Self.relativeDateFormatter.string(from: date)
     }
 }

--- a/MezonChat/Features/DirectMessages/DmMessageActivityStripView.swift
+++ b/MezonChat/Features/DirectMessages/DmMessageActivityStripView.swift
@@ -118,8 +118,9 @@ private final class DmMessageActivityCell: UICollectionViewCell {
     private let avatarImageView = UIImageView()
     private let nameLabel = UILabel()
     private let subtitleLabel = UILabel()
-    private var imageTask: URLSessionDataTask?
     private var avatarLoadGeneration: UInt = 0
+    private var configuredAvatarURLString: String?
+    private var isAvatarLoadInFlight = false
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -186,8 +187,8 @@ private final class DmMessageActivityCell: UICollectionViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         avatarLoadGeneration += 1
-        imageTask?.cancel()
-        imageTask = nil
+        isAvatarLoadInFlight = false
+        configuredAvatarURLString = nil
         avatarImageView.image = nil
         textAvatar.showImageMode()
     }
@@ -216,29 +217,35 @@ private final class DmMessageActivityCell: UICollectionViewCell {
             loadAvatar(url: url, fallbackUsername: item.username)
         } else {
             avatarLoadGeneration += 1
-            imageTask?.cancel()
-            imageTask = nil
+            isAvatarLoadInFlight = false
+            configuredAvatarURLString = nil
             avatarImageView.image = nil
             textAvatar.configure(username: item.username, fontSize: 14.sf)
         }
     }
 
     private func loadAvatar(url: URL, fallbackUsername: String) {
-        imageTask?.cancel()
-        imageTask = nil
+        let source = url.absoluteString
+        if configuredAvatarURLString == source && (isAvatarLoadInFlight || avatarImageView.image != nil) {
+            return
+        }
+        configuredAvatarURLString = source
         avatarLoadGeneration += 1
         let gen = avatarLoadGeneration
         let proxied = ImgproxyURL.avatarProxyURL(from: url.absoluteString, width: 100, height: 100)
-        if let cached = ImageCache.shared.cachedImage(forURL: proxied) {
+        if let cached = ImageCache.shared.memoryImage(forKey: proxied) {
             guard gen == avatarLoadGeneration else { return }
+            isAvatarLoadInFlight = false
             avatarImageView.image = cached
             textAvatar.showImageMode()
             return
         }
         avatarImageView.image = nil
-        textAvatar.showSkeleton()
-        imageTask = ImageCache.shared.loadImage(urlString: proxied) { [weak self] image in
+        isAvatarLoadInFlight = true
+        textAvatar.configure(username: fallbackUsername, fontSize: 14.sf)
+        ImageCache.shared.loadAvatar(urlString: proxied) { [weak self] image in
             guard let self, gen == self.avatarLoadGeneration else { return }
+            self.isAvatarLoadInFlight = false
             if let image {
                 self.avatarImageView.image = image
                 self.textAvatar.showImageMode()

--- a/MezonChat/Features/Main/MezonRootController.swift
+++ b/MezonChat/Features/Main/MezonRootController.swift
@@ -389,7 +389,7 @@ final class MezonRootController: NavigationController {
         }()
 
         let dmChatVC = ChatViewController(clanId: 0, channel: resolvedChannel, context: context)
-        dmChatVC.markNextFetchPrefersHTTPFirst()
+        dmChatVC.prepareForNotificationNavigation()
         pushViewController(dmChatVC, animated: false)
 
         Task { @MainActor [weak self] in
@@ -468,7 +468,7 @@ final class MezonRootController: NavigationController {
             let chatVC = ChatViewController(
                 clanId: resolvedClanId, channel: cachedChannel, context: context, parentName: parentName
             )
-            chatVC.markNextFetchPrefersHTTPFirst()
+            chatVC.prepareForNotificationNavigation()
             pushViewController(chatVC, animated: false)
             fetchClanChannelsInBackground(clanId: resolvedClanId, selectChannelId: channelIdInt)
             return
@@ -491,7 +491,7 @@ final class MezonRootController: NavigationController {
             let chatVC = ChatViewController(
                 clanId: resolvedClanId, channel: ch, context: context, parentName: parentName
             )
-            chatVC.markNextFetchPrefersHTTPFirst()
+            chatVC.prepareForNotificationNavigation()
             pushViewController(chatVC, animated: false)
             fetchClanChannelsInBackground(clanId: resolvedClanId, selectChannelId: channelIdInt)
             return
@@ -512,7 +512,7 @@ final class MezonRootController: NavigationController {
             let chatVC = ChatViewController(
                 clanId: resolvedClanId, channel: ch, context: context, parentName: parentName
             )
-            chatVC.markNextFetchPrefersHTTPFirst()
+            chatVC.prepareForNotificationNavigation()
             pushViewController(chatVC, animated: false)
             return
         }
@@ -540,7 +540,7 @@ final class MezonRootController: NavigationController {
             let chatVC = ChatViewController(
                 clanId: notificationClanId, channel: minimal, context: context
             )
-            chatVC.markNextFetchPrefersHTTPFirst()
+            chatVC.prepareForNotificationNavigation()
             pushViewController(chatVC, animated: false)
 
             let loaded = homeVC.channelListVC.channelsLoadedSignal
@@ -574,7 +574,7 @@ final class MezonRootController: NavigationController {
             let chatVC = ChatViewController(
                 clanId: targetClanId, channel: minimal, context: self.context
             )
-            chatVC.markNextFetchPrefersHTTPFirst()
+            chatVC.prepareForNotificationNavigation()
             pushViewController(chatVC, animated: false)
             fetchClanChannelsInBackground(clanId: targetClanId, selectChannelId: channelIdInt)
         }

--- a/MezonChat/Features/PeerCall/PeerWebRTCCallSession.swift
+++ b/MezonChat/Features/PeerCall/PeerWebRTCCallSession.swift
@@ -461,7 +461,6 @@ final class PeerWebRTCCallSession: NSObject {
     private func performPreWarmBuild(offerCompressed: String) async throws {
         try ensureCallStillActive()
         Self.ensureSSL()
-        try? configureAudioSession()
         try ensureCallStillActive()
         let factory = Self.makePeerConnectionFactory()
         peerFactory = factory

--- a/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
+++ b/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
@@ -1900,6 +1900,20 @@ final class SendMessageInputViewController: UIViewController {
         textView.becomeFirstResponder()
     }
 
+    var isTextInputFocused: Bool {
+        textView.isFirstResponder
+    }
+
+    func refocusTextInputAfterNavigation() {
+        guard !composerSendPermissionBlocked, !isVoiceRecordingActive else { return }
+        guard textView.isFirstResponder else { return }
+        textView.resignFirstResponder()
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.view.window != nil else { return }
+            self.textView.becomeFirstResponder()
+        }
+    }
+
     private func openPhotoPicker() {
         MediaPickerViewController.present(from: self) { [weak self] results in
             guard let self else { return }

--- a/MezonChat/Networking/MezonHTTPClient.swift
+++ b/MezonChat/Networking/MezonHTTPClient.swift
@@ -571,10 +571,11 @@ final class MezonHTTPClient {
         parentChannelId: Int64,
         clanId: Int64,
         page: Int32,
+        limit: Int32 = 100,
         token: String
     ) async throws -> Mezon_Api_ChannelDescList {
         var req = Mezon_Api_ListThreadRequest()
-        req.limit = 100
+        req.limit = limit
         req.state = 0
         req.clanID = clanId
         req.channelID = parentChannelId


### PR DESCRIPTION
## 1. Root Cause

- Clan Settings still showed the Roles section for users without role management permission because the UI did not check `RolePermissionService.canManageRoles`.
- Role/member selection UI could show stale state because reusable cells did not fully reset their checkbox/trailing/avatar state.
- Channel Permissions used `roleChannelActive` to determine channel access roles, instead of checking whether the role belongs to the current `channelId`.
- Private Channel toggle state was unstable because:
  - the card tap gesture could fire together with the `UISwitch`
  - `UpdateChannelPrivate` uses an action flag: `0 = make private`, `1 = publish`, which differs from local cached `channelPrivate`
- Minor Roles list UI issues: incorrect plural text for `0 member` and uneven horizontal spacing.

## 2. Solution

- Added permission gating for the Roles section in Clan Settings and guarded navigation for unauthorized users.
- Updated Channel Permissions role access logic to use `role.channelIds.contains(channelId)`.
- Fixed `UpdateChannelPrivate` payload mapping: send `0` to make private, send `1` to publish.
- Added `privacyUpdateInFlight`, disabled the switch while updating, and rollback UI state on failure.
- Prevented double-toggle by ignoring card tap gestures when the touch comes from a `UIControl`.
- Hardened reusable permission/member cells:
  - reset trailing/checkbox/chevron/avatar state on reuse
  - guard async avatar loading by configured URL
  - update visible checkbox state directly instead of reloading rows
- Fixed Roles list UI:
  - `0 member`, `1 member`, `2 members`
  - aligned horizontal spacing.

## 3. Selftest

- Build:
  - `xcodebuild -workspace MezonChat.xcworkspace -scheme MezonChat -configuration Debug -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO build`
  - Result: succeeded
- Static check:
  - `git diff --check`
  - Result: clean
- Manual verification:
  - Users without role permission no longer see the Roles section in Clan Settings.
  - Edit-role member selection toggles checkbox correctly without stale UI state.
  - Enabling private channel no longer shows all roles in Channel Permissions.
  - Toggling private off publishes the channel correctly and does not turn back on automatically.
  - Roles list displays `0 member` and horizontal spacing is aligned.