### PR TITLE
260526-IOS-Handle preview msg of notification

### DIFF
--- a/MezonChat/Core/Postbox/Notifications/NotificationRecord.swift
+++ b/MezonChat/Core/Postbox/Notifications/NotificationRecord.swift
@@ -67,7 +67,7 @@ public struct NotificationRecord: PostboxCoding, Identifiable, Equatable {
 extension NotificationRecord {
 
     public var previewText: String {
-        Self.extractDisplayText(from: content)
+        return content
     }
 
     init(from apiModel: Mezon_Api_Notification) {
@@ -87,7 +87,6 @@ extension NotificationRecord {
         } else {
             self.channelType = 0
         }
-
         let decoded = NotificationRecord.decodeContent(from: apiModel.content)
         self.content = decoded.text
         self.avatarURL = apiModel.avatarURL.isEmpty ? decoded.avatar : apiModel.avatarURL
@@ -107,83 +106,55 @@ extension NotificationRecord {
     static func extractDisplayText(from raw: String) -> String {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return "" }
+
         guard trimmed.first == "{" || trimmed.first == "[" else { return trimmed }
         guard let data = trimmed.data(using: .utf8),
             let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         else {
             return trimmed
         }
-        if let extracted = extractText(fromJSONObject: obj), !extracted.isEmpty {
-            return extracted
+        
+        var hasEmbed = false
+        var isContact = false
+        
+        if let embeds = obj["embed"] as? [[String: Any]] ?? (obj["embed"] as? [String: Any]).map({ [$0] }), !embeds.isEmpty {
+            hasEmbed = true
+            if let first = embeds.first, let fields = first["fields"] as? [[String: Any]], let firstField = fields.first, let val = firstField["value"] as? String, val.lowercased() == "share_contact_key" {
+                isContact = true
+            }
+        } else if let embeds = obj["embeds"] as? [[String: Any]] ?? (obj["embeds"] as? [String: Any]).map({ [$0] }), !embeds.isEmpty {
+            hasEmbed = true
         }
-        if obj["embed"] != nil || obj["embeds"] != nil {
-            return ""
+        
+        if hasEmbed {
+            if isContact {
+                return "[\(L(L10n.DirectMessage.previewContact))]"
+            } else {
+                return "[\(L(L10n.DirectMessage.previewEmbed))]"
+            }
         }
-        if obj["t"] is String || obj["text"] is String {
-            return ""
+        
+        var hasAttachment = false
+        if let attachments = obj["attachments"] as? [Any], !attachments.isEmpty {
+            hasAttachment = true
+        } else if let a = obj["a"] as? [Any], !a.isEmpty {
+            hasAttachment = true
         }
-        return trimmed
+        
+        if hasAttachment {
+            return "[\(L(L10n.DirectMessage.previewAttachment))]"
+        }
+        
+        if let text = obj["t"] as? String, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return text.trimmingCharacters(in: .whitespacesAndNewlines)
+        } else if let text = obj["text"] as? String, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return text.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        
+        return "[\(L(L10n.DirectMessage.previewAttachment))]"
     }
 
-    private static func extractText(fromJSONObject obj: [String: Any]) -> String? {
-        if let t = obj["t"] as? String {
-            let x = t.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !x.isEmpty { return x }
-        }
-        if let t = obj["text"] as? String {
-            let x = t.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !x.isEmpty { return x }
-        }
-        if let embedLine = extractEmbedSummary(from: obj["embed"]) { return embedLine }
-        if let embedLine = extractEmbedSummary(from: obj["embeds"]) { return embedLine }
-        guard let contentVal = obj["content"] else { return nil }
-        if let nestedString = contentVal as? String {
-            let out = extractDisplayText(from: nestedString)
-            return out.isEmpty ? nil : out
-        }
-        if let inner = contentVal as? [String: Any] {
-            return extractText(fromJSONObject: inner)
-        }
-        return nil
-    }
 
-    private static func extractEmbedSummary(from value: Any?) -> String? {
-        let items: [[String: Any]]
-        if let arr = value as? [[String: Any]] {
-            items = arr
-        } else if let one = value as? [String: Any] {
-            items = [one]
-        } else {
-            return nil
-        }
-        guard let first = items.first else { return nil }
-        var parts: [String] = []
-        if let s = first["title"] as? String {
-            let x = s.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !x.isEmpty { parts.append(x) }
-        }
-        if let s = first["description"] as? String {
-            let x = s.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !x.isEmpty { parts.append(x) }
-        }
-        if let author = first["author"] as? [String: Any], let s = author["name"] as? String {
-            let x = s.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !x.isEmpty { parts.append(x) }
-        }
-        if let footer = first["footer"] as? [String: Any], let s = footer["text"] as? String {
-            let x = s.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !x.isEmpty { parts.append(x) }
-        } else if let s = first["footer"] as? String {
-            let x = s.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !x.isEmpty { parts.append(x) }
-        }
-        guard !parts.isEmpty else { return nil }
-        let joined = parts.joined(separator: " ")
-        if joined.count > 220 {
-            return String(joined.prefix(220)) + "…"
-        }
-        return joined
-    }
 
     private static func parseInt64(_ value: Any?) -> Int64? {
         if let n = value as? NSNumber {
@@ -277,7 +248,7 @@ extension NotificationRecord {
         else {
             return (extractDisplayText(from: raw), "", 0, 0, 0)
         }
-        let text = extractText(fromJSONObject: obj) ?? extractDisplayText(from: raw)
+        let text = extractDisplayText(from: raw)
         let avatar = extractAvatar(fromJSONObject: obj)
         let messageID =
             parseInt64(obj["message_id"]) ?? parseInt64(obj["messageId"]) ?? parseInt64(obj["messageID"])

--- a/MezonChat/Features/Notifications/NotificationsContainerNode.swift
+++ b/MezonChat/Features/Notifications/NotificationsContainerNode.swift
@@ -22,15 +22,9 @@ enum NotificationItem {
         switch self {
         case .notification(let n): return n.subject
         case .topic(let t):
-            let preview = NotificationRecord.extractDisplayText(from: t.content)
-            if !preview.isEmpty {
-                return L(L10n.Notifications.repliedTo) + preview
-            }
             let raw = t.content.trimmingCharacters(in: .whitespacesAndNewlines)
-            if raw.first == "{" || raw.first == "[" {
-                return L(L10n.Notifications.repliedTo) + L(L10n.Notifications.unreachableMessage)
-            }
-            return L(L10n.Notifications.repliedTo) + raw
+            let preview = Self.parseTopicMessage(content: raw)
+            return L(L10n.Notifications.repliedTo) + preview
         }
     }
 
@@ -39,36 +33,18 @@ enum NotificationItem {
         case .notification(let n): return n.previewText
         case .topic(let t):
             let rawContent = t.lastSentMessageContent.trimmingCharacters(in: .whitespacesAndNewlines)
-            let msgText: String
-            if let decoded: TopicContent = safeJsonDecode(
-                t.lastSentMessageContent, to: TopicContent.self),
-                let text = decoded.t
-            {
-                let x = text.trimmingCharacters(in: .whitespacesAndNewlines)
-                if !x.isEmpty {
-                    msgText = x
-                } else {
-                    msgText = Self.topicMessagePreviewFallback(lastSent: rawContent)
-                }
-            } else if !rawContent.isEmpty && rawContent != "{}" {
-                msgText = Self.topicMessagePreviewFallback(lastSent: rawContent)
-            } else {
-                msgText = L(L10n.Notifications.unreachableMessage)
-            }
-
-            let line = L(L10n.Notifications.sender) + msgText
+            
+            let msgText = Self.parseTopicMessage(content: rawContent.isEmpty ? t.content : rawContent)
+            
+            let prefix = t.senderDisplayName.isEmpty ? "" : "\(t.senderDisplayName): "
+            let line = prefix + msgText
 
             return line
         }
     }
 
-    private static func topicMessagePreviewFallback(lastSent: String) -> String {
-        let extracted = NotificationRecord.extractDisplayText(from: lastSent)
-        if !extracted.isEmpty { return extracted }
-        if lastSent.first == "{" || lastSent.first == "[" {
-            return L(L10n.Notifications.unreachableMessage)
-        }
-        return lastSent
+    private static func parseTopicMessage(content: String) -> String {
+        return NotificationRecord.extractDisplayText(from: content)
     }
 
     var avatarURL: String {


### PR DESCRIPTION
issue: https://github.com/mezonai/mezon/issues/13113
Root Cause
Double-Parsing Bug in Mentions: NotificationRecord already extracted text from the raw JSON when saving it to the local database (content field). However, when rendering, the UI computed previewText by passing the already-extracted text back to extractDisplayText again. This caused a typed string like "{}" to be parsed a second time, triggering the fallback check and incorrectly displaying it as [Attachment].
Code Duplication & Fragmented Logic: Parsing logic was split across multiple files and methods (parseTopicMessage in NotificationsContainerNode, and extractText/extractEmbedSummary/extractDisplayText in NotificationRecord), leading to inconsistent parsing behaviors between Mentions and Topic tabs.
Solution
Eliminated Double-Parsing: Modified NotificationRecord.previewText to return the stored content directly without parsing it a second time.
Unified Parsing Engine: Deleted duplicate parsing code in NotificationsContainerNode.parseTopicMessage and unified all preview parsing across the entire app under a single, robust method: NotificationRecord.extractDisplayText(from:).
Cleaned Up Obsolete Parsers: Removed legacy methods (extractText and extractEmbedSummary) to prevent future logic fragmentation.
Test Cases
TC01: Verify that a standard plain text message (e.g., "Hello World") displays correctly as "Hello World" in both Mentions and Topic tabs.
TC02: Verify that a message containing literally "{}" (typed by the user) displays correctly as "{}" instead of [Attachment] in both tabs.
TC03: Verify that a message containing a shared contact embed displays correctly as [Contact] in both tabs.
TC04: Verify that a message containing a general link embed displays correctly as [Embed] in both tabs.
TC05: Verify that a message containing only a file/image attachment displays correctly as [Attachment] in both tabs.
TC06: Verify that a message containing both text content and an attachment prioritizes and displays as [Attachment] in both tabs.
