### PR TITLE
feat: add show slide media channel, fix pasted image, write last seen

### DIFF
--- a/MezonChat/Core/Display/TabBarControllerImpl.swift
+++ b/MezonChat/Core/Display/TabBarControllerImpl.swift
@@ -48,10 +48,6 @@ open class TabBarControllerImpl: ViewController, TabBarController {
 
     required public init(coder aDecoder: NSCoder) { fatalError() }
 
-    override open var shouldAutomaticallyForwardAppearanceMethods: Bool {
-        false
-    }
-
     deinit {
         NotificationCenter.default.removeObserver(self, name: ThemeManager.didChangeNotification, object: nil)
         pendingControllerDisposable.dispose()
@@ -249,17 +245,17 @@ open class TabBarControllerImpl: ViewController, TabBarController {
 
     override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        currentController?.beginAppearanceTransition(true, animated: animated)
+        currentController?.viewWillAppear(animated)
     }
 
     override open func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        currentController?.endAppearanceTransition()
+        currentController?.viewDidAppear(animated)
     }
 
     override open func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        currentController?.beginAppearanceTransition(false, animated: animated)
+        currentController?.viewWillDisappear(animated)
     }
 
     override open func viewDidDisappear(_ animated: Bool) {

--- a/MezonChat/Core/UI/Gallery/GalleryController.swift
+++ b/MezonChat/Core/UI/Gallery/GalleryController.swift
@@ -2,6 +2,7 @@ import Foundation
 import UIKit
 import AsyncDisplayKit
 import Photos
+import AVFoundation
 
 final class GalleryController: UIViewController {
     private enum PhotoLibrarySaveAuthorizationResult {
@@ -10,8 +11,9 @@ final class GalleryController: UIViewController {
         case restricted
     }
 
-    private let items: [GalleryItemInfo]
+    private var items: [GalleryItemInfo]
     private let initialIndex: Int
+    private let channelItemsLoader: (() async -> [GalleryItemInfo])?
 
     private let containerNode: ASDisplayNode
     private let backgroundNode: ASDisplayNode
@@ -24,6 +26,8 @@ final class GalleryController: UIViewController {
     private let dateLabel = UILabel()
     private let moreButton = UIButton(type: .system)
     private let counterLabel = UILabel()
+    private let footerView = UIView()
+    private let thumbnailCollectionView: UICollectionView
 
     private var isHeaderVisible = false
     private var panStartCenter: CGPoint = .zero
@@ -31,13 +35,20 @@ final class GalleryController: UIViewController {
     private let placeholderImageView = UIImageView()
     private var didPerformDeferredSetup = false
 
-    init(items: [GalleryItemInfo], initialIndex: Int) {
+    init(items: [GalleryItemInfo], initialIndex: Int, channelItemsLoader: (() async -> [GalleryItemInfo])? = nil) {
         self.items = items
         self.initialIndex = max(0, min(initialIndex, items.count - 1))
+        self.channelItemsLoader = channelItemsLoader
 
         self.containerNode = ASDisplayNode()
         self.backgroundNode = ASDisplayNode()
         self.pagingNode = GalleryPagingNode()
+        let thumbnailLayout = UICollectionViewFlowLayout()
+        thumbnailLayout.scrollDirection = .horizontal
+        thumbnailLayout.minimumInteritemSpacing = 4
+        thumbnailLayout.minimumLineSpacing = 4
+        thumbnailLayout.itemSize = CGSize(width: 44, height: 64)
+        self.thumbnailCollectionView = UICollectionView(frame: .zero, collectionViewLayout: thumbnailLayout)
 
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .overFullScreen
@@ -54,13 +65,15 @@ final class GalleryController: UIViewController {
         placeholderImageView.contentMode = .scaleAspectFit
         placeholderImageView.backgroundColor = .black
         placeholderImageView.translatesAutoresizingMaskIntoConstraints = false
-        let initialItem = items[initialIndex]
-        if let placeholderURL = initialItem.placeholderURL,
-           !placeholderURL.isEmpty,
-           let cached = ImageCache.shared.memoryImage(forKey: placeholderURL) {
-            placeholderImageView.image = cached
-        } else {
-            placeholderImageView.image = initialItem.image
+        if items.indices.contains(initialIndex) {
+            let initialItem = items[initialIndex]
+            if let placeholderURL = initialItem.placeholderURL,
+               !placeholderURL.isEmpty,
+               let cached = ImageCache.shared.memoryImage(forKey: placeholderURL) {
+                placeholderImageView.image = cached
+            } else {
+                placeholderImageView.image = initialItem.image
+            }
         }
         view.addSubview(placeholderImageView)
         NSLayoutConstraint.activate([
@@ -95,13 +108,15 @@ final class GalleryController: UIViewController {
         ])
 
         setupHeader()
-        headerView.alpha = 0
+        setupFooter()
+        headerView.alpha = isHeaderVisible ? 1 : 0
+        footerView.alpha = isHeaderVisible && items.count > 1 ? 1 : 0
 
         pagingNode.configure(items: items, initialIndex: initialIndex) { [weak self] info, index -> GalleryItemNode in
             return self?.makeItemNode(info: info, index: index) ?? GalleryItemNode()
         }
         pagingNode.centralItemIndexUpdated = { [weak self] index in
-            self?.updateHeader(for: index)
+            self?.updateSelection(for: index, revealControls: true)
         }
         pagingNode.toggleControlsVisibility = { [weak self] in
             self?.toggleHeader()
@@ -118,21 +133,20 @@ final class GalleryController: UIViewController {
         view.addSubview(counterLabel)
         NSLayoutConstraint.activate([
             counterLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            counterLabel.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -12),
+            counterLabel.bottomAnchor.constraint(equalTo: footerView.topAnchor, constant: -8),
         ])
 
-        counterLabel.alpha = 0
+        counterLabel.alpha = isHeaderVisible ? 1 : 0
 
         let pan = UIPanGestureRecognizer(target: self, action: #selector(handlePanDismiss(_:)))
         pan.delegate = self
         view.addGestureRecognizer(pan)
 
-        updateHeader(for: initialIndex)
-
         view.setNeedsLayout()
         view.layoutIfNeeded()
         pagingNode.frame = containerNode.bounds
         pagingNode.updateLayout(size: containerNode.bounds.size, navigationBarHeight: 0)
+        loadChannelItemsIfNeeded()
 
         DispatchQueue.main.async { [weak self] in
             self?.placeholderImageView.removeFromSuperview()
@@ -216,8 +230,50 @@ final class GalleryController: UIViewController {
         ])
     }
 
+    private func setupFooter() {
+        footerView.backgroundColor = UIColor.black.withAlphaComponent(0.4)
+        footerView.translatesAutoresizingMaskIntoConstraints = false
+        footerView.isHidden = !isHeaderVisible || items.count <= 1
+        view.addSubview(footerView)
+
+        thumbnailCollectionView.backgroundColor = .clear
+        thumbnailCollectionView.showsHorizontalScrollIndicator = false
+        thumbnailCollectionView.contentInset = UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 12)
+        thumbnailCollectionView.dataSource = self
+        thumbnailCollectionView.delegate = self
+        thumbnailCollectionView.register(GalleryThumbnailCell.self, forCellWithReuseIdentifier: GalleryThumbnailCell.reuseIdentifier)
+        thumbnailCollectionView.translatesAutoresizingMaskIntoConstraints = false
+        footerView.addSubview(thumbnailCollectionView)
+
+        NSLayoutConstraint.activate([
+            footerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            footerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            footerView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            footerView.heightAnchor.constraint(equalToConstant: 96),
+
+            thumbnailCollectionView.leadingAnchor.constraint(equalTo: footerView.leadingAnchor),
+            thumbnailCollectionView.trailingAnchor.constraint(equalTo: footerView.trailingAnchor),
+            thumbnailCollectionView.topAnchor.constraint(equalTo: footerView.topAnchor, constant: 12),
+            thumbnailCollectionView.bottomAnchor.constraint(equalTo: footerView.safeAreaLayoutGuide.bottomAnchor, constant: -10),
+        ])
+    }
+
+    private func updateSelection(for index: Int, revealControls: Bool) {
+        if revealControls {
+            if isHeaderVisible {
+                updateHeader(for: index)
+                updateFooterSelection(for: index, animated: true)
+            } else {
+                setControlsVisible(true, animated: true)
+            }
+        } else if isHeaderVisible {
+            updateHeader(for: index)
+            updateFooterSelection(for: index, animated: true)
+        }
+    }
+
     private func updateHeader(for index: Int) {
-        guard index < items.count else { return }
+        guard index >= 0, index < items.count else { return }
         let item = items[index]
 
         nameLabel.text = item.senderName.isEmpty ? nil : item.senderName
@@ -259,12 +315,100 @@ final class GalleryController: UIViewController {
         }
     }
 
-    private func toggleHeader() {
-        isHeaderVisible.toggle()
-        UIView.animate(withDuration: 0.25) {
-            self.headerView.alpha = self.isHeaderVisible ? 1 : 0
-            self.counterLabel.alpha = self.isHeaderVisible ? 1 : 0
+    private func updateFooterSelection(for index: Int, animated: Bool) {
+        guard items.count > 1, index >= 0, index < items.count else {
+            footerView.isHidden = true
+            return
         }
+        footerView.isHidden = false
+        thumbnailCollectionView.reloadData()
+        thumbnailCollectionView.layoutIfNeeded()
+        thumbnailCollectionView.selectItem(
+            at: IndexPath(item: index, section: 0),
+            animated: false,
+            scrollPosition: []
+        )
+        thumbnailCollectionView.scrollToItem(
+            at: IndexPath(item: index, section: 0),
+            at: .centeredHorizontally,
+            animated: animated
+        )
+    }
+
+    private func loadChannelItemsIfNeeded() {
+        guard let channelItemsLoader else { return }
+        Task { [weak self] in
+            let loadedItems = await channelItemsLoader()
+            await MainActor.run {
+                self?.applyLoadedChannelItems(loadedItems)
+            }
+        }
+    }
+
+    private func applyLoadedChannelItems(_ loadedItems: [GalleryItemInfo]) {
+        guard !loadedItems.isEmpty else { return }
+        let currentIdentity = items.indices.contains(pagingNode.centralItemIndex)
+            ? items[pagingNode.centralItemIndex].stableIdentity
+            : nil
+        let mergedItems = mergedItems(primary: loadedItems, fallback: items)
+        guard !mergedItems.isEmpty else { return }
+        let focusIndex: Int
+        if let currentIdentity,
+           let found = mergedItems.firstIndex(where: { $0.stableIdentity == currentIdentity }) {
+            focusIndex = found
+        } else {
+            focusIndex = min(pagingNode.centralItemIndex, mergedItems.count - 1)
+        }
+        items = mergedItems
+        pagingNode.replaceItemsPreservingCurrent(mergedItems, focusIndex: focusIndex)
+        if isHeaderVisible {
+            setControlsVisible(true, animated: false)
+        }
+    }
+
+    private func mergedItems(primary: [GalleryItemInfo], fallback: [GalleryItemInfo]) -> [GalleryItemInfo] {
+        var seen = Set<String>()
+        var result: [GalleryItemInfo] = []
+        for item in primary + fallback {
+            let key = item.stableIdentity.isEmpty ? "local:\(result.count)" : item.stableIdentity
+            guard seen.insert(key).inserted else { continue }
+            result.append(item)
+        }
+        return result
+    }
+
+    private func toggleHeader() {
+        setControlsVisible(!isHeaderVisible, animated: true)
+    }
+
+    private func setControlsVisible(_ visible: Bool, animated: Bool) {
+        isHeaderVisible = visible
+        if visible {
+            updateHeader(for: pagingNode.centralItemIndex)
+            updateFooterSelection(for: pagingNode.centralItemIndex, animated: false)
+        }
+        let updates = {
+            self.headerView.alpha = visible ? 1 : 0
+            self.counterLabel.alpha = visible ? 1 : 0
+            self.footerView.alpha = visible && self.items.count > 1 ? 1 : 0
+        }
+        guard animated else {
+            updates()
+            if !visible {
+                self.footerView.isHidden = true
+            }
+            return
+        }
+        if visible {
+            footerView.isHidden = items.count <= 1
+        }
+        UIView.animate(withDuration: 0.25, animations: {
+            updates()
+        }, completion: { _ in
+            if !visible {
+                self.footerView.isHidden = true
+            }
+        })
     }
 
     private func makeItemNode(info: GalleryItemInfo, index: Int) -> GalleryItemNode {
@@ -286,6 +430,7 @@ final class GalleryController: UIViewController {
     }
 
     @objc private func moreTapped() {
+        guard items.indices.contains(pagingNode.centralItemIndex) else { return }
         let sheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
         let currentItem = items[pagingNode.centralItemIndex]
@@ -445,6 +590,7 @@ final class GalleryController: UIViewController {
             if isHeaderVisible {
                 headerView.alpha = max(0, 1 - progress * 2)
                 counterLabel.alpha = max(0, 1 - progress * 2)
+                footerView.alpha = items.count > 1 ? max(0, 1 - progress * 2) : 0
             }
             containerNode.view.center = CGPoint(x: panStartCenter.x, y: panStartCenter.y + translation.y)
         case .ended, .cancelled:
@@ -457,6 +603,8 @@ final class GalleryController: UIViewController {
                     self.backgroundNode.alpha = 0
                     self.containerNode.alpha = 0
                     self.headerView.alpha = 0
+                    self.counterLabel.alpha = 0
+                    self.footerView.alpha = 0
                     let targetY = translation.y > 0 ? self.view.bounds.height : -self.view.bounds.height
                     self.containerNode.view.center = CGPoint(x: self.panStartCenter.x, y: targetY)
                 }) { _ in
@@ -466,6 +614,8 @@ final class GalleryController: UIViewController {
                 UIView.animate(withDuration: 0.3, delay: 0, usingSpringWithDamping: 0.8, initialSpringVelocity: 0) {
                     self.backgroundNode.alpha = 1
                     self.headerView.alpha = self.isHeaderVisible ? 1 : 0
+                    self.counterLabel.alpha = self.isHeaderVisible ? 1 : 0
+                    self.footerView.alpha = self.isHeaderVisible && self.items.count > 1 ? 1 : 0
                     self.containerNode.view.center = self.panStartCenter
                 }
             }
@@ -482,6 +632,151 @@ final class GalleryController: UIViewController {
         if cal.isDateInYesterday(date) { return "Yesterday at \(time)" }
         fmt.dateFormat = "dd/MM/yyyy HH:mm"
         return fmt.string(from: date)
+    }
+}
+
+extension GalleryController: UICollectionViewDataSource, UICollectionViewDelegate {
+
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        items.count
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: GalleryThumbnailCell.reuseIdentifier,
+            for: indexPath
+        ) as? GalleryThumbnailCell else {
+            return UICollectionViewCell()
+        }
+        let index = indexPath.item
+        if index < items.count {
+            cell.configure(item: items[index], isSelected: index == pagingNode.centralItemIndex)
+        }
+        return cell
+    }
+
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard indexPath.item < items.count else { return }
+        pagingNode.setCentralItemIndex(indexPath.item, animated: true)
+        updateSelection(for: indexPath.item, revealControls: false)
+    }
+}
+
+private final class GalleryThumbnailCell: UICollectionViewCell {
+    static let reuseIdentifier = "GalleryThumbnailCell"
+
+    private let imageView = UIImageView()
+    private let playOverlayView = UIView()
+    private let playIconView = UIImageView()
+    private var representedIdentity: String?
+    private var imageTask: URLSessionDataTask?
+    private var thumbnailGenerator: AVAssetImageGenerator?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        contentView.clipsToBounds = true
+        contentView.layer.cornerRadius = 4
+        contentView.backgroundColor = UIColor.white.withAlphaComponent(0.12)
+
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(imageView)
+
+        playOverlayView.backgroundColor = UIColor.black.withAlphaComponent(0.28)
+        playOverlayView.translatesAutoresizingMaskIntoConstraints = false
+        playOverlayView.isHidden = true
+        contentView.addSubview(playOverlayView)
+
+        let playConfig = UIImage.SymbolConfiguration(pointSize: 16, weight: .semibold)
+        playIconView.image = UIImage(systemName: "play.fill", withConfiguration: playConfig)?
+            .withTintColor(.white, renderingMode: .alwaysOriginal)
+        playIconView.contentMode = .scaleAspectFit
+        playIconView.translatesAutoresizingMaskIntoConstraints = false
+        playOverlayView.addSubview(playIconView)
+
+        NSLayoutConstraint.activate([
+            imageView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            imageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            imageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+
+            playOverlayView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            playOverlayView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            playOverlayView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            playOverlayView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+
+            playIconView.centerXAnchor.constraint(equalTo: playOverlayView.centerXAnchor),
+            playIconView.centerYAnchor.constraint(equalTo: playOverlayView.centerYAnchor),
+            playIconView.widthAnchor.constraint(equalToConstant: 18),
+            playIconView.heightAnchor.constraint(equalToConstant: 18),
+        ])
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        representedIdentity = nil
+        imageTask?.cancel()
+        imageTask = nil
+        thumbnailGenerator?.cancelAllCGImageGeneration()
+        thumbnailGenerator = nil
+        imageView.image = nil
+        playOverlayView.isHidden = true
+    }
+
+    func configure(item: GalleryItemInfo, isSelected: Bool) {
+        representedIdentity = item.stableIdentity
+        contentView.layer.borderWidth = isSelected ? 2 : 0
+        contentView.layer.borderColor = isSelected ? UIColor.systemBlue.cgColor : UIColor.clear.cgColor
+        playOverlayView.isHidden = !item.isVideo
+
+        if item.isVideo {
+            loadVideoThumbnail(urlString: item.sourceURL ?? item.url, identity: item.stableIdentity)
+        } else if let image = item.image {
+            imageView.image = image
+        } else {
+            let thumbnailURL = item.placeholderURL ?? item.url
+            loadImage(urlString: thumbnailURL, identity: item.stableIdentity)
+        }
+    }
+
+    private func loadImage(urlString: String, identity: String) {
+        guard !urlString.isEmpty else { return }
+        imageTask = ImageCache.shared.loadImage(urlString: urlString) { [weak self] image in
+            guard let self, self.representedIdentity == identity else { return }
+            self.imageView.image = image
+        }
+    }
+
+    private func loadVideoThumbnail(urlString: String, identity: String) {
+        guard let videoURL = URL(string: urlString), !urlString.isEmpty else { return }
+        let cacheKey = "video_thumb_\(urlString)"
+        if let cached = ImageCache.shared.image(forKey: cacheKey) {
+            imageView.image = cached
+            return
+        }
+
+        let asset = AVURLAsset(url: videoURL, options: [
+            AVURLAssetPreferPreciseDurationAndTimingKey: false
+        ])
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        generator.maximumSize = CGSize(width: 160, height: 160)
+        thumbnailGenerator = generator
+
+        let time = CMTime(seconds: 0.5, preferredTimescale: 600)
+        generator.generateCGImagesAsynchronously(forTimes: [NSValue(time: time)]) { [weak self] _, cgImage, _, _, _ in
+            guard let cgImage else { return }
+            let image = UIImage(cgImage: cgImage)
+            ImageCache.shared.setImage(image, data: image.jpegData(compressionQuality: 0.7), forKey: cacheKey)
+            DispatchQueue.main.async {
+                guard let self, self.representedIdentity == identity else { return }
+                self.imageView.image = image
+            }
+        }
     }
 }
 

--- a/MezonChat/Core/UI/Gallery/GalleryItemNode.swift
+++ b/MezonChat/Core/UI/Gallery/GalleryItemNode.swift
@@ -4,6 +4,7 @@ import AsyncDisplayKit
 
 public struct GalleryItemInfo {
     public let url: String
+    public let sourceURL: String?
     public let image: UIImage?
     public let placeholderURL: String?
     public let senderName: String
@@ -11,8 +12,14 @@ public struct GalleryItemInfo {
     public let timestamp: Date?
     public let isVideo: Bool
 
-    public init(url: String, image: UIImage? = nil, placeholderURL: String? = nil, senderName: String = "", senderAvatarURL: String? = nil, timestamp: Date? = nil, isVideo: Bool = false) {
+    public var stableIdentity: String {
+        if let sourceURL, !sourceURL.isEmpty { return sourceURL }
+        return url
+    }
+
+    public init(url: String, sourceURL: String? = nil, image: UIImage? = nil, placeholderURL: String? = nil, senderName: String = "", senderAvatarURL: String? = nil, timestamp: Date? = nil, isVideo: Bool = false) {
         self.url = url
+        self.sourceURL = sourceURL
         self.image = image
         self.placeholderURL = placeholderURL
         self.senderName = senderName

--- a/MezonChat/Core/UI/Gallery/GalleryPagingNode.swift
+++ b/MezonChat/Core/UI/Gallery/GalleryPagingNode.swift
@@ -42,6 +42,72 @@ final class GalleryPagingNode: ASDisplayNode, UIScrollViewDelegate {
         self.centralItemIndex = max(0, min(initialIndex, items.count - 1))
     }
 
+    func replaceItems(_ items: [GalleryItemInfo], focusIndex: Int) {
+        for node in itemNodes.values {
+            node.view.removeFromSuperview()
+        }
+        itemNodes.removeAll()
+        self.items = items
+        self.centralItemIndex = max(0, min(focusIndex, items.count - 1))
+        self.hasPerformedInitialLayout = false
+        if currentSize.width > 0, currentSize.height > 0 {
+            updateLayout(size: currentSize, navigationBarHeight: 0)
+        }
+    }
+
+    func replaceItemsPreservingCurrent(_ items: [GalleryItemInfo], focusIndex: Int) {
+        guard currentSize.width > 0, currentSize.height > 0,
+              !items.isEmpty,
+              let currentNode = itemNodes[centralItemIndex]
+        else {
+            replaceItems(items, focusIndex: focusIndex)
+            return
+        }
+
+        let targetIndex = max(0, min(focusIndex, items.count - 1))
+        for (index, node) in itemNodes where index != centralItemIndex {
+            node.view.removeFromSuperview()
+        }
+        itemNodes.removeAll()
+        itemNodes[targetIndex] = currentNode
+
+        self.items = items
+        self.centralItemIndex = targetIndex
+        self.hasPerformedInitialLayout = true
+
+        UIView.performWithoutAnimation {
+            scrollView.contentSize = CGSize(width: currentSize.width * CGFloat(items.count), height: currentSize.height)
+            scrollView.contentOffset = CGPoint(x: CGFloat(targetIndex) * currentSize.width, y: 0)
+            currentNode.index = targetIndex
+            currentNode.itemInfo = items[targetIndex]
+            currentNode.frame = CGRect(
+                x: CGFloat(targetIndex) * currentSize.width,
+                y: 0,
+                width: currentSize.width,
+                height: currentSize.height
+            )
+            currentNode.containerLayoutUpdated(currentSize, navigationBarHeight: 0, transition: .immediate)
+            currentNode.centralityUpdated(isCentral: true)
+            scrollView.layoutIfNeeded()
+        }
+
+        loadVisibleItems(size: currentSize, navigationBarHeight: 0)
+    }
+
+    func setCentralItemIndex(_ index: Int, animated: Bool) {
+        let targetIndex = max(0, min(index, items.count - 1))
+        guard targetIndex != centralItemIndex || animated else { return }
+        if currentSize.width <= 0 {
+            centralItemIndex = targetIndex
+            return
+        }
+        let targetOffset = CGPoint(x: CGFloat(targetIndex) * currentSize.width, y: 0)
+        scrollView.setContentOffset(targetOffset, animated: animated)
+        if !animated {
+            updateCentralIndex()
+        }
+    }
+
     func updateLayout(size: CGSize, navigationBarHeight: CGFloat) {
         guard size.width > 0, size.height > 0 else { return }
         self.currentSize = size

--- a/MezonChat/Core/UI/Toast.swift
+++ b/MezonChat/Core/UI/Toast.swift
@@ -50,6 +50,7 @@ final class Toast {
 private final class ToastManager {
 
     static let shared = ToastManager()
+    private static let overlayZPosition: CGFloat = 10_000
 
     private var toastContainer: UIView?
     private var toastWindow: UIWindow?
@@ -76,7 +77,7 @@ private final class ToastManager {
 
         let container = UIView()
         container.translatesAutoresizingMaskIntoConstraints = false
-        container.layer.zPosition = CGFloat.greatestFiniteMagnitude
+        container.layer.zPosition = Self.overlayZPosition
         container.addSubview(toastView)
 
         hostView.addSubview(container)
@@ -94,10 +95,8 @@ private final class ToastManager {
         ])
 
         toastContainer = container
-        toastView.alpha = 0
         toastView.transform = CGAffineTransform(translationX: 0, y: -20)
         UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseOut) {
-            toastView.alpha = 1
             toastView.transform = .identity
         }
 
@@ -112,14 +111,10 @@ private final class ToastManager {
         dismissWorkItem?.cancel()
         dismissWorkItem = nil
 
-        UIView.animate(withDuration: 0.2) {
-            self.toastContainer?.alpha = 0
-        } completion: { _ in
-            self.toastContainer?.removeFromSuperview()
-            self.toastContainer = nil
-            self.toastWindow?.isHidden = true
-            self.toastWindow = nil
-        }
+        toastContainer?.removeFromSuperview()
+        toastContainer = nil
+        toastWindow?.isHidden = true
+        toastWindow = nil
     }
 
     func presentComingSoonPill(message: String, duration: TimeInterval) {
@@ -133,7 +128,7 @@ private final class ToastManager {
         pill.translatesAutoresizingMaskIntoConstraints = false
         let container = UIView()
         container.translatesAutoresizingMaskIntoConstraints = false
-        container.layer.zPosition = CGFloat.greatestFiniteMagnitude
+        container.layer.zPosition = Self.overlayZPosition
         container.addSubview(pill)
         hostView.addSubview(container)
         hostView.bringSubviewToFront(container)
@@ -150,10 +145,8 @@ private final class ToastManager {
             pill.bottomAnchor.constraint(equalTo: container.bottomAnchor)
         ])
         toastContainer = container
-        pill.alpha = 0
         pill.transform = CGAffineTransform(translationX: 0, y: 16)
         UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseOut) {
-            pill.alpha = 1
             pill.transform = .identity
         }
         let work = DispatchWorkItem { [weak self] in
@@ -165,15 +158,28 @@ private final class ToastManager {
 
     private func makeToastHostView() -> UIView? {
         guard let scene = Self.findWindowScene() else { return nil }
+        let statusBarStyle = Self.currentStatusBarStyle(in: scene)
         let window = ToastPassthroughWindow(windowScene: scene)
         window.backgroundColor = .clear
         window.windowLevel = .alert + 1
-        let controller = UIViewController()
+        let controller = ToastRootViewController(statusBarStyle: statusBarStyle)
         controller.view.backgroundColor = .clear
         window.rootViewController = controller
         window.isHidden = false
         toastWindow = window
         return controller.view
+    }
+
+    private static func currentStatusBarStyle(in scene: UIWindowScene) -> UIStatusBarStyle {
+        let candidateWindows = scene.windows.filter { window in
+            window.isKeyWindow && !window.isHidden && !(window is ToastPassthroughWindow)
+        }
+
+        if let rootViewController = candidateWindows.first?.rootViewController {
+            return rootViewController.preferredStatusBarStyle
+        }
+
+        return ThemeManager.shared.preferredStatusBarStyle
     }
 
     private static func findWindowScene() -> UIWindowScene? {
@@ -191,7 +197,30 @@ private final class ToastManager {
     }
 }
 
+private final class ToastRootViewController: UIViewController {
+    private let statusBarStyle: UIStatusBarStyle
+
+    init(statusBarStyle: UIStatusBarStyle) {
+        self.statusBarStyle = statusBarStyle
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        statusBarStyle
+    }
+
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        .all
+    }
+}
+
 private final class ToastPassthroughWindow: UIWindow {
+    override var canBecomeKey: Bool {
+        false
+    }
+
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         let hitView = super.hitTest(point, with: event)
         if hitView === rootViewController?.view {
@@ -210,6 +239,10 @@ private final class ToastView: UIView {
     private let titleText: String?
     private let messageText: String
 
+    private let contentView = UIView()
+    private let gradientLayer = CAGradientLayer()
+    private let cornerRadius: CGFloat = 12.sw
+
     init(type: ToastType, title: String?, message: String) {
         self.type = type
         self.titleText = title
@@ -220,15 +253,39 @@ private final class ToastView: UIView {
 
     required init?(coder: NSCoder) { fatalError() }
 
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        gradientLayer.frame = contentView.bounds
+        layer.shadowPath = UIBezierPath(roundedRect: bounds, cornerRadius: cornerRadius).cgPath
+    }
+
     private func setup() {
         let config = Self.config(for: type)
 
         translatesAutoresizingMaskIntoConstraints = false
-        backgroundColor = config.bgColor
-        layer.cornerRadius = 12.sw
-        layer.borderWidth = 1
-        layer.borderColor = config.borderColor.cgColor
-        clipsToBounds = true
+        backgroundColor = .clear
+
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.08
+        layer.shadowOffset = CGSize(width: 0, height: 3)
+        layer.shadowRadius = 10
+
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.backgroundColor = UIColor.white
+        contentView.layer.cornerRadius = cornerRadius
+        contentView.layer.borderWidth = 1
+        contentView.layer.borderColor = config.borderColor.cgColor
+        contentView.layer.masksToBounds = true
+
+        gradientLayer.colors = [
+            config.bgGradientStart.cgColor,
+            config.bgGradientEnd.cgColor
+        ]
+        gradientLayer.startPoint = CGPoint(x: 0, y: 0.5)
+        gradientLayer.endPoint = CGPoint(x: 1, y: 0.5)
+        contentView.layer.insertSublayer(gradientLayer, at: 0)
+
+        addSubview(contentView)
 
         let tap = UITapGestureRecognizer(target: self, action: #selector(handleTap))
         addGestureRecognizer(tap)
@@ -251,43 +308,46 @@ private final class ToastView: UIView {
         let titleLabel = UILabel()
         titleLabel.text = titleText ?? config.defaultTitle
         titleLabel.font = .systemFont(ofSize: 15.sf, weight: .bold)
-        titleLabel.textColor = type == .notification ? UIColor.theme.textStrong : .init(white: 0.15, alpha: 1)
+        titleLabel.textColor = type == .notification ? UIColor.theme.textStrong : .init(white: 0.1, alpha: 1)
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
 
         let messageLabel = UILabel()
         messageLabel.text = messageText
         messageLabel.font = .systemFont(ofSize: 14.sf)
-        messageLabel.textColor = type == .notification ? UIColor.theme.text : .init(white: 0.35, alpha: 1)
+        messageLabel.textColor = type == .notification ? UIColor.theme.text : .init(white: 0.25, alpha: 1)
         messageLabel.numberOfLines = 3
         messageLabel.translatesAutoresizingMaskIntoConstraints = false
 
         let closeBtn = UIButton(type: .system)
         closeBtn.setImage(UIImage(systemName: "xmark"), for: .normal)
-        closeBtn.tintColor = type == .notification ? UIColor.theme.iconSecondary : .init(white: 0.4, alpha: 1)
+        closeBtn.tintColor = type == .notification ? UIColor.theme.iconSecondary : .init(white: 0.3, alpha: 1)
         closeBtn.addTarget(self, action: #selector(closeButtonTapped), for: .touchUpInside)
         closeBtn.translatesAutoresizingMaskIntoConstraints = false
 
-        addSubview(leftBar)
-        addSubview(iconBg)
-        addSubview(titleLabel)
-        addSubview(messageLabel)
-        addSubview(closeBtn)
+        contentView.addSubview(leftBar)
+        contentView.addSubview(iconBg)
+        contentView.addSubview(closeBtn)
 
         let textStack = UIStackView(arrangedSubviews: [titleLabel, messageLabel])
         textStack.axis = .vertical
         textStack.spacing = 4.sh
         textStack.alignment = .leading
         textStack.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(textStack)
+        contentView.addSubview(textStack)
 
         NSLayoutConstraint.activate([
-            leftBar.leadingAnchor.constraint(equalTo: leadingAnchor),
-            leftBar.topAnchor.constraint(equalTo: topAnchor),
-            leftBar.bottomAnchor.constraint(equalTo: bottomAnchor),
+            contentView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            contentView.topAnchor.constraint(equalTo: topAnchor),
+            contentView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            leftBar.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            leftBar.topAnchor.constraint(equalTo: contentView.topAnchor),
+            leftBar.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
             leftBar.widthAnchor.constraint(equalToConstant: 4.sw),
 
             iconBg.leadingAnchor.constraint(equalTo: leftBar.trailingAnchor, constant: 12.sw),
-            iconBg.centerYAnchor.constraint(equalTo: centerYAnchor),
+            iconBg.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             iconBg.widthAnchor.constraint(equalToConstant: 36.swh),
             iconBg.heightAnchor.constraint(equalToConstant: 36.swh),
             iconView.centerXAnchor.constraint(equalTo: iconBg.centerXAnchor),
@@ -297,27 +357,34 @@ private final class ToastView: UIView {
 
             textStack.leadingAnchor.constraint(equalTo: iconBg.trailingAnchor, constant: 12.sw),
             textStack.trailingAnchor.constraint(equalTo: closeBtn.leadingAnchor, constant: -12.sw),
-            textStack.centerYAnchor.constraint(equalTo: centerYAnchor),
-            textStack.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: 14.sh),
-            bottomAnchor.constraint(greaterThanOrEqualTo: textStack.bottomAnchor, constant: 14.sh),
+            textStack.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            textStack.topAnchor.constraint(greaterThanOrEqualTo: contentView.topAnchor, constant: 14.sh),
+            contentView.bottomAnchor.constraint(greaterThanOrEqualTo: textStack.bottomAnchor, constant: 14.sh),
 
-            closeBtn.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12.sw),
-            closeBtn.centerYAnchor.constraint(equalTo: centerYAnchor),
+            closeBtn.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -12.sw),
+            closeBtn.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             closeBtn.widthAnchor.constraint(equalToConstant: 32.swh),
             closeBtn.heightAnchor.constraint(equalToConstant: 32.swh),
         ])
     }
 
-    private static func config(for type: ToastType) -> (accentColor: UIColor, bgColor: UIColor, borderColor: UIColor, iconName: String, defaultTitle: String) {
+    private static func config(for type: ToastType) -> (
+        accentColor: UIColor,
+        bgGradientStart: UIColor,
+        bgGradientEnd: UIColor,
+        borderColor: UIColor,
+        iconName: String,
+        defaultTitle: String
+    ) {
         switch type {
         case .success:
-            return (hex("#22c55e"), hex("#dcfce7"), hex("#bbf7d0"), "checkmark", "Success")
+            return (hex("#22c55e"), hex("#86efac"), hex("#dcfce7"), hex("#86efac"), "checkmark", "Success")
         case .error:
-            return (hex("#ef4444"), hex("#fef2f2"), hex("#fecaca"), "xmark", "Error")
+            return (hex("#ef4444"), hex("#fca5a5"), hex("#fef2f2"), hex("#fca5a5"), "xmark", "Error")
         case .info:
-            return (hex("#3b82f6"), hex("#eff6ff"), hex("#bfdbfe"), "info.circle.fill", "Info")
+            return (hex("#3b82f6"), hex("#93c5fd"), hex("#eff6ff"), hex("#93c5fd"), "info.circle.fill", "Info")
         case .notification:
-            return (UIColor.theme.iconPrimary, UIColor.theme.secondary, UIColor.theme.border, "bell.fill", "Notification")
+            return (UIColor.theme.iconPrimary, UIColor.theme.secondary, UIColor.theme.secondary, UIColor.theme.border, "bell.fill", "Notification")
         }
     }
 
@@ -334,7 +401,7 @@ private final class ToastView: UIView {
 private final class ComingSoonPillView: UIView {
     init(message: String) {
         super.init(frame: .zero)
-        backgroundColor = UIColor(white: 0.2, alpha: 0.92)
+        backgroundColor = UIColor(white: 0.2, alpha: 1)
         layer.cornerRadius = 24.swh
         layer.masksToBounds = true
         let label = UILabel()

--- a/MezonChat/Features/Chat/Cells/MessageBubbleNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageBubbleNode.swift
@@ -367,7 +367,7 @@ final class MessageBubbleNode: ASDisplayNode {
 
         if hasShareContact, let shareContactData {
             let scn = MessageShareContactNode()
-            scn.configure(data: shareContactData)
+            scn.configure(data: shareContactData, callBlocked: interaction.isShareContactCallBlocked(shareContactData))
             scn.onProfileTapped = { [weak self] data in
                 self?.interaction.onShareContactProfileTapped(data)
             }
@@ -630,6 +630,7 @@ final class MessageBubbleNode: ASDisplayNode {
             addSubnode(n)
         }
 
+        let textContentExistenceChanged: Bool
         if Self.shouldShowTextContent(for: newDisplay) {
             if let tcn = textContentNode {
                 if textChanged || mentionHighlightChanged {
@@ -639,6 +640,7 @@ final class MessageBubbleNode: ASDisplayNode {
                         hashtagChannelAccess: interaction.hashtagChannelIsAccessible
                     )
                 }
+                textContentExistenceChanged = false
             } else {
                 let tcn = MessageTextContentNode()
                 tcn.configure(
@@ -657,11 +659,15 @@ final class MessageBubbleNode: ASDisplayNode {
                 if let c = clanInviteLinkNode { insertSubnode(tcn, belowSubnode: c) }
                 else if let m = mediaContentNode { insertSubnode(tcn, belowSubnode: m) }
                 else { addSubnode(tcn) }
+                textContentExistenceChanged = true
             }
         } else {
             if let tcn = textContentNode {
                 tcn.removeFromSupernode()
                 textContentNode = nil
+                textContentExistenceChanged = true
+            } else {
+                textContentExistenceChanged = false
             }
         }
 
@@ -688,13 +694,16 @@ final class MessageBubbleNode: ASDisplayNode {
         let newShareContact = newDisplay.shareContactData
         let shareContactChanged = oldShareContact != newShareContact
         if let data = newShareContact {
+            let callBlocked = interaction.isShareContactCallBlocked(data)
             if let scn = shareContactNode {
                 if shareContactChanged {
-                    scn.configure(data: data)
+                    scn.configure(data: data, callBlocked: callBlocked)
+                } else {
+                    scn.setCallBlocked(callBlocked)
                 }
             } else {
                 let scn = MessageShareContactNode()
-                scn.configure(data: data)
+                scn.configure(data: data, callBlocked: callBlocked)
                 scn.onProfileTapped = { [weak self] data in
                     self?.interaction.onShareContactProfileTapped(data)
                 }
@@ -809,7 +818,7 @@ final class MessageBubbleNode: ASDisplayNode {
             || ogpPreviewChanged
             || (oldFailed != newDisplay.isFailed)
             || inviteChanged || (oldWantInvite != newWantInvite)
-            || (Self.shouldShowTextContent(for: newDisplay) != (textContentNode != nil))
+            || textContentExistenceChanged
             || shareContactChanged
             || embedChanged
             || topicChanged
@@ -817,6 +826,9 @@ final class MessageBubbleNode: ASDisplayNode {
         if needsRelayout {
             let _ = measureSize(width: cachedTotalSize.width)
             setNeedsLayout()
+        }
+        if textContentExistenceChanged {
+            interaction.onMessageNeedsRelayout?(newDisplay.id)
         }
         if !isCombine && avatarChanged {
             loadAvatar()
@@ -1063,6 +1075,10 @@ final class MessageBubbleNode: ASDisplayNode {
     }
 
     private func handleImageTap(index: Int, media: [ParsedAttachment], interaction: ChatInteraction) {
+        if let onMediaTapped = interaction.onMediaTapped {
+            onMediaTapped(index, media, display)
+            return
+        }
         let galleryItems: [GalleryItemInfo] = media.enumerated().map { (_, att) in
             let placeholderURL: String? = att.isVideo
                 ? nil
@@ -1074,6 +1090,7 @@ final class MessageBubbleNode: ASDisplayNode {
                 )
             return GalleryItemInfo(
                 url: att.url,
+                sourceURL: att.url,
                 image: nil,
                 placeholderURL: placeholderURL,
                 senderName: display.senderDisplayName,
@@ -1768,6 +1785,7 @@ private final class MessageShareContactNode: ASDisplayNode {
     private var cachedTopHeight: CGFloat = 0
     private var cachedSize: CGSize = .zero
     private var avatarLoadGeneration: Int = 0
+    private var callBlocked = false
 
     var onProfileTapped: ((ShareContactData) -> Void)?
     var onMessageTapped: ((ShareContactData) -> Void)?
@@ -1816,7 +1834,7 @@ private final class MessageShareContactNode: ASDisplayNode {
         addSubnode(messageButtonNode)
     }
 
-    func configure(data: ShareContactData) {
+    func configure(data: ShareContactData, callBlocked: Bool) {
         self.data = data
         let t = UIColor.theme
         borderColor = t.borderDim.cgColor
@@ -1854,8 +1872,16 @@ private final class MessageShareContactNode: ASDisplayNode {
                 .foregroundColor: t.text,
             ]
         )
-        callButtonNode.applyTheme()
+        setCallBlocked(callBlocked)
         messageButtonNode.applyTheme()
+    }
+
+    func setCallBlocked(_ callBlocked: Bool) {
+        self.callBlocked = callBlocked
+        callButtonNode.isHidden = callBlocked
+        dividerNode.isHidden = callBlocked
+        callButtonNode.setEnabled(!callBlocked)
+        setNeedsLayout()
     }
 
     private func loadAvatar(_ rawAvatar: String, seed: String) {
@@ -1947,8 +1973,13 @@ private final class MessageShareContactNode: ASDisplayNode {
         profileControlNode.frame = CGRect(x: 0, y: 0, width: bounds.width, height: topHeight)
 
         let buttonWidth = floor(bounds.width / 2)
-        callButtonNode.frame = CGRect(x: 0, y: topHeight, width: buttonWidth, height: actionHeight)
-        messageButtonNode.frame = CGRect(x: buttonWidth, y: topHeight, width: bounds.width - buttonWidth, height: actionHeight)
+        if callBlocked {
+            callButtonNode.frame = CGRect(x: 0, y: topHeight, width: 0, height: actionHeight)
+            messageButtonNode.frame = CGRect(x: 0, y: topHeight, width: bounds.width, height: actionHeight)
+        } else {
+            callButtonNode.frame = CGRect(x: 0, y: topHeight, width: buttonWidth, height: actionHeight)
+            messageButtonNode.frame = CGRect(x: buttonWidth, y: topHeight, width: bounds.width - buttonWidth, height: actionHeight)
+        }
     }
 }
 
@@ -1976,6 +2007,7 @@ private final class MessageShareContactActionButtonNode: ASDisplayNode {
 
     var onTapped: (() -> Void)?
     private let titleUsesAccent: Bool
+    private var actionEnabled = true
 
     init(title: String, systemIcon: String, titleUsesAccent: Bool) {
         self.titleUsesAccent = titleUsesAccent
@@ -2005,40 +2037,56 @@ private final class MessageShareContactActionButtonNode: ASDisplayNode {
         applyTheme()
     }
 
+    func setEnabled(_ enabled: Bool) {
+        actionEnabled = enabled
+        control.isEnabled = enabled
+        applyTheme()
+    }
+
     func applyTheme() {
         backgroundNode.backgroundColor = .clear
-        iconNode.tintColor = MessageShareContactNode.blurpleColor
+        let accentColor = MessageShareContactNode.blurpleColor
+        let textColor = titleUsesAccent ? accentColor : UIColor.theme.textStrong
+        let foregroundColor = actionEnabled ? textColor : UIColor.theme.textDisabled
+        iconNode.tintColor = actionEnabled ? accentColor : UIColor.theme.textDisabled
         if let text = titleNode.attributedText?.string {
             titleNode.attributedText = NSAttributedString(
                 string: text,
                 attributes: [
                     .font: UIFont.systemFont(ofSize: 14.sf, weight: .medium),
-                    .foregroundColor: titleUsesAccent ? MessageShareContactNode.blurpleColor : UIColor.theme.textStrong,
+                    .foregroundColor: foregroundColor,
                 ]
             )
         }
     }
 
     @objc private func tapped() {
+        guard actionEnabled else { return }
         onTapped?()
     }
 
     override func layout() {
         super.layout()
         backgroundNode.frame = bounds
+        controlNode.frame = bounds
+        guard bounds.width > 0, bounds.height > 0 else {
+            iconNode.frame = .zero
+            titleNode.frame = .zero
+            return
+        }
         let iconSide: CGFloat = 18
         let gap: CGFloat = 6
         let labelSize = titleNode.measure(CGSize(width: max(bounds.width - 30, 1), height: bounds.height))
         let totalWidth = min(iconSide + gap + labelSize.width, bounds.width - 12)
         let x = max((bounds.width - totalWidth) / 2, 6)
         iconNode.frame = CGRect(x: x, y: (bounds.height - iconSide) / 2, width: iconSide, height: iconSide)
+        let titleWidth = max(min(labelSize.width, bounds.width - iconNode.frame.maxX - gap - 6), 0)
         titleNode.frame = CGRect(
             x: iconNode.frame.maxX + gap,
             y: (bounds.height - labelSize.height) / 2,
-            width: min(labelSize.width, bounds.width - iconNode.frame.maxX - gap - 6),
+            width: titleWidth,
             height: labelSize.height
         )
-        controlNode.frame = bounds
     }
 }
 

--- a/MezonChat/Features/Chat/Cells/MessageReplyNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageReplyNode.swift
@@ -153,22 +153,7 @@ final class MessageReplyNode: ASDisplayNode {
         } else {
             hasAttachment = false
             attachmentIconNode.removeFromSupernode()
-            let raw = ref.content
-            let preview: String
-            if raw.isEmpty {
-                preview = ""
-            } else if let data = raw.data(using: .utf8),
-                      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-                let textVal = (json["t"] as? String) ?? (json["text"] as? String)
-                if let s = textVal {
-                    let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
-                    preview = trimmed.isEmpty ? "" : (trimmed.count > 80 ? String(trimmed.prefix(80)) + "…" : trimmed)
-                } else {
-                    preview = ""
-                }
-            } else {
-                preview = raw.count > 80 ? String(raw.prefix(80)) + "…" : raw
-            }
+            let preview = Self.previewText(from: ref.content)
             previewNode.isHidden = preview.isEmpty
             previewNode.attributedText = NSAttributedString(
                 string: preview,
@@ -178,6 +163,64 @@ final class MessageReplyNode: ASDisplayNode {
                 ]
             )
         }
+    }
+
+    private static func previewText(from raw: String) -> String {
+        let trimmedRaw = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedRaw.isEmpty else { return "" }
+
+        guard let data = trimmedRaw.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return truncatedPreview(trimmedRaw)
+        }
+
+        if isShareContactContent(json) {
+            return "[\(L(L10n.DirectMessage.previewContact))]"
+        }
+
+        let textVal = (json["t"] as? String) ?? (json["text"] as? String)
+        guard let textVal else { return "" }
+        let trimmed = textVal.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "" : truncatedPreview(trimmed)
+    }
+
+    private static func truncatedPreview(_ text: String) -> String {
+        text.count > 80 ? String(text.prefix(80)) + "…" : text
+    }
+
+    private static func isShareContactContent(_ json: [String: Any]) -> Bool {
+        if containsShareContactEmbed(json["embed"]) { return true }
+        if containsShareContactEmbed(json["embeds"]) { return true }
+        return false
+    }
+
+    private static func containsShareContactEmbed(_ value: Any?) -> Bool {
+        let embeds: [[String: Any]]
+        if let array = value as? [[String: Any]] {
+            embeds = array
+        } else if let object = value as? [String: Any] {
+            embeds = [object]
+        } else {
+            return false
+        }
+
+        return embeds.contains { embed in
+            guard let fields = embed["fields"] as? [[String: Any]] else { return false }
+            return fields.contains { field in
+                let name = (field["name"] as? String)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .lowercased() ?? ""
+                let value = (field["value"] as? String)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .lowercased() ?? ""
+                if name == "key", isShareContactValue(value) { return true }
+                return isShareContactValue(value)
+            }
+        }
+    }
+
+    private static func isShareContactValue(_ value: String) -> Bool {
+        value == MezonConstants.shareContactKey || value == "share_contact_key"
     }
 
     func measureSize(maxWidth: CGFloat) -> CGSize {

--- a/MezonChat/Features/Chat/ChatContainerNode.swift
+++ b/MezonChat/Features/Chat/ChatContainerNode.swift
@@ -47,6 +47,7 @@ struct ChatInteraction {
     let onShareContactProfileTapped: (ShareContactData) -> Void
     let onShareContactMessageTapped: (ShareContactData) -> Void
     let onShareContactCallTapped: (ShareContactData) -> Void
+    let isShareContactCallBlocked: (ShareContactData) -> Bool
     let onSwipeReply: (ChatMessageDisplay) -> Void
     let loadClanInviteInfo: (String, @escaping (ClanInviteInfo?) -> Void) -> Void
     let onClanInvitePrimaryAction: (String, ClanInviteInfo) -> Void
@@ -63,6 +64,7 @@ struct ChatInteraction {
     var onMessagesReloaded: (() -> Void)?
     var onMessageNeedsRelayout: ((String) -> Void)?
     var onEmbedButtonClicked: ((ParsedEmbedButton, String, ChatMessageDisplay) -> Void)?  
+    var onMediaTapped: ((_ index: Int, _ media: [ParsedAttachment], _ display: ChatMessageDisplay) -> Void)? = nil
 }
 
 final class ChatContainerNode: ASDisplayNode {
@@ -92,6 +94,7 @@ final class ChatContainerNode: ASDisplayNode {
     private(set) var didAutoScrollForNewMessages = false
     private var isLoadMoreGuardActive = false
     private var lastKnownDistanceFromBottom: CGFloat = 0
+    private static let nearBottomDistanceThreshold: CGFloat = 100
 
     init(signal: Signal<ChatState, NoError>, interaction: ChatInteraction, isDM: Bool = false) {
         listView = ListView()
@@ -128,7 +131,7 @@ final class ChatContainerNode: ASDisplayNode {
             switch offset {
             case let .known(value):
                 self.lastKnownDistanceFromBottom = value
-                let atBottom = value < 100
+                let atBottom = value < Self.nearBottomDistanceThreshold
                 self.interaction.onScrolledToBottom(atBottom)
                 self.refreshJumpButtonVisibility()
             case .none, .unknown:
@@ -209,7 +212,7 @@ final class ChatContainerNode: ASDisplayNode {
     }
 
     private func refreshJumpButtonVisibility() {
-        let isFarFromBottom = lastKnownDistanceFromBottom >= 100
+        let isFarFromBottom = lastKnownDistanceFromBottom >= Self.nearBottomDistanceThreshold
         let hasNewerToLoad = state.hasMoreNewer
         setJumpButtonVisible(isFarFromBottom || hasNewerToLoad)
     }
@@ -506,9 +509,9 @@ final class ChatContainerNode: ASDisplayNode {
         let isAtBottom: Bool = {
             switch self.listView.visibleContentOffset() {
             case let .known(value):
-                return value < 10
+                return value < Self.nearBottomDistanceThreshold
             case .none, .unknown:
-                return true
+                return self.lastKnownDistanceFromBottom < Self.nearBottomDistanceThreshold
             }
         }()
 

--- a/MezonChat/Features/Chat/ChatViewController.swift
+++ b/MezonChat/Features/Chat/ChatViewController.swift
@@ -319,7 +319,15 @@ final class ChatViewController: ViewController {
     let clanId: Int64
     private(set) var channel: Mezon_Api_ChannelDescription
     let context: AccountContext
-    var topicId: Int64 = 0
+    var topicId: Int64 = 0 {
+        didSet {
+            guard topicId != oldValue else { return }
+            if isViewLoaded {
+                syncChannelToComposer()
+            }
+        }
+    }
+    private var skipRemoteFetchWhileTopicIsEmpty = false
     private var storageChannelId: String {
         topicId != 0 ? "topic-\(topicId)" : "\(channel.channelID)"
     }
@@ -433,7 +441,7 @@ final class ChatViewController: ViewController {
     private var notificationKeyboardReconcileWorkItem: DispatchWorkItem?
     private lazy var shouldScrollToBottom: Bool = lastSeenMessageId == nil
     private var pendingScrollToBottom = false
-    private var hasMarkedAsRead = false
+    private var lastMarkedAsReadMessageId: Int64?
     private var pendingMarkAsRead = false
     private var nextFetchPrefersHTTPFirst = false
     private var readyToLoadMore = false
@@ -595,6 +603,9 @@ final class ChatViewController: ViewController {
             },
             onShareContactCallTapped: { [weak self] data in
                 self?.startShareContactCall(data)
+            },
+            isShareContactCallBlocked: { [weak self] data in
+                self?.isShareContactCallBlocked(data) ?? false
             },
             onSwipeReply: { [weak self] display in
                 self?.sendInputViewController.setReply(display)
@@ -792,6 +803,9 @@ final class ChatViewController: ViewController {
             onMessageNeedsRelayout: nil,
             onEmbedButtonClicked: nil
         )
+        interaction.onMediaTapped = { [weak self] index, media, display in
+            self?.presentMessageMediaGallery(index: index, media: media, display: display)
+        }
         interaction.onMessagesReloaded = { [weak self] in
             guard let self else { return }
             if let seenId = self.lastSeenMessageId {
@@ -1458,6 +1472,9 @@ final class ChatViewController: ViewController {
         let oldLastId = messages.last?.id
         persistentMessages = normalizedDisplayOrder(v)
         messages = normalizedDisplayOrder(persistentMessages + ephemeralMessages)
+        if !persistentMessages.isEmpty {
+            skipRemoteFetchWhileTopicIsEmpty = false
+        }
         let newFirstId = persistentMessages.first(where: { !$0.isWelcome })?.id
         let newLastId = persistentMessages.last?.id
         if newFirstId != oldFirstId { lastFetchedOlderMessageId = nil }
@@ -1555,6 +1572,7 @@ final class ChatViewController: ViewController {
 
         let channelIdStr = storageChannelId
         let messagesKeyInvalid = topicId == 0 && channel.channelID == 0
+        var skipInitialRemoteFetchForEmptyTopic = false
 
         if messagesKeyInvalid {
             setMessages([])
@@ -1565,7 +1583,16 @@ final class ChatViewController: ViewController {
                 tx.getMessages(channelId: channelIdStr).filter { $0.channelId == channelIdStr }
             }
             let hasCache = !cachedMessages.isEmpty
-            if !hasCache && NetworkMonitor.shared.isConnected {
+            skipInitialRemoteFetchForEmptyTopic = shouldSkipRemoteFetchForEmptyTopic(
+                hadCachedMessages: !messages.isEmpty,
+                hadCachedInPostbox: hasCache
+            )
+            if skipInitialRemoteFetchForEmptyTopic {
+                hasCompletedInitialFetch = true
+                setHasMoreOlder(false)
+                setHasMoreNewer(false)
+            }
+            if !hasCache && NetworkMonitor.shared.isConnected && !skipInitialRemoteFetchForEmptyTopic {
                 setIsLoading(true)
             } else {
                 setIsLoading(false)
@@ -1604,11 +1631,18 @@ final class ChatViewController: ViewController {
         )
         ensureParentChannelMetaSubscription()
 
+        let shouldSkipInitialRemoteFetchForEmptyTopic = skipInitialRemoteFetchForEmptyTopic
         Task { @MainActor [weak self] in
             guard let self else { return }
             if self.topicId == 0 && self.channel.channelID == 0 {
                 self.setIsLoading(false)
                 return
+            }
+            if shouldSkipInitialRemoteFetchForEmptyTopic {
+                self.setHasMoreOlder(false)
+                self.setHasMoreNewer(false)
+                self.setIsLoading(false)
+                self.setIsLoadingMessageContext(false)
             }
             if !NetworkMonitor.shared.isConnected {
                 self.setIsLoading(false)
@@ -1620,7 +1654,7 @@ final class ChatViewController: ViewController {
                 if let t = SessionStore.load()?.token, !t.isEmpty { return t }
                 return nil
             }()
-            if let immediateToken {
+            if let immediateToken, !self.hasCompletedInitialFetch {
                 self.hasCompletedInitialFetch = true
                 self.fetchMessages(token: immediateToken)
             }
@@ -1820,7 +1854,7 @@ final class ChatViewController: ViewController {
 
     func handleBroughtForwardFromNotificationDeepLink() {
         prepareForNotificationNavigation()
-        hasMarkedAsRead = false
+        lastMarkedAsReadMessageId = nil
         if !messages.isEmpty {
             markChannelAsRead()
         }
@@ -1871,14 +1905,24 @@ final class ChatViewController: ViewController {
     }
 
     private func markChannelAsRead() {
-        guard !hasMarkedAsRead, !messages.isEmpty else { return }
-        guard let lastMessage = messages.last else { return }
-        guard let messageId = Int64(lastMessage.message.id) else { return }
+        guard !messages.isEmpty else { return }
+
+        var latestServerMessageId: Int64?
+        for display in messages.reversed() where !display.isWelcome {
+            if let id = Int64(display.message.id), id != 0 {
+                latestServerMessageId = id
+                break
+            }
+        }
+        guard let messageId = latestServerMessageId else { return }
+
+        if let already = lastMarkedAsReadMessageId, messageId <= already { return }
+
         guard context.account.socket.isConnected else {
             pendingMarkAsRead = true
             return
         }
-        hasMarkedAsRead = true
+        lastMarkedAsReadMessageId = messageId
         pendingMarkAsRead = false
 
         let channelUnreadCount = channel.countMessUnread
@@ -1923,9 +1967,27 @@ final class ChatViewController: ViewController {
         }
     }
 
+    private func shouldSkipRemoteFetchForEmptyTopic(hadCachedMessages: Bool, hadCachedInPostbox: Bool) -> Bool {
+        topicId != 0
+            && skipRemoteFetchWhileTopicIsEmpty
+            && !hadCachedMessages
+            && !hadCachedInPostbox
+    }
+
     func fetchMessages(token: String? = nil) {
         let hadCachedMessages = !messages.isEmpty
         let hadCachedInPostbox = hasCachedMessagesInPostbox()
+        if shouldSkipRemoteFetchForEmptyTopic(
+            hadCachedMessages: hadCachedMessages,
+            hadCachedInPostbox: hadCachedInPostbox
+        ) {
+            setHasMoreOlder(false)
+            setHasMoreNewer(false)
+            setIsLoading(false)
+            setIsLoadingMessageContext(false)
+            setErrorMessage(nil)
+            return
+        }
         if !NetworkMonitor.shared.isConnected {
             setIsLoading(false)
             return
@@ -3883,6 +3945,7 @@ final class ChatViewController: ViewController {
         let topicVC = ChatViewController(
             clanId: clanId, channel: topicChannel, context: context, parentName: nil)
         topicVC.topicId = topicIdInt
+        topicVC.skipRemoteFetchWhileTopicIsEmpty = topicData.replyCount <= 0
         needsRefreshAfterTopicDiscussion = true
         navigationController?.pushViewController(topicVC, animated: true)
     }
@@ -4512,6 +4575,10 @@ final class ChatViewController: ViewController {
             Toast.error("Cannot call yourself")
             return
         }
+        guard !isShareContactCallBlocked(data) else {
+            Toast.error(L(L10n.Forward.blockedByYou))
+            return
+        }
         loadOrCreateShareContactDirectMessage(data) { [weak self] channel in
             guard let self, let remoteUserId = data.userIdInt else { return }
             PeerCallLogMessage.sendStartCallLog(
@@ -4529,6 +4596,11 @@ final class ChatViewController: ViewController {
             )
             self.pushPeerCallScreen(callVC)
         }
+    }
+
+    private func isShareContactCallBlocked(_ data: ShareContactData) -> Bool {
+        guard let userId = data.userIdInt else { return false }
+        return context.engine.friendsData.blockedUserIds().contains(userId)
     }
 
     private func loadOrCreateShareContactDirectMessage(
@@ -4926,6 +4998,192 @@ final class ChatViewController: ViewController {
         )
         presentInGlobalOverlay(sheet)
         sheet.animateIn()
+    }
+
+    private func presentMessageMediaGallery(index: Int, media: [ParsedAttachment], display: ChatMessageDisplay) {
+        let galleryItems = media.map {
+            makeMessageGalleryItem(attachment: $0, display: display)
+        }
+        guard !galleryItems.isEmpty else { return }
+        let initialIndex = max(0, min(index, galleryItems.count - 1))
+        let gallery = GalleryController(
+            items: galleryItems,
+            initialIndex: initialIndex,
+            channelItemsLoader: { [weak self] in
+                guard let self else { return [] }
+                return await self.loadChannelGalleryItems(around: display)
+            }
+        )
+        present(gallery, animated: true)
+    }
+
+    private func makeMessageGalleryItem(attachment: ParsedAttachment, display: ChatMessageDisplay) -> GalleryItemInfo {
+        let placeholderURL: String? = attachment.isVideo
+            ? nil
+            : ImgproxyURL.attachmentURL(
+                from: attachment.url,
+                width: 400,
+                height: 400,
+                resizeType: "fit"
+            )
+        return GalleryItemInfo(
+            url: attachment.url,
+            sourceURL: attachment.url,
+            image: attachment.localImage,
+            placeholderURL: placeholderURL,
+            senderName: display.senderDisplayName,
+            senderAvatarURL: display.avatarURL,
+            timestamp: display.message.createdAt,
+            isVideo: attachment.isVideo
+        )
+    }
+
+    private func loadChannelGalleryItems(around display: ChatMessageDisplay) async -> [GalleryItemInfo] {
+        guard let token = await context.getToken() else { return [] }
+        let channelType = channel.type != 0
+            ? channel.type
+            : (clanId == 0 ? MezonConstants.ChannelType.group.rawValue : MezonConstants.ChannelType.channel.rawValue)
+        let requestClanId =
+            (channelType == MezonConstants.ChannelType.dm.rawValue
+                || channelType == MezonConstants.ChannelType.group.rawValue) ? 0 : clanId
+        let messageTimestamp = display.message.createdAt.timeIntervalSince1970
+        let selectedTimestamp = UInt32(max(0, min(messageTimestamp, Double(UInt32.max))))
+        let beforeTime = display.message.createdAt.addingTimeInterval(24 * 60 * 60).timeIntervalSince1970
+        let beforeTimestamp = UInt32(max(0, min(beforeTime, Double(UInt32.max))))
+
+        let olderAndCurrent = await requestChannelGalleryAttachments(
+            clanId: requestClanId,
+            token: token,
+            before: beforeTimestamp,
+            after: 0
+        )
+        let newer = await requestChannelGalleryAttachments(
+            clanId: requestClanId,
+            token: token,
+            before: 0,
+            after: selectedTimestamp
+        )
+
+        let fullPx = galleryFullScreenProxyPixels()
+        let visualItems = (newer + olderAndCurrent)
+            .filter { Self.isVisualChannelAttachment($0) }
+            .sorted { $0.createTimeSeconds > $1.createTimeSeconds }
+            .reduce(into: [Mezon_Api_ChannelAttachment]()) { result, attachment in
+                let key = attachment.url.isEmpty ? "id:\(attachment.id)" : "url:\(attachment.url)"
+                guard !result.contains(where: {
+                    ($0.url.isEmpty ? "id:\($0.id)" : "url:\($0.url)") == key
+                }) else { return }
+                result.append(attachment)
+            }
+            .map { makeChannelGalleryItem(attachment: $0, fullProxyPixels: fullPx) }
+        return Array(visualItems.reversed())
+    }
+
+    private func requestChannelGalleryAttachments(
+        clanId: Int64,
+        token: String,
+        before: UInt32,
+        after: UInt32
+    ) async -> [Mezon_Api_ChannelAttachment] {
+        do {
+            let response = try await context.account.network.listChannelAttachments(
+                clanId: clanId,
+                channelId: channel.channelID,
+                fileType: "image",
+                limit: 30,
+                before: before,
+                after: after,
+                token: token
+            )
+            return response.attachments
+        } catch {
+            return []
+        }
+    }
+
+    private func makeChannelGalleryItem(attachment: Mezon_Api_ChannelAttachment, fullProxyPixels: Int) -> GalleryItemInfo {
+        let isVideo = Self.isVideoChannelAttachment(attachment)
+        let url: String
+        let placeholderURL: String?
+        if isVideo {
+            url = attachment.url
+            placeholderURL = nil
+        } else {
+            url = ImgproxyURL.attachmentURL(
+                from: attachment.url,
+                width: fullProxyPixels,
+                height: fullProxyPixels,
+                resizeType: "fit"
+            )
+            placeholderURL = ImgproxyURL.attachmentURL(
+                from: attachment.url,
+                width: 100,
+                height: 100,
+                resizeType: "fit"
+            )
+        }
+        let uploader = resolvedUploaderInfo(uploaderId: attachment.uploader)
+        let timestamp = attachment.createTimeSeconds > 0
+            ? Date(timeIntervalSince1970: TimeInterval(attachment.createTimeSeconds))
+            : nil
+        return GalleryItemInfo(
+            url: url,
+            sourceURL: attachment.url,
+            image: nil,
+            placeholderURL: placeholderURL,
+            senderName: uploader.name,
+            senderAvatarURL: uploader.avatarURL,
+            timestamp: timestamp,
+            isVideo: isVideo
+        )
+    }
+
+    private static func isVisualChannelAttachment(_ attachment: Mezon_Api_ChannelAttachment) -> Bool {
+        let filetype = attachment.filetype.lowercased()
+        if filetype == "sticker" || attachment.url.contains("/stickers") { return false }
+        if filetype.hasPrefix("image/") || filetype.hasPrefix("video/") { return true }
+        let filenameExtension = (attachment.filename as NSString).pathExtension.lowercased()
+        let urlExtension = URL(string: attachment.url)?.pathExtension.lowercased() ?? ""
+        let imageExtensions: Set<String> = ["jpg", "jpeg", "png", "gif", "webp", "heic"]
+        let videoExtensions: Set<String> = ["mp4", "mov", "m4v", "webm"]
+        return imageExtensions.contains(filenameExtension)
+            || imageExtensions.contains(urlExtension)
+            || videoExtensions.contains(filenameExtension)
+            || videoExtensions.contains(urlExtension)
+    }
+
+    private static func isVideoChannelAttachment(_ attachment: Mezon_Api_ChannelAttachment) -> Bool {
+        let filetype = attachment.filetype.lowercased()
+        if filetype.hasPrefix("video/") { return true }
+        let filenameExtension = (attachment.filename as NSString).pathExtension.lowercased()
+        let urlExtension = URL(string: attachment.url)?.pathExtension.lowercased() ?? ""
+        return ["mp4", "mov", "m4v", "webm"].contains(filenameExtension)
+            || ["mp4", "mov", "m4v", "webm"].contains(urlExtension)
+    }
+
+    private func galleryFullScreenProxyPixels() -> Int {
+        let longest = max(UIScreen.main.bounds.width, UIScreen.main.bounds.height)
+        let pixels = Int((longest * UIScreen.main.scale).rounded(.up))
+        return max(512, min(pixels, 2048))
+    }
+
+    private func resolvedUploaderInfo(uploaderId: Int64) -> (name: String, avatarURL: String?) {
+        guard uploaderId != 0 else { return ("", nil) }
+        let idString = String(uploaderId)
+        var name = ""
+        var avatarURL: String?
+        context.account.postbox.read { tx in
+            guard let profile = tx.getProfile(userId: idString) else { return }
+            if let displayName = profile.displayName, !displayName.isEmpty {
+                name = displayName
+            } else if !profile.username.isEmpty {
+                name = profile.username
+            }
+            if let avatar = profile.avatarUrl, !avatar.isEmpty {
+                avatarURL = avatar
+            }
+        }
+        return (name.isEmpty ? idString : name, avatarURL)
     }
 
     private enum PhotoLibrarySaveAuthorizationResult {

--- a/MezonChat/Features/DirectMessages/DmListItemCell.swift
+++ b/MezonChat/Features/DirectMessages/DmListItemCell.swift
@@ -378,7 +378,7 @@ final class DmListItemCell: UITableViewCell {
             return (Self.previewWhenNoMessageBody(), time)
         }
         let body = Self.normalizeJsonEscapedSlashes(in: preview)
-        return (body.count >= 32 ? body + "..." : body, time)
+        return (body.utf8.count >= 31 ? body + "..." : body, time)
     }
 
     private static let contentKeysAllowingEmptyAttachmentInference: Set<String> = ["t", "mk", "ej", "hg"]

--- a/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
+++ b/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
@@ -2207,21 +2207,35 @@ final class SendMessageInputViewController: UIViewController {
         updatePreviewVisibility()
     }
 
-    private func handlePastedImages(_ images: [UIImage]) {
+    private static let pastePreservedImageExtensions: Set<String> = ["jpg", "jpeg", "png", "gif", "webp"]
+
+    private func handlePastedImages(_ pasted: [PastedImage]) {
         guard !isEditingShareContactMessage else { return }
         let tempDir = FileManager.default.temporaryDirectory
-        for image in images {
-            let filename = "pasted-\(UUID().uuidString).png"
+        for item in pasted {
+            let resolvedData: Data
+            let resolvedExt: String
+            if let originalData = item.data,
+               let originalExt = item.fileExtension,
+               Self.pastePreservedImageExtensions.contains(originalExt.lowercased()) {
+                resolvedData = originalData
+                resolvedExt = originalExt
+            } else if let jpegData = item.image.jpegData(compressionQuality: 0.9) {
+                resolvedData = jpegData
+                resolvedExt = "jpg"
+            } else {
+                continue
+            }
+            let filename = "pasted-\(UUID().uuidString).\(resolvedExt)"
             let fileURL = tempDir.appendingPathComponent(filename)
-            guard let data = image.pngData() else { continue }
             do {
-                try data.write(to: fileURL)
+                try resolvedData.write(to: fileURL)
             } catch {
                 continue
             }
             let index = pickedImages.count
-            pickedImages.append(image)
-            attachmentPreviewView.addImage(image)
+            pickedImages.append(item.image)
+            attachmentPreviewView.addImage(item.image)
             pickedFileURLs[index] = fileURL
         }
         saveToCache()
@@ -4583,6 +4597,8 @@ final class SendMessageInputViewController: UIViewController {
         case "gif":         return "image/gif"
         case "webp":        return "image/webp"
         case "heic", "heif": return "image/heic"
+        case "tiff", "tif": return "image/tiff"
+        case "bmp":         return "image/bmp"
         case "mp4":         return "video/mp4"
         case "mov":         return "video/quicktime"
         case "m4v":         return "video/x-m4v"
@@ -5378,10 +5394,14 @@ final class SendMessageInputViewController: UIViewController {
         ref.messageSenderDisplayName = display.senderDisplayName
         ref.messageSenderAvatar = display.avatarURL ?? ""
         ref.hasAttachment_p = !display.attachments.isEmpty
-        let contentJSON: [String: Any] = ["t": display.parsedContent.text]
-        if let jsonData = try? JSONSerialization.data(withJSONObject: contentJSON),
-           let jsonStr = String(data: jsonData, encoding: .utf8) {
-            ref.content = jsonStr
+        if display.shareContactData != nil {
+            ref.content = display.replyRefSourceContent
+        } else {
+            let contentJSON: [String: Any] = ["t": display.parsedContent.text]
+            if let jsonData = try? JSONSerialization.data(withJSONObject: contentJSON),
+               let jsonStr = String(data: jsonData, encoding: .utf8) {
+                ref.content = jsonStr
+            }
         }
         return ref
     }
@@ -5670,9 +5690,15 @@ extension SendMessageInputViewController: UITextViewDelegate {
 }
 
 
+struct PastedImage {
+    let image: UIImage
+    let data: Data?
+    let fileExtension: String?
+}
+
 final class PastableTextView: UITextView {
 
-    var onImagesPasted: (([UIImage]) -> Void)?
+    var onImagesPasted: (([PastedImage]) -> Void)?
     var onGIFPasted: ((Data) -> Void)?
 
     override func layoutSubviews() {
@@ -5707,8 +5733,18 @@ final class PastableTextView: UITextView {
             return
         }
 
+        let dataImages = Self.imagesFromPasteboardData(pb)
+        if !dataImages.isEmpty {
+            onImagesPasted?(dataImages)
+            if let text = pb.string, !text.isEmpty {
+                insertText(text)
+            }
+            return
+        }
+
         if let images = pb.images, !images.isEmpty {
-            onImagesPasted?(images)
+            let pasted = images.map { PastedImage(image: Self.normalizedOrientation($0), data: nil, fileExtension: nil) }
+            onImagesPasted?(pasted)
             if let text = pb.string, !text.isEmpty {
                 insertText(text)
             }
@@ -5716,11 +5752,76 @@ final class PastableTextView: UITextView {
         }
 
         if pb.hasImages, let image = pb.image {
-            onImagesPasted?([image])
+            onImagesPasted?([PastedImage(image: Self.normalizedOrientation(image), data: nil, fileExtension: nil)])
             return
         }
 
         super.paste(sender)
+    }
+
+    private static let imageDataPasteboardTypes: [(uti: String, ext: String)] = [
+        ("public.heic", "heic"),
+        ("public.heif", "heif"),
+        ("public.jpeg", "jpg"),
+        ("public.png", "png"),
+        ("public.tiff", "tiff"),
+        ("public.webp", "webp"),
+        ("public.image", ""),
+    ]
+
+    private static func imagesFromPasteboardData(_ pb: UIPasteboard) -> [PastedImage] {
+        let itemCount = pb.numberOfItems
+        guard itemCount > 0 else { return [] }
+        var result: [PastedImage] = []
+        for i in 0..<itemCount {
+            for entry in imageDataPasteboardTypes {
+                guard let data = pb.data(forPasteboardType: entry.uti, inItemSet: IndexSet(integer: i))?.first,
+                      let decoded = UIImage(data: data) else { continue }
+                let resolvedExt = entry.ext.isEmpty ? Self.inferExtension(from: data) : entry.ext
+                result.append(PastedImage(
+                    image: normalizedOrientation(decoded),
+                    data: data,
+                    fileExtension: resolvedExt
+                ))
+                break
+            }
+        }
+        return result
+    }
+
+    private static func inferExtension(from data: Data) -> String? {
+        guard data.count >= 12 else { return nil }
+        let bytes = [UInt8](data.prefix(12))
+        if bytes.starts(with: [0xFF, 0xD8, 0xFF]) { return "jpg" }
+        if bytes.starts(with: [0x89, 0x50, 0x4E, 0x47]) { return "png" }
+        if bytes.starts(with: [0x47, 0x49, 0x46, 0x38]) { return "gif" }
+        if bytes.starts(with: [0x42, 0x4D]) { return "bmp" }
+        if bytes.starts(with: [0x49, 0x49, 0x2A, 0x00]) || bytes.starts(with: [0x4D, 0x4D, 0x00, 0x2A]) { return "tiff" }
+        if bytes.count >= 12, bytes[4] == 0x66, bytes[5] == 0x74, bytes[6] == 0x79, bytes[7] == 0x70 {
+            let brand = String(bytes: bytes[8..<12], encoding: .ascii) ?? ""
+            switch brand {
+            case "heic", "heix", "hevc", "hevx", "heim", "heis", "hevm", "hevs": return "heic"
+            case "mif1", "msf1": return "heif"
+            default: return nil
+            }
+        }
+        if bytes.starts(with: [0x52, 0x49, 0x46, 0x46]),
+           bytes.count >= 12,
+           bytes[8] == 0x57, bytes[9] == 0x45, bytes[10] == 0x42, bytes[11] == 0x50 {
+            return "webp"
+        }
+        return nil
+    }
+
+    private static func normalizedOrientation(_ image: UIImage) -> UIImage {
+        guard image.imageOrientation != .up else { return image }
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = image.scale
+        format.opaque = false
+        let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
+        return renderer.image { _ in
+            image.draw(in: CGRect(origin: .zero, size: image.size))
+        }
     }
 }
 

--- a/project.yml
+++ b/project.yml
@@ -119,7 +119,7 @@ targets:
         ENABLE_USER_SCRIPT_SANDBOXING: NO
         PRODUCT_BUNDLE_IDENTIFIER: mezon.mobile
         PRODUCT_NAME: Mezon
-        MARKETING_VERSION: "1.2.96"
+        MARKETING_VERSION: "1.2.97"
         CURRENT_PROJECT_VERSION: "1"
         INFOPLIST_FILE: MezonChat/Resources/Info.plist
         DEVELOPMENT_TEAM: ""
@@ -220,7 +220,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: mezon.mobile.MezonSharing
         PRODUCT_NAME: MezonSharing
-        MARKETING_VERSION: "1.2.96"
+        MARKETING_VERSION: "1.2.97"
         CURRENT_PROJECT_VERSION: "1"
         DEVELOPMENT_TEAM: ""
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## 1. Root Cause

- The chat media viewer only handled media from the current message and did not support thumbnail navigation or loading nearby channel media.
- Some chat edge cases were not handled correctly: empty Topic Discussion could stay in skeleton loading and repeatedly call the messages API; shared contact messages still showed the call action for blocked users; shared contact reply previews were not readable.
- Pasted images in the composer were converted to PNG, which could lose the original format and MIME type.
- Toast overlay used fade opacity and an unsafe zPosition value, which could cause CoreAnimation warnings or inconsistent display.

## 2. Solution

- Upgraded the gallery with a thumbnail strip, stable media identity, video thumbnails, nearby channel media loading, and current item preservation when refreshing data.
- Wired media taps from chat bubbles into the new gallery flow.
- Fixed empty Topic Discussion state so new topics without replies no longer show long skeleton loading or retry `ListChannelMessages`.
- Hid the shared contact call action when the target user is blocked.
- Improved shared contact reply preview rendering.
- Preserved pasted image data and extension when possible, and added MIME handling for TIFF/BMP.
- Updated toast UI to use a finite zPosition, keep opacity at `1`, and remove alpha fade animations.
- Bumped app and share extension marketing version to `1.2.97`.

## 3. Selftest
  - Open image/video in chat and verify gallery paging plus thumbnail strip.
  - Paste JPG/PNG/GIF/WebP/HEIC image into composer and send.
  - Create/open an empty Topic Discussion and verify there is no long skeleton/API retry loop.
  - Verify shared contact call button is hidden for blocked users.
  - Show success/error/info toast and verify opacity is `1`.