### PR TITLE
260529-IOS-Fix bug UI color inactive

### DIFF
--- a/MezonChat/Features/ChannelCreator/CreateChannelContainerNode.swift
+++ b/MezonChat/Features/ChannelCreator/CreateChannelContainerNode.swift
@@ -417,7 +417,7 @@ private class RadioButtonView: UIView {
             inner.backgroundColor = .white
             inner.isHidden = false
         } else {
-            layer.borderColor = UIColor.white.withAlphaComponent(0.3).cgColor
+            layer.borderColor = UIColor.theme.textStrong.withAlphaComponent(0.3).cgColor
             backgroundColor = .clear
             inner.isHidden = true
         }

--- a/MezonChat/Features/ChannelList/NotificationSettingsSheetController.swift
+++ b/MezonChat/Features/ChannelList/NotificationSettingsSheetController.swift
@@ -421,7 +421,7 @@ private final class NotificationOptionRow: ASDisplayNode {
             radioInner.backgroundColor = .white
             radioInner.isHidden = false
         } else {
-            radioNode.borderColor = UIColor.white.withAlphaComponent(0.3).cgColor
+            radioNode.borderColor = UIColor.theme.textStrong.withAlphaComponent(0.3).cgColor
             radioNode.backgroundColor = .clear
             radioInner.isHidden = true
         }


### PR DESCRIPTION
issue: https://github.com/mezonai/mezon-ios/issues/159
Result: 
<img width="441" height="321" alt="image" src="https://github.com/user-attachments/assets/a0f5f885-ab3d-4915-bb47-8e789b9de2b3" />
<img width="397" height="320" alt="image" src="https://github.com/user-attachments/assets/372d2501-633d-4350-adcc-bdc8a915fb26" />
Test case:
Switch to Light theme. Go to the "Create Channel" screen and the "Notification Settings" bottom sheet. Verify that the unselected radio button borders are visible.
Switch to Dark theme and verify that the unselected borders are subtle and not overly bright.

Root cause: The border color for unselected radio buttons was hardcoded to UIColor.white.withAlphaComponent(0.3). This works in Dark theme but causes the border to be invisible against a white background in Light theme

Solution: Replaced the hardcoded white color with a dynamic theme color: UIColor.theme.textStrong.withAlphaComponent(0.3). This ensures proper contrast across both Light and Dark themes.