### PR TITLE
fix: gallery videos, members in voices, echo in voice

### DIFF
--- a/MezonChat/Core/UI/Gallery/ChatVideoGalleryItemNode.swift
+++ b/MezonChat/Core/UI/Gallery/ChatVideoGalleryItemNode.swift
@@ -18,6 +18,9 @@ final class ChatVideoGalleryItemNode: GalleryItemNode {
         node.toggleOverlayVisibility = { [weak self] in
             self?.toggleControlsVisibility()
         }
+        node.setPagingEnabled = { [weak self] enabled in
+            self?.setPagingEnabled(enabled)
+        }
         self.playerNode = node
         self.addSubnode(node)
     }

--- a/MezonChat/Core/UI/Gallery/GalleryItemNode.swift
+++ b/MezonChat/Core/UI/Gallery/GalleryItemNode.swift
@@ -39,6 +39,7 @@ open class GalleryItemNode: ASDisplayNode {
 
     public var toggleControlsVisibility: () -> Void = {}
     public var dismiss: () -> Void = {}
+    public var setPagingEnabled: (Bool) -> Void = { _ in }
     public var itemInfo: GalleryItemInfo?
 
     override public init() {

--- a/MezonChat/Core/UI/Gallery/GalleryPagingNode.swift
+++ b/MezonChat/Core/UI/Gallery/GalleryPagingNode.swift
@@ -33,7 +33,13 @@ final class GalleryPagingNode: ASDisplayNode, UIScrollViewDelegate {
         scrollView.alwaysBounceHorizontal = true
         scrollView.contentInsetAdjustmentBehavior = .never
         scrollView.backgroundColor = .clear
+        scrollView.delaysContentTouches = false
+        scrollView.canCancelContentTouches = true
         self.view.addSubview(scrollView)
+    }
+
+    func setPagingEnabled(_ enabled: Bool) {
+        scrollView.isScrollEnabled = enabled
     }
 
     func configure(items: [GalleryItemInfo], initialIndex: Int, factory: @escaping (GalleryItemInfo, Int) -> GalleryItemNode) {
@@ -144,6 +150,7 @@ final class GalleryPagingNode: ASDisplayNode, UIScrollViewDelegate {
                 node = factory(items[index], index)
                 node.toggleControlsVisibility = { [weak self] in self?.toggleControlsVisibility?() }
                 node.dismiss = { [weak self] in self?.dismiss?() }
+                node.setPagingEnabled = { [weak self] enabled in self?.setPagingEnabled(enabled) }
                 node.itemInfo = items[index]
 
                 scrollView.addSubview(node.view)

--- a/MezonChat/Core/UI/Video/MezonVideoPlayerNode.swift
+++ b/MezonChat/Core/UI/Video/MezonVideoPlayerNode.swift
@@ -34,6 +34,7 @@ final class MezonVideoPlayerNode: ASDisplayNode {
 
     var toggleOverlayVisibility: (() -> Void)?
     var onPlaybackFailed: (() -> Void)?
+    var setPagingEnabled: ((Bool) -> Void)?
 
     convenience init(url: URL, posterURL: String) {
         let asset = AVURLAsset(url: url, options: [
@@ -116,6 +117,7 @@ final class MezonVideoPlayerNode: ASDisplayNode {
         self.timeSlider.addTarget(self, action: #selector(sliderDidChange), for: .valueChanged)
         self.timeSlider.addTarget(self, action: #selector(sliderDidEndScrubbing), for: .touchUpInside)
         self.timeSlider.addTarget(self, action: #selector(sliderDidEndScrubbing), for: .touchUpOutside)
+        self.timeSlider.addTarget(self, action: #selector(sliderDidEndScrubbing), for: .touchCancel)
 
 
         updatePlayPauseIcons(isPlaying: false)
@@ -381,6 +383,7 @@ final class MezonVideoPlayerNode: ASDisplayNode {
 
     @objc private func sliderDidBeginScrubbing() {
         isScrubbing = true
+        setPagingEnabled?(false)
         player?.pause()
         controlsHideTimer?.invalidate()
     }
@@ -399,6 +402,7 @@ final class MezonVideoPlayerNode: ASDisplayNode {
 
     @objc private func sliderDidEndScrubbing() {
         isScrubbing = false
+        setPagingEnabled?(true)
         let seconds = Double(timeSlider.value)
         player?.seek(to: CMTime(seconds: seconds, preferredTimescale: 600)) { [weak self] _ in
             if self?.player?.rate == 0 {

--- a/MezonChat/Core/UI/Video/UniversalVideoPlayerNode.swift
+++ b/MezonChat/Core/UI/Video/UniversalVideoPlayerNode.swift
@@ -13,6 +13,7 @@ final class UniversalVideoPlayerNode: ASDisplayNode {
     private var didTryVLCPlayer = false
     
     var toggleOverlayVisibility: (() -> Void)?
+    var setPagingEnabled: ((Bool) -> Void)?
     
     init(url: URL, posterURL: String) {
         self.url = url
@@ -41,6 +42,9 @@ final class UniversalVideoPlayerNode: ASDisplayNode {
         avNode.toggleOverlayVisibility = { [weak self] in
             self?.toggleOverlayVisibility?()
         }
+        avNode.setPagingEnabled = { [weak self] enabled in
+            self?.setPagingEnabled?(enabled)
+        }
         avNode.onPlaybackFailed = { [weak self] in
             self?.fallbackToVLC()
         }
@@ -55,6 +59,9 @@ final class UniversalVideoPlayerNode: ASDisplayNode {
         let vlcNode = VLCVideoPlayerNode(url: url, posterURL: posterURL)
         vlcNode.toggleOverlayVisibility = { [weak self] in
             self?.toggleOverlayVisibility?()
+        }
+        vlcNode.setPagingEnabled = { [weak self] enabled in
+            self?.setPagingEnabled?(enabled)
         }
         vlcPlayerNode = vlcNode
         addSubnode(vlcNode)

--- a/MezonChat/Core/UI/Video/VLCVideoPlayerNode.swift
+++ b/MezonChat/Core/UI/Video/VLCVideoPlayerNode.swift
@@ -35,6 +35,7 @@ final class VLCVideoPlayerNode: ASDisplayNode {
     private var loadingTimeoutTimer: Foundation.Timer?
     
     var toggleOverlayVisibility: (() -> Void)?
+    var setPagingEnabled: ((Bool) -> Void)?
     
     init(url: URL, posterURL: String) {
         self.sourceURL = url
@@ -98,6 +99,7 @@ final class VLCVideoPlayerNode: ASDisplayNode {
         self.timeSlider.addTarget(self, action: #selector(sliderDidChange), for: .valueChanged)
         self.timeSlider.addTarget(self, action: #selector(sliderDidEndScrubbing), for: .touchUpInside)
         self.timeSlider.addTarget(self, action: #selector(sliderDidEndScrubbing), for: .touchUpOutside)
+        self.timeSlider.addTarget(self, action: #selector(sliderDidEndScrubbing), for: .touchCancel)
         
         updatePlayPauseIcons(isPlaying: false)
         
@@ -256,6 +258,7 @@ final class VLCVideoPlayerNode: ASDisplayNode {
     
     @objc private func sliderDidBeginScrubbing() {
         isScrubbing = true
+        setPagingEnabled?(false)
         controlsHideTimer?.invalidate()
     }
     
@@ -276,6 +279,7 @@ final class VLCVideoPlayerNode: ASDisplayNode {
     
     @objc private func sliderDidEndScrubbing() {
         isScrubbing = false
+        setPagingEnabled?(true)
         guard let player = vlcPlayer, let media = player.media else { return }
         let duration = Double(media.length.intValue) / 1000.0
         guard duration > 0 else { return }

--- a/MezonChat/Core/Utils/SharingManager.swift
+++ b/MezonChat/Core/Utils/SharingManager.swift
@@ -15,6 +15,8 @@ final class SharingManager {
         var thumbnail: String?
         var duration: Double?
         var type: SharedMediaType
+        var width: CGFloat?
+        var height: CGFloat?
     }
 
     enum SharedMediaType: Int, Codable {

--- a/MezonChat/Features/ChannelDetail/Tabs/MemberListNode.swift
+++ b/MezonChat/Features/ChannelDetail/Tabs/MemberListNode.swift
@@ -567,6 +567,11 @@ extension MemberListNode: ASTableDataSource, ASTableDelegate {
                 } else {
                     host.present(callVC, animated: true)
                 }
+            },
+            onTransferFunds: { [weak self, weak host] payload in
+                guard let self, let host else { return }
+                let vc = WalletTransferViewController(context: self.context, payload: payload)
+                host.navigationController?.pushViewController(vc, animated: true)
             }
         )
         host.presentInGlobalOverlay(sheet)

--- a/MezonChat/Features/ChannelList/ChannelListContainerNode.swift
+++ b/MezonChat/Features/ChannelList/ChannelListContainerNode.swift
@@ -191,17 +191,19 @@ final class ChannelListContainerNode: ASDisplayNode {
         guard firstCategoryIndexContainingListChannel(selectedId) != nil else { return }
         let selectionChanged = prevState.selectedChannelId != newState.selectedChannelId
         let loadingJustFinished = prevState.isLoading && !newState.isLoading
-        let voiceMapChanged = prevState.voiceUsersByChannel != newState.voiceUsersByChannel
         let selectedIsVoiceChannel = newState.allChannels.contains {
             $0.channelID == selectedId && Self.voiceChannelTypes.contains($0.type)
         }
+        let prevSelectedVoiceEmpty = (prevState.voiceUsersByChannel[selectedId] ?? []).isEmpty
+        let newSelectedVoiceActive = !(newState.voiceUsersByChannel[selectedId] ?? []).isEmpty
+        let selectedVoiceBecameActive = prevSelectedVoiceEmpty && newSelectedVoiceActive
         if loadingJustFinished && skipNextLoadingFinishedReveal {
             skipNextLoadingFinishedReveal = false
-            if !(wasClanSwitching || selectionChanged || (selectedIsVoiceChannel && voiceMapChanged)) {
+            if !(wasClanSwitching || selectionChanged || (selectedIsVoiceChannel && selectedVoiceBecameActive)) {
                 return
             }
         }
-        guard wasClanSwitching || selectionChanged || loadingJustFinished || (selectedIsVoiceChannel && voiceMapChanged) else { return }
+        guard wasClanSwitching || selectionChanged || loadingJustFinished || (selectedIsVoiceChannel && selectedVoiceBecameActive) else { return }
         scrollToChannel(channelId: selectedId, animated: !wasClanSwitching)
     }
 
@@ -340,6 +342,12 @@ final class ChannelListContainerNode: ASDisplayNode {
                 if $0.section != $1.section { return $0.section < $1.section }
                 return $0.row < $1.row
             }
+
+            let voiceStructureChanged =
+                pathsContainVoiceRow(sortedInserts, in: new)
+                || pathsContainVoiceRow(sortedDeletes, in: prev)
+            let scrollAnchor = voiceStructureChanged ? captureScrollAnchor(prev: prev) : nil
+
             tableNode.performBatch(animated: false) {
                 if !sortedDeletes.isEmpty {
                     self.tableNode.deleteRows(at: sortedDeletes, with: rowAnim)
@@ -374,8 +382,100 @@ final class ChannelListContainerNode: ASDisplayNode {
                     tableNode.waitUntilAllUpdatesAreProcessed()
                 }
             }
+
+            if let scrollAnchor {
+                restoreScrollAnchor(scrollAnchor)
+            }
         }
         committedSectionCount = expectedAfter
+    }
+
+    private func pathsContainVoiceRow(_ paths: [IndexPath], in stateForPaths: ChannelListState) -> Bool {
+        guard !paths.isEmpty else { return false }
+        let sectionOffset = channelAppsStripeVisible ? 1 : 0
+        for ip in paths {
+            guard ip.section >= sectionOffset else { continue }
+            let catIdx = ip.section - sectionOffset
+            guard catIdx >= 0, catIdx < stateForPaths.categories.count else { continue }
+            let rows = computeRows(for: stateForPaths, categoryIndex: catIdx)
+            guard ip.row >= 0, ip.row < rows.count else { continue }
+            switch rows[ip.row] {
+            case .voiceMembersCollapsed, .voiceMemberExpanded:
+                return true
+            default:
+                continue
+            }
+        }
+        return false
+    }
+
+    private struct ScrollAnchor {
+        let key: String
+        let section: Int
+        let distanceFromTop: CGFloat
+    }
+
+    private func captureScrollAnchor(prev: ChannelListState) -> ScrollAnchor? {
+        let tv = tableNode.view
+        guard tv.bounds.height > 0 else { return nil }
+        guard let visible = tv.indexPathsForVisibleRows, !visible.isEmpty else { return nil }
+        let offsetY = tv.contentOffset.y
+        let sectionOffset = channelAppsStripeVisible ? 1 : 0
+        let sorted = visible.sorted {
+            $0.section != $1.section ? $0.section < $1.section : $0.row < $1.row
+        }
+
+        func makeAnchor(_ ip: IndexPath, _ row: ChannelListRow) -> ScrollAnchor? {
+            let rect = tv.rectForRow(at: ip)
+            guard rect.height > 0 else { return nil }
+            return ScrollAnchor(
+                key: Self.rowDiffKey(row),
+                section: ip.section,
+                distanceFromTop: rect.minY - offsetY
+            )
+        }
+
+        var firstVisibleAnchor: ScrollAnchor?
+        for ip in sorted {
+            guard ip.section >= sectionOffset else { continue }
+            let catIdx = ip.section - sectionOffset
+            guard catIdx >= 0, catIdx < prev.categories.count else { continue }
+            let oldRows = computeRows(for: prev, categoryIndex: catIdx)
+            guard ip.row >= 0, ip.row < oldRows.count else { continue }
+            let row = oldRows[ip.row]
+            guard let anchor = makeAnchor(ip, row) else { continue }
+            if firstVisibleAnchor == nil { firstVisibleAnchor = anchor }
+            switch row {
+            case .voiceMembersCollapsed, .voiceMemberExpanded:
+                continue
+            default:
+                return anchor
+            }
+        }
+        return firstVisibleAnchor
+    }
+
+    private func restoreScrollAnchor(_ anchor: ScrollAnchor) {
+        let tv = tableNode.view
+        let sectionOffset = channelAppsStripeVisible ? 1 : 0
+        let section = anchor.section
+        guard section >= sectionOffset, section < tableNode.numberOfSections else { return }
+        let catIdx = section - sectionOffset
+        guard catIdx >= 0, catIdx < state.categories.count else { return }
+        let newRows = rowsForSection(catIdx)
+        guard let newRow = newRows.firstIndex(where: { Self.rowDiffKey($0) == anchor.key }) else { return }
+        guard newRow < tableNode.numberOfRows(inSection: section) else { return }
+        let rect = tv.rectForRow(at: IndexPath(row: newRow, section: section))
+        guard rect.height > 0 else { return }
+        let targetY = rect.minY - anchor.distanceFromTop
+        let minY = -tv.adjustedContentInset.top
+        let maxY = max(minY, tv.contentSize.height - tv.bounds.height + tv.adjustedContentInset.bottom)
+        let clamped = min(max(targetY, minY), maxY)
+        guard abs(clamped - tv.contentOffset.y) > 0.5 else { return }
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        tv.setContentOffset(CGPoint(x: tv.contentOffset.x, y: clamped), animated: false)
+        CATransaction.commit()
     }
 
     private static func rowDiffKey(_ row: ChannelListRow) -> String {

--- a/MezonChat/Features/ChannelList/ChannelListViewController.swift
+++ b/MezonChat/Features/ChannelList/ChannelListViewController.swift
@@ -119,40 +119,31 @@ private func prioritizeChannels(_ channels: [Mezon_Api_ChannelDescription]) -> [
         if aTop && !bTop { return true }
         if !aTop && bTop { return false }
         if aTop && bTop {
-            return String(a.channelID) < String(b.channelID)
+            return a.channelID < b.channelID
         }
-        return String(a.parentID) < String(b.parentID)
+        return a.parentID < b.parentID
     }
 }
 
 
 private func sortChannelsForCategory(_ channels: [Mezon_Api_ChannelDescription], categoryId: Int64) -> [Mezon_Api_ChannelDescription] {
     var sortedChannels: [Mezon_Api_ChannelDescription] = []
-    let numOfChannel: Int = channels.count
-    let threadStart: Int = channels.firstIndex(where: { $0.parentID != 0 }) ?? numOfChannel
-    var indexThread: Int = threadStart
-    let numOfParent: Int = threadStart
-    var i = 0
-    while i < numOfParent {
-        let channel = channels[i]
-        if channel.categoryID == categoryId {
-            sortedChannels.append(channel)
-            while indexThread < numOfChannel {
-                let thread = channels[indexThread]
-                let parentIdStr = String(thread.parentID)
-                if thread.parentID == channel.channelID {
-                    sortedChannels.append(thread)
-                    indexThread += 1
-                } else if String(channel.channelID) < parentIdStr {
-                    indexThread -= 1
-                    break
-                } else {
-                    indexThread += 1
-                }
-            }
-        }
-        i += 1
+    
+    let parents = channels.filter { $0.parentID == 0 && $0.categoryID == categoryId }
+    let threads = channels.filter { $0.parentID != 0 }
+    
+    var threadsByParent: [Int64: [Mezon_Api_ChannelDescription]] = [:]
+    for thread in threads {
+        threadsByParent[thread.parentID, default: []].append(thread)
     }
+    
+    for parent in parents {
+        sortedChannels.append(parent)
+        if let childThreads = threadsByParent[parent.channelID] {
+            sortedChannels.append(contentsOf: childThreads)
+        }
+    }
+    
     return sortedChannels
 }
 
@@ -181,15 +172,19 @@ private func splitParentsAndOrderedThreads(from flatSorted: [Mezon_Api_ChannelDe
     var i = 0
     while i < flatSorted.count {
         let ch = flatSorted[i]
-        parents.append(ch)
-        i += 1
-        var threads: [Mezon_Api_ChannelDescription] = []
-        while i < flatSorted.count, flatSorted[i].parentID == ch.channelID {
-            threads.append(flatSorted[i])
+        if ch.parentID == 0 {
+            parents.append(ch)
             i += 1
-        }
-        if !threads.isEmpty {
-            threadsByParent[ch.channelID] = threads
+            var threads: [Mezon_Api_ChannelDescription] = []
+            while i < flatSorted.count, flatSorted[i].parentID == ch.channelID {
+                threads.append(flatSorted[i])
+                i += 1
+            }
+            if !threads.isEmpty {
+                threadsByParent[ch.channelID] = threads
+            }
+        } else {
+            i += 1
         }
     }
     return (parents, threadsByParent)
@@ -391,6 +386,9 @@ final class ChannelListViewController: ViewController {
     private let errorMessagePipe = ValuePipe<String?>()
     private let needsReloadPipe = ValuePipe<Void>()
 
+    private var voicePresenceReloadScheduled = false
+    private let voicePresenceCoalesceInterval: TimeInterval = 0.4
+
     private let channelsLoadedPromise = ValuePromise<Bool>(false, ignoreRepeated: true)
     var channelsLoadedSignal: Signal<Bool, NoError> { channelsLoadedPromise.get() }
 
@@ -550,7 +548,18 @@ final class ChannelListViewController: ViewController {
     @objc private func handleVoicePresenceChanged(_ notification: Notification) {
         guard let n = notification.userInfo?["clanId"] as? NSNumber else { return }
         guard n.int64Value == clanId, clanId != 0 else { return }
-        needsReloadPipe.putNext(())
+        scheduleCoalescedVoicePresenceReload()
+    }
+
+    private func scheduleCoalescedVoicePresenceReload() {
+        guard !voicePresenceReloadScheduled else { return }
+        voicePresenceReloadScheduled = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + voicePresenceCoalesceInterval) { [weak self] in
+            guard let self else { return }
+            self.voicePresenceReloadScheduled = false
+            guard self.clanId != 0 else { return }
+            self.needsReloadPipe.putNext(())
+        }
     }
 
     @objc private func handleNetworkStatusChanged(_ notification: Notification) {

--- a/MezonChat/Features/Chat/ChatViewController.swift
+++ b/MezonChat/Features/Chat/ChatViewController.swift
@@ -4414,6 +4414,11 @@ final class ChatViewController: ViewController {
             },
             onStartCall: { [weak self] dmChannel in
                 self?.startDirectMessageCall(channel: dmChannel, user: user)
+            },
+            onTransferFunds: { [weak self] payload in
+                guard let self else { return }
+                let vc = WalletTransferViewController(context: self.context, payload: payload)
+                self.navigationController?.pushViewController(vc, animated: true)
             }
         )
         presentInGlobalOverlay(sheet)
@@ -4482,6 +4487,11 @@ final class ChatViewController: ViewController {
             },
             onStartCall: { [weak self] dmChannel in
                 self?.startDirectMessageCall(channel: dmChannel, user: user)
+            },
+            onTransferFunds: { [weak self] payload in
+                guard let self else { return }
+                let vc = WalletTransferViewController(context: self.context, payload: payload)
+                self.navigationController?.pushViewController(vc, animated: true)
             }
         )
         presentInGlobalOverlay(sheet)
@@ -4504,6 +4514,11 @@ final class ChatViewController: ViewController {
                 let chatVC = ChatViewController(
                     clanId: 0, channel: dmChannel, context: self.context, parentName: nil)
                 self.navigationController?.pushViewController(chatVC, animated: true)
+            },
+            onTransferFunds: { [weak self] payload in
+                guard let self else { return }
+                let vc = WalletTransferViewController(context: self.context, payload: payload)
+                self.navigationController?.pushViewController(vc, animated: true)
             }
         )
         presentInGlobalOverlay(sheet)

--- a/MezonChat/Features/Chat/MessageActionSheet.swift
+++ b/MezonChat/Features/Chat/MessageActionSheet.swift
@@ -303,6 +303,7 @@ final class MessageActionSheetController: ViewController {
         if display.isBuzzMessage { return false }
         if display.isForward { return false }
         if display.isPollMessage { return false }
+        if display.isSendTokenLog { return false }
         if display.message.id.hasPrefix("pending-") { return false }
         if display.shareContactData != nil { return true }
         guard !t.isEmpty || !display.attachments.isEmpty else { return false }

--- a/MezonChat/Features/Components/MemberProfileSheetController.swift
+++ b/MezonChat/Features/Components/MemberProfileSheetController.swift
@@ -226,6 +226,7 @@ final class MemberProfileSheetController: ViewController {
     private let onDismiss: (() -> Void)?
     private let onSendMessage: ((Mezon_Api_ChannelDescription) -> Void)?
     private let onStartCall: ((Mezon_Api_ChannelDescription) -> Void)?
+    private let onTransferFunds: ((TransferQRPayload) -> Void)?
 
     private var sheetNode: MemberProfileSheetNode { displayNode as! MemberProfileSheetNode }
 
@@ -238,7 +239,8 @@ final class MemberProfileSheetController: ViewController {
         groupAction: MemberProfileGroupAction? = nil,
         onDismiss: (() -> Void)? = nil,
         onSendMessage: ((Mezon_Api_ChannelDescription) -> Void)? = nil,
-        onStartCall: ((Mezon_Api_ChannelDescription) -> Void)? = nil
+        onStartCall: ((Mezon_Api_ChannelDescription) -> Void)? = nil,
+        onTransferFunds: ((TransferQRPayload) -> Void)? = nil
     ) {
         self.user = user
         self.context = context
@@ -249,6 +251,7 @@ final class MemberProfileSheetController: ViewController {
         self.onDismiss = onDismiss
         self.onSendMessage = onSendMessage
         self.onStartCall = onStartCall
+        self.onTransferFunds = onTransferFunds
         super.init(navigationBarPresentationData: nil)
         self.statusBar.statusBarStyle = .Hide
         self.blocksBackgroundWhenInOverlay = true
@@ -265,6 +268,7 @@ final class MemberProfileSheetController: ViewController {
             showAddFriendAction: voiceChannelActions == nil && shouldShowAddFriendAction(),
             voiceChannelActions: voiceChannelActions,
             showRemoveFromGroup: groupAction != nil && !isCurrentUser,
+            showTransferAction: onTransferFunds != nil && !isCurrentUser && user.id != 0,
             onSendMessageTapped: { [weak self] in
                 self?.handleSendMessage()
             },
@@ -273,6 +277,9 @@ final class MemberProfileSheetController: ViewController {
             },
             onAddFriendTapped: { [weak self] in
                 self?.handleAddFriend()
+            },
+            onTransferFundsTapped: { [weak self] in
+                self?.handleTransferFunds()
             },
             onDimTapped: { [weak self] in
                 self?.animateDismiss()
@@ -356,10 +363,11 @@ final class MemberProfileSheetController: ViewController {
         sheetNode.animateIn()
     }
 
-    private func animateDismiss() {
+    private func animateDismiss(completion: (() -> Void)? = nil) {
         sheetNode.animateOut { [weak self] in
             self?.dismiss(animated: false)
             self?.onDismiss?()
+            completion?()
         }
     }
 
@@ -525,6 +533,25 @@ final class MemberProfileSheetController: ViewController {
         }
     }
 
+    private func handleTransferFunds() {
+        guard !isCurrentUser, user.id != 0, let onTransferFunds else { return }
+
+        let displayName = user.displayName.isEmpty ? user.username : user.displayName
+        let payload = TransferQRPayload(
+            receiverUserId: String(user.id),
+            walletAddress: nil,
+            suggestedAmount: "10000",
+            note: L(L10n.Profile.transferFunds),
+            extraAttribute: nil,
+            receiverDisplayName: displayName.isEmpty ? String(user.id) : displayName,
+            recipientLocked: true
+        )
+
+        animateDismiss {
+            onTransferFunds(payload)
+        }
+    }
+
     private func resolveDirectMessageChannel() async -> Mezon_Api_ChannelDescription? {
         guard let token = await context.getToken() else {
             Toast.error(L(L10n.ClanInviteSheet.sessionNotFound))
@@ -598,6 +625,7 @@ private final class MemberProfileSheetNode: ASDisplayNode, UIGestureRecognizerDe
     private let messageBtn = ProfileActionButton(icon: "bubble.left.fill", title: "Message")
     private let callBtn = ProfileActionButton(icon: "phone.fill", title: "Call")
     private let addFriendBtn = ProfileActionButton(icon: "person.badge.plus", title: "Add Friend", isGreen: true)
+    private let transferButton = ASButtonNode()
     private let removeFromGroupButton = ASButtonNode()
 
     private let memberCardNode = ASDisplayNode()
@@ -610,6 +638,7 @@ private final class MemberProfileSheetNode: ASDisplayNode, UIGestureRecognizerDe
     private let onSendMessageTapped: () -> Void
     private let onStartCallTapped: () -> Void
     private let onAddFriendTapped: () -> Void
+    private let onTransferFundsTapped: () -> Void
     private let onDimTapped: () -> Void
     private let onVoiceMuteTap: () -> Void
     private let onVoiceKickTap: () -> Void
@@ -618,6 +647,7 @@ private final class MemberProfileSheetNode: ASDisplayNode, UIGestureRecognizerDe
     private let isCurrentUser: Bool
     private let showCallAction: Bool
     private let showAddFriendAction: Bool
+    private let showTransferAction: Bool
     private let voiceChannelActions: MemberProfileVoiceChannelActions?
     private let showRemoveFromGroup: Bool
 
@@ -652,9 +682,11 @@ private final class MemberProfileSheetNode: ASDisplayNode, UIGestureRecognizerDe
         showAddFriendAction: Bool,
         voiceChannelActions: MemberProfileVoiceChannelActions?,
         showRemoveFromGroup: Bool,
+        showTransferAction: Bool,
         onSendMessageTapped: @escaping () -> Void,
         onStartCallTapped: @escaping () -> Void,
         onAddFriendTapped: @escaping () -> Void,
+        onTransferFundsTapped: @escaping () -> Void,
         onDimTapped: @escaping () -> Void,
         onVoiceMuteTap: @escaping () -> Void,
         onVoiceKickTap: @escaping () -> Void,
@@ -668,9 +700,11 @@ private final class MemberProfileSheetNode: ASDisplayNode, UIGestureRecognizerDe
         self.showAddFriendAction = showAddFriendAction
         self.voiceChannelActions = voiceChannelActions
         self.showRemoveFromGroup = showRemoveFromGroup
+        self.showTransferAction = showTransferAction
         self.onSendMessageTapped = onSendMessageTapped
         self.onStartCallTapped = onStartCallTapped
         self.onAddFriendTapped = onAddFriendTapped
+        self.onTransferFundsTapped = onTransferFundsTapped
         self.onDimTapped = onDimTapped
         self.onVoiceMuteTap = onVoiceMuteTap
         self.onVoiceKickTap = onVoiceKickTap
@@ -728,6 +762,17 @@ private final class MemberProfileSheetNode: ASDisplayNode, UIGestureRecognizerDe
 
         infoCardNode.backgroundColor = t.secondary
         infoCardNode.cornerRadius = 10.sf
+
+        transferButton.backgroundColor = t.tertiary
+        transferButton.cornerRadius = 18.sf
+        transferButton.clipsToBounds = true
+        let transferIcon = (UIImage(named: "Profile/TransferIcon", in: Bundle.main, compatibleWith: nil)
+            ?? UIImage(systemName: "arrow.up.circle.fill"))?
+            .withTintColor(t.textStrong, renderingMode: .alwaysOriginal)
+        transferButton.setImage(transferIcon, for: .normal)
+        transferButton.imageNode.contentMode = .scaleAspectFit
+        transferButton.imageNode.style.preferredSize = CGSize(width: 20.sf, height: 20.sf)
+        transferButton.accessibilityLabel = L(L10n.Profile.transferFunds)
 
         let name = user.displayName.isEmpty ? user.username : user.displayName
         displayNameNode.attributedText = NSAttributedString(
@@ -799,6 +844,9 @@ private final class MemberProfileSheetNode: ASDisplayNode, UIGestureRecognizerDe
             voiceCardNode.isUserInteractionEnabled = true
         }
         contentNode.addSubnode(infoCardNode)
+        if showTransferAction {
+            contentNode.addSubnode(transferButton)
+        }
         infoCardNode.addSubnode(displayNameNode)
         infoCardNode.addSubnode(usernameNode)
         infoCardNode.addSubnode(actionRow)
@@ -860,6 +908,7 @@ private final class MemberProfileSheetNode: ASDisplayNode, UIGestureRecognizerDe
         voiceCardNode.layer.zPosition = voiceChannelActions != nil ? 8 : 0
         avatarNode.layer.zPosition = 10
         textAvatarNode.layer.zPosition = 9
+        transferButton.layer.zPosition = 12
         statusDotNode.layer.zPosition = 13
 
         loadingIndicator.hidesWhenStopped = true
@@ -869,6 +918,9 @@ private final class MemberProfileSheetNode: ASDisplayNode, UIGestureRecognizerDe
         messageBtn.onTapped = { [weak self] in self?.messageTapped() }
         callBtn.onTapped = { [weak self] in self?.callTapped() }
         addFriendBtn.onTapped = { [weak self] in self?.addFriendTapped() }
+        if showTransferAction {
+            transferButton.addTarget(self, action: #selector(transferTapped), forControlEvents: .touchUpInside)
+        }
         if showRemoveFromGroup {
             removeFromGroupButton.addTarget(
                 self, action: #selector(removeFromGroupTapped), forControlEvents: .touchUpInside)
@@ -988,6 +1040,7 @@ private final class MemberProfileSheetNode: ASDisplayNode, UIGestureRecognizerDe
 
     @objc private func dimTapped() { onDimTapped() }
     @objc private func removeFromGroupTapped() { onRemoveFromGroupTap() }
+    @objc private func transferTapped() { onTransferFundsTapped() }
     private func messageTapped() { onSendMessageTapped() }
     private func callTapped() { onStartCallTapped() }
     private func addFriendTapped() { onAddFriendTapped() }
@@ -1098,17 +1151,21 @@ private final class MemberProfileSheetNode: ASDisplayNode, UIGestureRecognizerDe
             messageBtn.isUserInteractionEnabled = false
             callBtn.isUserInteractionEnabled = false
             addFriendBtn.isUserInteractionEnabled = false
+            transferButton.isUserInteractionEnabled = false
             messageBtn.alpha = 0.5
             callBtn.alpha = 0.5
             addFriendBtn.alpha = 0.5
+            transferButton.alpha = 0.5
         } else {
             loadingIndicator.stopAnimating()
             messageBtn.isUserInteractionEnabled = true
             callBtn.isUserInteractionEnabled = true
             addFriendBtn.isUserInteractionEnabled = true
+            transferButton.isUserInteractionEnabled = true
             messageBtn.alpha = 1
             callBtn.alpha = 1
             addFriendBtn.alpha = 1
+            transferButton.alpha = 1
         }
     }
 
@@ -1135,9 +1192,11 @@ private final class MemberProfileSheetNode: ASDisplayNode, UIGestureRecognizerDe
         let infoCardPad: CGFloat = 20.sf
         let infoBottomPad = infoCardPad + 4.sh
 
-        let nameSize = displayNameNode.measure(CGSize(width: screenW - pad * 2 - infoCardPad * 2, height: .greatestFiniteMagnitude))
+        let transferButtonSize: CGFloat = 36.sf
+        let nameMaxWidth = max(1, screenW - pad * 2 - infoCardPad * 2)
+        let nameSize = displayNameNode.measure(CGSize(width: nameMaxWidth, height: .greatestFiniteMagnitude))
         let userSize = usernameNode.attributedText != nil
-            ? usernameNode.measure(CGSize(width: screenW - pad * 2 - infoCardPad * 2, height: .greatestFiniteMagnitude))
+            ? usernameNode.measure(CGSize(width: nameMaxWidth, height: .greatestFiniteMagnitude))
             : .zero
 
         let btnH: CGFloat = 76.sh
@@ -1224,6 +1283,14 @@ private final class MemberProfileSheetNode: ASDisplayNode, UIGestureRecognizerDe
 
         let infoCardH = infoY
         infoCardNode.frame = CGRect(x: pad, y: infoCardBaseTop, width: cardW, height: infoCardH)
+        if showTransferAction {
+            transferButton.frame = CGRect(
+                x: screenW - pad - transferButtonSize,
+                y: 12.sh,
+                width: transferButtonSize,
+                height: transferButtonSize
+            )
+        }
 
         var nextCardTop = infoCardBaseTop + infoCardH + 8
 

--- a/MezonChat/Features/DirectMessages/FriendListViewController.swift
+++ b/MezonChat/Features/DirectMessages/FriendListViewController.swift
@@ -301,6 +301,11 @@ final class FriendListViewController: ViewController {
                 guard let self else { return }
                 let chatVC = ChatViewController(clanId: 0, channel: dmChannel, context: self.context, parentName: nil)
                 self.navigationController?.pushViewController(chatVC, animated: true)
+            },
+            onTransferFunds: { [weak self] payload in
+                guard let self else { return }
+                let vc = WalletTransferViewController(context: self.context, payload: payload)
+                self.navigationController?.pushViewController(vc, animated: true)
             }
         )
         self.presentInGlobalOverlay(sheet)

--- a/MezonChat/Features/ScanQR/TransferSuccessViewController.swift
+++ b/MezonChat/Features/ScanQR/TransferSuccessViewController.swift
@@ -275,7 +275,9 @@ final class TransferSuccessViewController: UIViewController {
                 path: url.path,
                 thumbnail: nil,
                 duration: nil,
-                type: .image
+                type: .image,
+                width: nil,
+                height: nil
             )
             let sharingVC = SharingViewController(context: context, sharedContent: .media([file]))
             sharingVC.modalPresentationStyle = .pageSheet

--- a/MezonChat/Features/ScanQR/WalletTransferViewController.swift
+++ b/MezonChat/Features/ScanQR/WalletTransferViewController.swift
@@ -1,5 +1,83 @@
 import UIKit
 
+private final class AmountFormattingTextField: UITextField {
+    var onPlainAmountChanged: ((Int64) -> Void)?
+    private var isFormattingAmount = false
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        addTarget(self, action: #selector(amountTextChanged), for: .editingChanged)
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    func setFormattedAmount(_ raw: String) {
+        text = raw
+        normalizeAmountText(preserveCaret: false)
+    }
+
+    override func insertText(_ text: String) {
+        super.insertText(text)
+        normalizeAmountText(preserveCaret: true)
+    }
+
+    override func deleteBackward() {
+        super.deleteBackward()
+        normalizeAmountText(preserveCaret: true)
+    }
+
+    override func paste(_ sender: Any?) {
+        super.paste(sender)
+        normalizeAmountText(preserveCaret: true)
+    }
+
+    @objc private func amountTextChanged() {
+        normalizeAmountText(preserveCaret: true)
+    }
+
+    private func normalizeAmountText(preserveCaret: Bool) {
+        guard !isFormattingAmount else { return }
+        isFormattingAmount = true
+        defer { isFormattingAmount = false }
+
+        let current = text ?? ""
+        let caretDigitIndex = preserveCaret
+            ? amountCaretDigitIndex()
+            : MmnMoneyFormat.onlyDigitCharacters(current).count
+        let result = MmnMoneyFormat.formatTokenAmount(current)
+        onPlainAmountChanged?(result.plain)
+        
+        guard current != result.display else { return }
+        
+        text = result.display
+        let digitCount = MmnMoneyFormat.onlyDigitCharacters(result.display).count
+        let charIdx = MmnMoneyFormat.tokenAmountCaretCharacterIndex(
+            display: result.display,
+            digitIndex: min(caretDigitIndex, digitCount)
+        )
+        setCaret(characterIndex: charIdx)
+    }
+
+    private func amountCaretDigitIndex() -> Int {
+        let current = text ?? ""
+        guard let selectedRange = selectedTextRange else {
+            return MmnMoneyFormat.onlyDigitCharacters(current).count
+        }
+        let offset = self.offset(from: beginningOfDocument, to: selectedRange.start)
+        let clampedOffset = max(0, min(offset, (current as NSString).length))
+        let beforeCaret = (current as NSString).substring(to: clampedOffset)
+        return MmnMoneyFormat.onlyDigitCharacters(beforeCaret).count
+    }
+
+    private func setCaret(characterIndex: Int) {
+        let len = (text ?? "") as NSString
+        let c = max(0, min(characterIndex, len.length))
+        if let pos = position(from: beginningOfDocument, offset: c) {
+            selectedTextRange = textRange(from: pos, to: pos)
+        }
+    }
+}
+
 @MainActor
 final class WalletTransferViewController: BaseViewController, UIGestureRecognizerDelegate {
 
@@ -28,7 +106,7 @@ final class WalletTransferViewController: BaseViewController, UIGestureRecognize
     private let recipientChevron = UIImageView()
 
     private let amountLabel = UILabel()
-    private let amountField = UITextField()
+    private let amountField = AmountFormattingTextField()
     private let amountFieldContainer = UIView()
 
     private let noteLabel = UILabel()
@@ -234,15 +312,17 @@ final class WalletTransferViewController: BaseViewController, UIGestureRecognize
 
     private func presentRecipientPickerIfNeeded() {
         if let w = payload.walletAddress, !w.isEmpty { return }
+        if payload.recipientLocked { return }
         let picker = TransferRecipientPickerViewController(context: context) { [weak self] row in
             guard let self else { return }
             self.payload.receiverUserId = String(row.user.id)
             self.payload.walletAddress = nil
+            self.payload.recipientLocked = false
             let label = row.primaryText.isEmpty ? "\(row.user.id)" : row.primaryText
             self.payload.receiverDisplayName = label
             self.recipientValueLabel.text = label
             self.copyButton.isHidden = true
-            self.recipientChevron.isHidden = true
+            self.recipientChevron.isHidden = false
             DispatchQueue.main.async {
                 _ = self.amountField.becomeFirstResponder()
             }
@@ -288,8 +368,10 @@ final class WalletTransferViewController: BaseViewController, UIGestureRecognize
         amountField.font = .systemFont(ofSize: 16, weight: .semibold)
         amountField.keyboardType = .numberPad
         amountField.textAlignment = .left
-        amountField.delegate = self
-        amountField.text = "0"
+        amountField.onPlainAmountChanged = { [weak self] amount in
+            self?.plainAmount = amount
+        }
+        amountField.setFormattedAmount("0")
 
         amountFieldContainer.addSubview(amountField)
         NSLayoutConstraint.activate([
@@ -300,9 +382,7 @@ final class WalletTransferViewController: BaseViewController, UIGestureRecognize
         ])
 
         if let suggested = payload.suggestedAmount, !suggested.isEmpty {
-            let r = MmnMoneyFormat.formatTokenAmount(suggested)
-            amountField.text = r.display
-            plainAmount = r.plain
+            amountField.setFormattedAmount(suggested)
         }
     }
 
@@ -426,7 +506,7 @@ final class WalletTransferViewController: BaseViewController, UIGestureRecognize
             }()
             recipientValueLabel.text = shown
             copyButton.isHidden = true
-            recipientChevron.isHidden = true
+            recipientChevron.isHidden = payload.recipientLocked
         } else {
             recipientValueLabel.text = L(L10n.Profile.sendTokenSelectAccount)
             copyButton.isHidden = true
@@ -664,44 +744,10 @@ final class WalletTransferViewController: BaseViewController, UIGestureRecognize
     }
 
     private func resetForm() {
-        plainAmount = 0
-        amountField.text = "0"
+        amountField.setFormattedAmount("0")
         noteField.text = L(L10n.Profile.sendTokenDefaultNote)
         updateNotePlaceholder()
         updateNoteCounter()
-    }
-}
-
-extension WalletTransferViewController: UITextFieldDelegate {
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        guard textField === amountField else { return true }
-        let current = textField.text ?? ""
-        if let out = MmnMoneyFormat.displayAfterTokenEdit(currentDisplay: current, range: range, replacement: string) {
-            plainAmount = out.plain
-            textField.text = out.display
-            let charIdx = MmnMoneyFormat.tokenAmountCaretCharacterIndex(display: out.display, digitIndex: out.caretDigitIndex)
-            DispatchQueue.main.async { [weak textField] in
-                guard let tf = textField, tf === self.amountField else { return }
-                let len = (tf.text ?? "") as NSString
-                let c = max(0, min(charIdx, len.length))
-                if let pos = tf.position(from: tf.beginningOfDocument, offset: c) {
-                    tf.selectedTextRange = tf.textRange(from: pos, to: pos)
-                }
-            }
-        } else {
-            let new = (current as NSString).replacingCharacters(in: range, with: string)
-            let result = MmnMoneyFormat.formatTokenAmount(new)
-            plainAmount = result.plain
-            textField.text = result.display
-            DispatchQueue.main.async { [weak textField] in
-                guard let tf = textField, tf === self.amountField else { return }
-                let len = (tf.text ?? "") as NSString
-                if let pos = tf.position(from: tf.beginningOfDocument, offset: len.length) {
-                    tf.selectedTextRange = tf.textRange(from: pos, to: pos)
-                }
-            }
-        }
-        return false
     }
 }
 

--- a/MezonChat/Features/Search/SearchViewController.swift
+++ b/MezonChat/Features/Search/SearchViewController.swift
@@ -620,6 +620,11 @@ final class SearchViewController: ViewController {
                 let chatVC = ChatViewController(
                     clanId: 0, channel: dmChannel, context: self.context, parentName: nil)
                 self.navigationController?.pushViewController(chatVC, animated: true)
+            },
+            onTransferFunds: { [weak self] payload in
+                guard let self else { return }
+                let vc = WalletTransferViewController(context: self.context, payload: payload)
+                self.navigationController?.pushViewController(vc, animated: true)
             }
         )
         self.presentInGlobalOverlay(sheet)

--- a/MezonChat/Features/Sharing/SharingViewController.swift
+++ b/MezonChat/Features/Sharing/SharingViewController.swift
@@ -1395,6 +1395,11 @@ final class SharingViewController: UIViewController {
                        let image = UIImage(data: imageData) {
                         width = Int(image.size.width)
                         height = Int(image.size.height)
+                    } else if file.type == .video {
+                        if let w = file.width, let h = file.height {
+                            width = Int(w)
+                            height = Int(h)
+                        }
                     }
 
                     let sanitized = filename.replacingOccurrences(of: "[^a-zA-Z0-9._-]", with: "_", options: .regularExpression)

--- a/MezonChat/Features/VoiceChannel/VoiceChannelLiveKitBridge.swift
+++ b/MezonChat/Features/VoiceChannel/VoiceChannelLiveKitBridge.swift
@@ -19,7 +19,7 @@ final class VoiceChannelLiveKitBridge: NSObject, RoomDelegate {
         AudioManager.shared.audioSession.isAutomaticConfigurationEnabled = false
         AudioManager.shared.audioSession.isAutomaticDeactivationEnabled = false
         Self.primeWebRTCAudioConfigForMixIfNeeded()
-        Self.applyVoiceProcessingBypassForMix(VoiceChannelAudioPreferences.mixWithOthersEnabled)
+        Self.applyEchoCancellationConfiguration()
         room = Room(delegate: self, roomOptions: RoomOptions(adaptiveStream: true, dynacast: true))
     }
 
@@ -37,10 +37,10 @@ final class VoiceChannelLiveKitBridge: NSObject, RoomDelegate {
         LKRTCAudioSessionConfiguration.setWebRTC(cfg)
     }
 
-    static func applyVoiceProcessingBypassForMix(_ enabled: Bool) {
-        AudioManager.shared.isVoiceProcessingBypassed = enabled
+    static func applyEchoCancellationConfiguration() {
+        AudioManager.shared.isVoiceProcessingBypassed = false
         if #available(iOS 17, *) {
-            AudioManager.shared.duckingLevel = enabled ? .min : .default
+            AudioManager.shared.duckingLevel = VoiceChannelAudioPreferences.mixWithOthersEnabled ? .min : .default
         }
     }
 
@@ -78,7 +78,7 @@ final class VoiceChannelLiveKitBridge: NSObject, RoomDelegate {
         guard !didEndSession else { return }
         didEndSession = true
         await room.disconnect()
-        Self.applyVoiceProcessingBypassForMix(false)
+        AudioManager.shared.isVoiceProcessingBypassed = false
     }
 
     func setMicrophoneEnabled(_ enabled: Bool) async throws {

--- a/MezonChat/Features/VoiceChannel/VoiceChannelRoomViewController.swift
+++ b/MezonChat/Features/VoiceChannel/VoiceChannelRoomViewController.swift
@@ -187,7 +187,7 @@ enum VoiceChannelAudioPreferences {
         set {
             UserDefaults.standard.set(newValue, forKey: mixWithOthersKey)
             UserDefaults.standard.synchronize()
-            VoiceChannelLiveKitBridge.applyVoiceProcessingBypassForMix(newValue)
+            VoiceChannelLiveKitBridge.applyEchoCancellationConfiguration()
         }
     }
 }
@@ -3942,6 +3942,11 @@ final class VoiceChannelRoomViewController: ViewController, ScreenShareExpandedP
                     let chatVC = ChatViewController(
                         clanId: 0, channel: dmChannel, context: self.context, parentName: nil)
                     self.navigationController?.pushViewController(chatVC, animated: true)
+                },
+                onTransferFunds: { [weak self] payload in
+                    guard let self else { return }
+                    let vc = WalletTransferViewController(context: self.context, payload: payload)
+                    self.navigationController?.pushViewController(vc, animated: true)
                 }
             )
 

--- a/MezonChat/Mmn/MmnClient.swift
+++ b/MezonChat/Mmn/MmnClient.swift
@@ -237,9 +237,11 @@ enum MmnMoneyFormat {
         if value == 0 { return ("0", 0) }
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
-        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.groupingSeparator = ","
+        formatter.groupingSize = 3
         formatter.usesGroupingSeparator = true
+        formatter.maximumFractionDigits = 0
+        formatter.minimumFractionDigits = 0
         let display = formatter.string(from: NSNumber(value: value)) ?? s
         return (display, value)
     }

--- a/MezonChat/Mmn/MmnTransferCoordinator.swift
+++ b/MezonChat/Mmn/MmnTransferCoordinator.swift
@@ -7,6 +7,7 @@ struct TransferQRPayload: Sendable {
     var note: String?
     var extraAttribute: String?
     var receiverDisplayName: String?
+    var recipientLocked: Bool = false
 }
 
 enum MmnTransferParse {
@@ -30,7 +31,8 @@ enum MmnTransferParse {
             suggestedAmount: amount,
             note: note,
             extraAttribute: extra,
-            receiverDisplayName: (rname?.isEmpty == false) ? rname : nil
+            receiverDisplayName: (rname?.isEmpty == false) ? rname : nil,
+            recipientLocked: rid != nil || wa != nil
         )
         return p
     }

--- a/MezonSharing/ShareViewController.swift
+++ b/MezonSharing/ShareViewController.swift
@@ -83,7 +83,9 @@ class ShareViewController: UIViewController {
                                 path: savedURL.absoluteString,
                                 thumbnail: nil,
                                 duration: nil,
-                                type: .image
+                                type: .image,
+                                width: nil,
+                                height: nil
                             ))
                         }
                     }
@@ -109,7 +111,9 @@ class ShareViewController: UIViewController {
                     path: newPath.absoluteString,
                     thumbnail: nil,
                     duration: nil,
-                    type: .image
+                    type: .image,
+                    width: nil,
+                    height: nil
                 ))
             }
 
@@ -168,7 +172,9 @@ class ShareViewController: UIViewController {
                         path: newPath.absoluteString,
                         thumbnail: nil,
                         duration: nil,
-                        type: .file
+                        type: .file,
+                        width: nil,
+                        height: nil
                     ))
                 } catch {
                 }
@@ -204,7 +210,9 @@ class ShareViewController: UIViewController {
                 path: newPath.absoluteString,
                 thumbnail: nil,
                 duration: nil,
-                type: .file
+                type: .file,
+                width: nil,
+                height: nil
             ))
         }
     }
@@ -339,9 +347,38 @@ class ShareViewController: UIViewController {
         let asset = AVAsset(url: videoURL)
         let duration = CMTimeGetSeconds(asset.duration) * 1000
 
+        var width: CGFloat = 0
+        var height: CGFloat = 0
+        
+        if let videoTrack = asset.tracks(withMediaType: .video).first {
+            let size = videoTrack.naturalSize
+            let transform = videoTrack.preferredTransform
+            
+            let txA = transform.a
+            let txB = transform.b
+            let txC = transform.c
+            let txD = transform.d
+            
+            if (txA == 0 && txB == 1.0 && txC == -1.0 && txD == 0) ||
+               (txA == 0 && txB == -1.0 && txC == 1.0 && txD == 0) {
+                width = size.height
+                height = size.width
+            } else {
+                width = size.width
+                height = size.height
+            }
+        }
+
         let thumbnailPath = getThumbnailPath(for: videoURL)
         if FileManager.default.fileExists(atPath: thumbnailPath.path) {
-            return SharedMediaFile(path: videoURL.absoluteString, thumbnail: thumbnailPath.absoluteString, duration: duration, type: .video)
+            return SharedMediaFile(
+                path: videoURL.absoluteString,
+                thumbnail: thumbnailPath.absoluteString,
+                duration: duration,
+                type: .video,
+                width: width,
+                height: height
+            )
         }
 
         let assetImgGenerate = AVAssetImageGenerator(asset: asset)
@@ -351,9 +388,23 @@ class ShareViewController: UIViewController {
         do {
             let img = try assetImgGenerate.copyCGImage(at: CMTimeMakeWithSeconds(0, preferredTimescale: 1), actualTime: nil)
             try UIImage(cgImage: img).pngData()?.write(to: thumbnailPath)
-            return SharedMediaFile(path: videoURL.absoluteString, thumbnail: thumbnailPath.absoluteString, duration: duration, type: .video)
+            return SharedMediaFile(
+                path: videoURL.absoluteString,
+                thumbnail: thumbnailPath.absoluteString,
+                duration: duration,
+                type: .video,
+                width: width,
+                height: height
+            )
         } catch {
-            return SharedMediaFile(path: videoURL.absoluteString, thumbnail: nil, duration: duration, type: .video)
+            return SharedMediaFile(
+                path: videoURL.absoluteString,
+                thumbnail: nil,
+                duration: duration,
+                type: .video,
+                width: width,
+                height: height
+            )
         }
     }
 
@@ -388,6 +439,8 @@ struct SharedMediaFile: Codable {
     var thumbnail: String?
     var duration: Double?
     var type: SharedMediaType
+    var width: CGFloat?
+    var height: CGFloat?
 }
 
 enum SharedMediaType: Int, Codable {


### PR DESCRIPTION
## Fix: Voice channel list auto-scroll & jank on user join/leave

### 1. Root Cause

While inside a voice channel, every time another user joins/leaves caused 3 UX issues:

**a) Auto-scroll back to the joined voice channel**
- `ChannelListContainerNode.maybeRevealSelectedChannel` used the condition
  `voiceMapChanged = prevState.voiceUsersByChannel != newState.voiceUsersByChannel`.
- This is true on *any* membership change. Since the joined voice channel is also the selected channel, every join/leave event scrolled the list back to focus that channel.

**b) List jank from flooded reloads**
- `ChannelListViewController.handleVoicePresenceChanged` called `needsReloadPipe.putNext(())` immediately on every notification → full state recompute + table diff. Rapid user churn flooded the run loop.

**c) List jumps when a voice-member row is inserted/removed**
- When a user joins, a `voiceMemberExpanded` row is inserted. If the insertion point is above the viewport, `UITableView` shifts all content below it downward, so the list appears to jump even though the channel didn't change.

### 2. Solution

**a) Narrow the auto-scroll condition** (`ChannelListContainerNode.maybeRevealSelectedChannel`)
- Replaced `voiceMapChanged` with `selectedVoiceBecameActive` — only scroll when the selected voice channel transitions from **empty → active** (the moment of joining), instead of on every membership change.
- Preserved all other valid scroll cases: clan switch, channel selection change, loading finished.

**b) Coalesce voice presence reloads** (`ChannelListViewController`)
- Coalesce voice presence notifications within a `0.4s` window into a single reload (`scheduleCoalescedVoicePresenceReload`).
- `currentState` always reads the latest voice data at emit time → no data loss, just fewer diffs.

**c) Preserve scroll position when voice rows change** (`ChannelListContainerNode.applyBatchStructureUpdate`)
- `pathsContainVoiceRow`: only trigger scroll preservation when the insert/delete batch contains a voice-member row → other updates (category collapse, channel add/remove) are unaffected.
- `captureScrollAnchor`: anchor a currently visible row (prefer a stable channel/thread row, avoid picking a voice row that may be removed in the same batch), storing its `rowDiffKey` + distance from the top edge.
- `restoreScrollAnchor`: locate the row after the update, adjust `contentOffset` to keep the same distance (clamped + animations disabled via `CATransaction`).

> No changes to the existing diff/reload machinery. Local user joins still scroll-to-channel correctly because `maybeRevealSelectedChannel` runs after the anchor restore.

### 3. Self-test

**Auto-scroll**
- [ ] Join a voice channel → list scrolls to focus that channel (same as before).
- [ ] Another user joins/leaves while I'm in a voice channel → list does **not** auto-scroll.
- [ ] Switch clan / select a different channel → scroll-to-channel still works.

**Jank / reload**
- [ ] Many users joining/leaving rapidly → list does **not** jank, updates smoothly.
- [ ] Voice member count is correct after settling (no missing users).

**Scroll position preservation**
- [ ] Scroll mid-list with a voice channel above the viewport → user join/leave → scroll position stays put, no jump.
- [ ] Voice member rows still insert/remove correctly (avatar, name display accurate).
- [ ] Collapse/expand category, add/remove text channel → behavior unchanged.

**Regression**
- [ ] Unread badges and selection highlight work as expected.
- [ ] Clan switch and pull-to-refresh work without errors.
