### PR TITLE
Optimize: Incremental Multi-Image Upload

### DIFF
--- a/MezonChat/Core/Postbox/Messages/MessageRecord.swift
+++ b/MezonChat/Core/Postbox/Messages/MessageRecord.swift
@@ -99,6 +99,7 @@ extension MessageRecord {
         let channelId = api.topicID != 0 ? "topic-\(api.topicID)" : "\(api.channelID)"
         let editedAt: Date? = {
             if isPoll { return nil }
+            if api.hideEditted { return nil }
             return api.updateTimeSeconds > api.createTimeSeconds
                 ? Date(timeIntervalSince1970: TimeInterval(api.updateTimeSeconds))
                 : nil

--- a/MezonChat/Features/ChannelList/ChannelListContainerNode.swift
+++ b/MezonChat/Features/ChannelList/ChannelListContainerNode.swift
@@ -71,6 +71,8 @@ final class ChannelListContainerNode: ASDisplayNode {
     private let interaction: ChannelListInteraction
     private let disposables = DisposableSet()
     private var isClanSwitching = false
+    private var nodeIsVisible = false
+    private var pendingVisibleReconcile = false
 
     private var latestCoalescedChannelListState: ChannelListState?
     private var channelListStateApplyScheduled = false
@@ -150,7 +152,6 @@ final class ChannelListContainerNode: ASDisplayNode {
         }
 
         let wasClanSwitching = isClanSwitching
-        isClanSwitching = false
         state = newState
         threadLookup = buildThreadLookup(newState.allChannels)
         cachedRows = [:]
@@ -167,9 +168,22 @@ final class ChannelListContainerNode: ASDisplayNode {
                     || ($0.favoriteFlatChannels?.count ?? 0) != ($1.favoriteFlatChannels?.count ?? 0)
             })
 
+        let switchSettled = wasClanSwitching && !newState.isLoading
+            && (!newCats.isEmpty || prevState.isLoading)
+        isClanSwitching = wasClanSwitching && !switchSettled
+
         if wasClanSwitching {
             cachedHeaders = [:]
-            applyCrossfadeReload()
+            if nodeIsVisible {
+                applyCrossfadeReload()
+            } else {
+                pendingVisibleReconcile = true
+                safeReloadData()
+            }
+        } else if !nodeIsVisible && structureChanged {
+            cachedHeaders = [:]
+            pendingVisibleReconcile = true
+            safeReloadData()
         } else if structureChanged {
             cachedHeaders = [:]
             applyBatchStructureUpdate(prev: prevState, new: newState)
@@ -949,6 +963,22 @@ final class ChannelListContainerNode: ASDisplayNode {
         newUnreadButton.addTarget(self, action: #selector(newUnreadButtonTapped), for: .touchUpInside)
         view.addSubview(newUnreadButton)
         refreshNewUnreadButton()
+    }
+
+    override func didEnterVisibleState() {
+        super.didEnterVisibleState()
+        nodeIsVisible = true
+        if pendingVisibleReconcile {
+            pendingVisibleReconcile = false
+            cachedRows = [:]
+            cachedHeaders = [:]
+            applyCrossfadeReload()
+        }
+    }
+
+    override func didExitVisibleState() {
+        super.didExitVisibleState()
+        nodeIsVisible = false
     }
 
     private func scheduleReload() {

--- a/MezonChat/Features/Chat/Cells/MessageBubbleNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageBubbleNode.swift
@@ -1075,6 +1075,10 @@ final class MessageBubbleNode: ASDisplayNode {
     }
 
     private func handleImageTap(index: Int, media: [ParsedAttachment], interaction: ChatInteraction) {
+        if index >= 0, index < media.count, media[index].uploadFailed {
+            interaction.onMediaRetryTapped?(index, display)
+            return
+        }
         if let onMediaTapped = interaction.onMediaTapped {
             onMediaTapped(index, media, display)
             return

--- a/MezonChat/Features/Chat/Cells/MessageMediaContentNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageMediaContentNode.swift
@@ -154,6 +154,11 @@ final class MessageMediaContentNode: ASDisplayNode {
                 videoOverlayNodes.append(overlay)
                 addSubnode(overlay)
             }
+            if media[0].uploadFailed {
+                let overlay = makeFailedOverlay()
+                videoOverlayNodes.append(overlay)
+                addSubnode(overlay)
+            }
         } else {
             isSticker = false
             isSingleImage = false
@@ -178,6 +183,10 @@ final class MessageMediaContentNode: ASDisplayNode {
                     addSubnode(overlay)
                 } else if att.isUploading {
                     let overlay = makeUploadingOverlay()
+                    videoOverlayNodes.append(overlay)
+                    addSubnode(overlay)
+                } else if att.uploadFailed {
+                    let overlay = makeFailedOverlay()
                     videoOverlayNodes.append(overlay)
                     addSubnode(overlay)
                 } else {
@@ -332,7 +341,7 @@ final class MessageMediaContentNode: ASDisplayNode {
                         y: imgFrame.midY - sz / 2,
                         width: sz, height: sz
                     )
-                } else if attachments.first?.isUploading == true {
+                } else if attachments.first?.isUploading == true || attachments.first?.uploadFailed == true {
                     overlay.frame = imgFrame
                 }
             }
@@ -343,7 +352,7 @@ final class MessageMediaContentNode: ASDisplayNode {
                     let imgFrame = cachedImageFrames[i]
                     let sz: CGFloat = 48
                     overlay.frame = CGRect(x: imgFrame.midX - sz / 2, y: imgFrame.midY - sz / 2, width: sz, height: sz)
-                } else if i < attachments.count, attachments[i].isUploading {
+                } else if i < attachments.count, attachments[i].isUploading || attachments[i].uploadFailed {
                     overlay.frame = cachedImageFrames[i]
                 }
             }
@@ -478,6 +487,30 @@ final class MessageMediaContentNode: ASDisplayNode {
 
         overlay.layoutSpecBlock = { _, _ in
             ASCenterLayoutSpec(centeringOptions: .XY, sizingOptions: [], child: spinner)
+        }
+
+        return overlay
+    }
+
+    private func makeFailedOverlay() -> ASDisplayNode {
+        let overlay = ASDisplayNode()
+        overlay.backgroundColor = UIColor.black.withAlphaComponent(0.45)
+        overlay.cornerRadius = 8.swh
+        overlay.clipsToBounds = true
+        overlay.isUserInteractionEnabled = false
+
+        let icon = ASImageNode()
+        let symbolConfig = UIImage.SymbolConfiguration(pointSize: 30, weight: .semibold)
+        if let sfImage = UIImage(systemName: "arrow.clockwise.circle.fill", withConfiguration: symbolConfig)?
+            .withTintColor(.white, renderingMode: .alwaysOriginal) {
+            icon.image = sfImage
+        }
+        icon.contentMode = .scaleAspectFit
+        icon.style.preferredSize = CGSize(width: 40, height: 40)
+        overlay.addSubnode(icon)
+
+        overlay.layoutSpecBlock = { _, _ in
+            ASCenterLayoutSpec(centeringOptions: .XY, sizingOptions: [], child: icon)
         }
 
         return overlay

--- a/MezonChat/Features/Chat/ChatContainerNode.swift
+++ b/MezonChat/Features/Chat/ChatContainerNode.swift
@@ -65,6 +65,7 @@ struct ChatInteraction {
     var onMessageNeedsRelayout: ((String) -> Void)?
     var onEmbedButtonClicked: ((ParsedEmbedButton, String, ChatMessageDisplay) -> Void)?  
     var onMediaTapped: ((_ index: Int, _ media: [ParsedAttachment], _ display: ChatMessageDisplay) -> Void)? = nil
+    var onMediaRetryTapped: ((_ index: Int, _ display: ChatMessageDisplay) -> Void)? = nil
 }
 
 final class ChatContainerNode: ASDisplayNode {

--- a/MezonChat/Features/Chat/ChatViewController.swift
+++ b/MezonChat/Features/Chat/ChatViewController.swift
@@ -23,6 +23,7 @@ struct ParsedAttachment: Equatable {
     let durationSeconds: Int?
     var localImage: UIImage?
     var isUploading: Bool = false
+    var uploadFailed: Bool = false
 
     var isImage: Bool {
         filetype.hasPrefix("image/") || filetype == "sticker"
@@ -58,7 +59,7 @@ struct ParsedAttachment: Equatable {
     static func ==(lhs: ParsedAttachment, rhs: ParsedAttachment) -> Bool {
         lhs.url == rhs.url && lhs.filename == rhs.filename && lhs.filetype == rhs.filetype
             && lhs.width == rhs.width && lhs.height == rhs.height && lhs.durationSeconds == rhs.durationSeconds
-            && lhs.isUploading == rhs.isUploading
+            && lhs.isUploading == rhs.isUploading && lhs.uploadFailed == rhs.uploadFailed
     }
 
     private static let maxPendingCacheEntries = 50
@@ -807,6 +808,11 @@ final class ChatViewController: ViewController {
         )
         interaction.onMediaTapped = { [weak self] index, media, display in
             self?.presentMessageMediaGallery(index: index, media: media, display: display)
+        }
+        interaction.onMediaRetryTapped = { [weak self] index, display in
+            guard let self else { return }
+            AttachmentUploadCoordinator.shared.retry(
+                context: self.context, messageId: display.message.id, itemIndex: index)
         }
         interaction.onMessagesReloaded = { [weak self] in
             guard let self else { return }
@@ -2612,7 +2618,15 @@ final class ChatViewController: ViewController {
                 && now.timeIntervalSince(sendingFeedbackBeganAt) >= Self.pendingSendFeedbackDelay
 
             var attachments = Self.parseAttachments(record.attachmentsJSON)
-            if record.sendingState == .pending {
+            if let overlayMedia = AttachmentUploadCoordinator.shared.imageOverlay(for: record.id) {
+                let nonMedia = attachments.filter { !$0.isMedia }
+                if nonMedia.isEmpty {
+                    let localDocs = ParsedAttachment.pendingDocumentPlaceholders[record.id] ?? []
+                    attachments = overlayMedia + localDocs
+                } else {
+                    attachments = overlayMedia + nonMedia
+                }
+            } else if record.sendingState == .pending {
                 let stillUploading = true
                 let localImages = ParsedAttachment.pendingImageCache[record.id] ?? []
                 let localDocs = ParsedAttachment.pendingDocumentPlaceholders[record.id] ?? []

--- a/MezonChat/Features/Components/MemberProfileSheetController.swift
+++ b/MezonChat/Features/Components/MemberProfileSheetController.swift
@@ -766,8 +766,7 @@ private final class MemberProfileSheetNode: ASDisplayNode, UIGestureRecognizerDe
         transferButton.backgroundColor = t.tertiary
         transferButton.cornerRadius = 18.sf
         transferButton.clipsToBounds = true
-        let transferIcon = (UIImage(named: "Profile/TransferIcon", in: Bundle.main, compatibleWith: nil)
-            ?? UIImage(systemName: "arrow.up.circle.fill"))?
+        let transferIcon = UIImage(named: "Profile/TransferIcon", in: Bundle.main, compatibleWith: nil)?
             .withTintColor(t.textStrong, renderingMode: .alwaysOriginal)
         transferButton.setImage(transferIcon, for: .normal)
         transferButton.imageNode.contentMode = .scaleAspectFit

--- a/MezonChat/Features/SendMessageInput/AttachmentUploadCoordinator.swift
+++ b/MezonChat/Features/SendMessageInput/AttachmentUploadCoordinator.swift
@@ -1,0 +1,526 @@
+import UIKit
+
+struct ImageSendParams {
+    let localId: String
+    let channelIdStr: String
+    let clanId: Int64
+    let channelId: Int64
+    let mode: Int32
+    let isPublic: Bool
+    let topicId: Int64
+    let hasText: Bool
+    let contentStr: String
+    let outgoingContentData: Data
+    let mentionList: [Mezon_Api_MessageMention]
+    let mentionsPayload: Data
+    let references: [Mezon_Api_MessageRef]
+    let pendingReferencesData: Data
+    let avatar: String
+    let pendingSenderDisplayName: String
+    let pendingSenderAvatarURL: String?
+    let images: [UIImage]
+    let fileURLs: [Int: URL]
+    let files: [PickedFileInfo]
+}
+
+enum ImageUploadItemState {
+    case uploading
+    case uploaded(Mezon_Api_MessageAttachment)
+    case failed
+
+    var isUploading: Bool { if case .uploading = self { return true } else { return false } }
+    var isFailed: Bool { if case .failed = self { return true } else { return false } }
+    var uploadedAttachment: Mezon_Api_MessageAttachment? {
+        if case let .uploaded(att) = self { return att } else { return nil }
+    }
+}
+
+final class ImageUploadItem {
+    let image: UIImage
+    let fileURL: URL?
+    var state: ImageUploadItemState = .uploading
+
+    init(image: UIImage, fileURL: URL?) {
+        self.image = image
+        self.fileURL = fileURL
+    }
+}
+
+final class ImageUploadSession {
+    let params: ImageSendParams
+    var items: [ImageUploadItem]
+    var fileAttachments: [Mezon_Api_MessageAttachment] = []
+    var serverMessageId: Int64 = 0
+    var hasSent = false
+    var aborted = false
+    var finished = false
+    var lastFlushCompletedCount = 0
+
+    init(params: ImageSendParams) {
+        self.params = params
+        self.items = params.images.enumerated().map { idx, img in
+            ImageUploadItem(image: img, fileURL: params.fileURLs[idx])
+        }
+    }
+}
+
+final class AttachmentUploadCoordinator {
+
+    static let shared = AttachmentUploadCoordinator()
+    private init() {}
+
+    private static let editBatchSize = 4
+    private static let maxConcurrentUploads = 4
+
+    private let lock = NSLock()
+    private var sessionsByKey: [String: ImageUploadSession] = [:]
+
+    // MARK: - Store
+
+    private func register(_ session: ImageUploadSession, key: String) {
+        lock.lock(); defer { lock.unlock() }
+        sessionsByKey[key] = session
+    }
+
+    private func session(forKey key: String) -> ImageUploadSession? {
+        lock.lock(); defer { lock.unlock() }
+        return sessionsByKey[key]
+    }
+
+    private func remove(_ session: ImageUploadSession) {
+        lock.lock(); defer { lock.unlock() }
+        sessionsByKey = sessionsByKey.filter { $0.value !== session }
+    }
+
+    func activeMessageIds() -> Set<String> {
+        lock.lock(); defer { lock.unlock() }
+        return Set(sessionsByKey.keys)
+    }
+
+    func pruneSessions(keepingMessageIds keep: Set<String>) {
+        lock.lock(); defer { lock.unlock() }
+        sessionsByKey = sessionsByKey.filter { keep.contains($0.key) }
+    }
+
+    // MARK: - Overlay for rendering
+
+    func imageOverlay(for messageId: String) -> [ParsedAttachment]? {
+        guard let session = session(forKey: messageId) else { return nil }
+        return session.items.map { item -> ParsedAttachment in
+            switch item.state {
+            case let .uploaded(att):
+                return ParsedAttachment(
+                    url: att.url,
+                    filename: att.filename,
+                    filetype: att.filetype,
+                    width: att.width != 0 ? Int(att.width) : Int(item.image.size.width),
+                    height: att.height != 0 ? Int(att.height) : Int(item.image.size.height),
+                    durationSeconds: att.duration != 0 ? Int(att.duration) : nil,
+                    localImage: item.image,
+                    isUploading: false,
+                    uploadFailed: false
+                )
+            case .uploading:
+                return ParsedAttachment(
+                    url: "",
+                    filename: "uploading.jpg",
+                    filetype: "image/jpeg",
+                    width: Int(item.image.size.width),
+                    height: Int(item.image.size.height),
+                    durationSeconds: nil,
+                    localImage: item.image,
+                    isUploading: true,
+                    uploadFailed: false
+                )
+            case .failed:
+                return ParsedAttachment(
+                    url: "",
+                    filename: "failed.jpg",
+                    filetype: "image/jpeg",
+                    width: Int(item.image.size.width),
+                    height: Int(item.image.size.height),
+                    durationSeconds: nil,
+                    localImage: item.image,
+                    isUploading: false,
+                    uploadFailed: true
+                )
+            }
+        }
+    }
+
+    // MARK: - Public API
+
+    @MainActor
+    func startImageSend(
+        context: AccountContext,
+        params: ImageSendParams,
+        prepare: ((String) async -> Void)? = nil
+    ) {
+        let session = ImageUploadSession(params: params)
+        register(session, key: params.localId)
+
+        if let sender = context.currentUser {
+            let record = MessageRecord.pending(
+                localId: params.localId,
+                text: "",
+                channelId: params.channelIdStr,
+                clanId: params.clanId,
+                sender: sender,
+                displayName: params.pendingSenderDisplayName,
+                avatarURL: params.pendingSenderAvatarURL,
+                referencesData: params.pendingReferencesData,
+                mentionsData: params.mentionsPayload,
+                contentData: params.outgoingContentData
+            )
+            context.account.postbox.write { tx in tx.addMessages([record]) }
+        }
+
+        Task { @MainActor in
+            await self.runUploads(session, context: context, prepare: prepare)
+        }
+    }
+
+    @MainActor
+    func retry(context: AccountContext, messageId: String, itemIndex: Int) {
+        guard let session = session(forKey: messageId) else { return }
+        guard itemIndex >= 0, itemIndex < session.items.count else { return }
+        guard session.items[itemIndex].state.isFailed, !session.aborted else { return }
+
+        session.items[itemIndex].state = .uploading
+        session.finished = false
+        nudge(session, context: context)
+
+        Task { @MainActor in
+            guard let token = await context.getToken() else {
+                session.items[itemIndex].state = .failed
+                self.nudge(session, context: context)
+                return
+            }
+            let att = await self.uploadOneImage(session.items[itemIndex], context: context, token: token)
+            session.items[itemIndex].state = att.map { .uploaded($0) } ?? .failed
+            self.nudge(session, context: context)
+            await self.afterStateChange(session, context: context, token: token, forceFlush: true)
+        }
+    }
+
+    // MARK: - Orchestration
+
+    @MainActor
+    private func runUploads(
+        _ session: ImageUploadSession,
+        context: AccountContext,
+        prepare: ((String) async -> Void)?
+    ) async {
+        guard let token = await context.getToken() else {
+            for item in session.items where item.state.isUploading { item.state = .failed }
+            finalizeAllFailed(session, context: context)
+            return
+        }
+
+        await uploadFiles(session, context: context, token: token)
+        await prepare?(token)
+
+        var nextIndex = 0
+        await withTaskGroup(of: (Int, Mezon_Api_MessageAttachment?).self) { group in
+            func addNext() {
+                guard nextIndex < session.items.count else { return }
+                let index = nextIndex
+                nextIndex += 1
+                let item = session.items[index]
+                group.addTask {
+                    let att = await self.uploadOneImage(item, context: context, token: token)
+                    return (index, att)
+                }
+            }
+
+            for _ in 0..<Self.maxConcurrentUploads { addNext() }
+
+            for await (index, att) in group {
+                session.items[index].state = att.map { .uploaded($0) } ?? .failed
+                self.nudge(session, context: context)
+                addNext()
+                await self.afterStateChange(session, context: context, token: token)
+            }
+        }
+
+        await afterStateChange(session, context: context, token: token, forceFlush: true)
+    }
+
+    @MainActor
+    private func afterStateChange(
+        _ session: ImageUploadSession,
+        context: AccountContext,
+        token: String,
+        forceFlush: Bool = false
+    ) async {
+        guard !session.aborted else { return }
+
+        let completedCount = session.items.filter { !$0.state.isUploading }.count
+        let allResolved = completedCount == session.items.count
+        let ready = readyAttachments(session)
+
+        if !session.hasSent {
+            let canSend = !ready.isEmpty || (allResolved && session.params.hasText)
+            if !canSend {
+                if allResolved { finalizeAllFailed(session, context: context) }
+                return
+            }
+            session.lastFlushCompletedCount = completedCount
+            await doFirstSend(session, context: context, token: token, attachments: ready)
+        } else if session.serverMessageId != 0 {
+            let newlyCompleted = completedCount - session.lastFlushCompletedCount
+            let shouldUpdate = forceFlush || newlyCompleted >= Self.editBatchSize || (allResolved && newlyCompleted > 0)
+            guard shouldUpdate else { return }
+            session.lastFlushCompletedCount = completedCount
+            await doUpdate(session, context: context, token: token, attachments: ready)
+        }
+
+        if allResolved { finalizeSuccessIfNeeded(session, context: context, ready: ready) }
+    }
+
+    @MainActor
+    private func doFirstSend(
+        _ session: ImageUploadSession,
+        context: AccountContext,
+        token: String,
+        attachments: [Mezon_Api_MessageAttachment]
+    ) async {
+        let p = session.params
+        do {
+            let ack = try await context.account.network.sendChannelMessage(
+                clanId: p.clanId,
+                channelId: p.channelId,
+                mode: p.mode,
+                isPublic: p.isPublic,
+                content: p.contentStr,
+                mentions: p.mentionList,
+                attachments: attachments,
+                references: p.references,
+                anonymous: false,
+                mentionEveryone: false,
+                avatar: p.avatar,
+                topicId: p.topicId,
+                token: token
+            )
+            session.hasSent = true
+            session.serverMessageId = ack.messageID
+            if ack.messageID != 0 {
+                register(session, key: "\(ack.messageID)")
+            }
+            context.account.postbox.write { tx in
+                if tx.getMessageById(p.localId) != nil {
+                    tx.markMessageSent(id: p.localId)
+                }
+            }
+            nudge(session, context: context)
+        } catch {
+            session.aborted = true
+            SentryLogger.capture(error, extras: [
+                "where": "AttachmentUploadCoordinator.doFirstSend",
+                "channelId": p.channelId,
+                "clanId": p.clanId,
+            ])
+            context.account.postbox.write { tx in tx.markMessageFailed(id: p.localId) }
+        }
+    }
+
+    @MainActor
+    private func doUpdate(
+        _ session: ImageUploadSession,
+        context: AccountContext,
+        token: String,
+        attachments: [Mezon_Api_MessageAttachment]
+    ) async {
+        let p = session.params
+        do {
+            _ = try await context.account.network.updateChannelMessage(
+                clanId: p.clanId,
+                channelId: p.channelId,
+                mode: p.mode,
+                isPublic: p.isPublic,
+                messageId: session.serverMessageId,
+                content: p.contentStr,
+                mentions: p.mentionList,
+                attachments: attachments,
+                hideEditted: true,
+                topicId: p.topicId,
+                isUpdateMsgTopic: false,
+                token: token
+            )
+        } catch {
+            SentryLogger.capture(error, extras: [
+                "where": "AttachmentUploadCoordinator.doUpdate",
+                "channelId": p.channelId,
+                "messageId": session.serverMessageId,
+            ])
+        }
+    }
+
+    @MainActor
+    private func finalizeSuccessIfNeeded(
+        _ session: ImageUploadSession,
+        context: AccountContext,
+        ready: [Mezon_Api_MessageAttachment]
+    ) {
+        let anyFailed = session.items.contains { $0.state.isFailed }
+        if !anyFailed, session.hasSent, session.serverMessageId != 0 {
+            writeFinalAttachments(session, context: context, attachments: ready)
+            clearDocumentPlaceholders(session)
+            remove(session)
+        } else {
+            session.finished = true
+            nudge(session, context: context)
+        }
+    }
+
+    @MainActor
+    private func finalizeAllFailed(_ session: ImageUploadSession, context: AccountContext) {
+        session.finished = true
+        let id = session.serverMessageId != 0 ? "\(session.serverMessageId)" : session.params.localId
+        context.account.postbox.write { tx in tx.markMessageFailed(id: id) }
+        nudge(session, context: context)
+    }
+
+    @MainActor
+    private func writeFinalAttachments(
+        _ session: ImageUploadSession,
+        context: AccountContext,
+        attachments: [Mezon_Api_MessageAttachment]
+    ) {
+        let serverKey = "\(session.serverMessageId)"
+        let localId = session.params.localId
+        context.account.postbox.write { tx in
+            guard let old = tx.getMessageById(serverKey) ?? tx.getMessageById(localId) else { return }
+            let newAttachmentsJSON: Data = {
+                guard !attachments.isEmpty else { return old.attachmentsJSON }
+                var list = Mezon_Api_MessageAttachmentList()
+                list.attachments = attachments
+                return (try? list.serializedData()) ?? old.attachmentsJSON
+            }()
+            let updated = MessageRecord(
+                id: old.id,
+                channelId: old.channelId,
+                clanId: old.clanId,
+                senderId: old.senderId,
+                content: old.content,
+                createdAt: old.createdAt,
+                editedAt: old.editedAt,
+                isDeleted: old.isDeleted,
+                code: old.code,
+                senderDisplayName: old.senderDisplayName,
+                senderAvatarURL: old.senderAvatarURL,
+                sendingState: .sent,
+                attachmentsJSON: newAttachmentsJSON,
+                reactionsJSON: old.reactionsJSON,
+                referencesData: old.referencesData,
+                mentionsJSON: old.mentionsJSON
+            )
+            tx.addMessages([updated])
+        }
+    }
+
+    // MARK: - Upload primitives
+
+    private func readyAttachments(_ session: ImageUploadSession) -> [Mezon_Api_MessageAttachment] {
+        var result = session.items.compactMap { $0.state.uploadedAttachment }
+        result.append(contentsOf: session.fileAttachments)
+        return result
+    }
+
+    @MainActor
+    private func uploadFiles(_ session: ImageUploadSession, context: AccountContext, token: String) async {
+        for file in session.params.files {
+            guard let fileData = try? Data(contentsOf: file.url) else { continue }
+            let sanitized = file.filename.replacingOccurrences(
+                of: "[^a-zA-Z0-9._-]", with: "_", options: .regularExpression)
+            do {
+                let uploadInfo = try await context.account.network.uploadAttachmentFile(
+                    filename: sanitized, filetype: file.filetype, size: fileData.count,
+                    width: 0, height: 0, token: token)
+                try await context.account.network.uploadToMinIO(
+                    url: uploadInfo.url, data: fileData, contentType: file.filetype)
+                let cdnURL = "\(MezonConfig.baseImgURL)/\(uploadInfo.filename)"
+                var att = Mezon_Api_MessageAttachment()
+                att.filename = file.filename
+                att.url = cdnURL
+                att.filetype = file.filetype
+                att.size = Int32(fileData.count)
+                session.fileAttachments.append(att)
+                try? FileManager.default.removeItem(at: file.url)
+            } catch {
+                SentryLogger.capture(error, extras: [
+                    "where": "AttachmentUploadCoordinator.uploadFiles",
+                    "filename": file.filename,
+                ])
+            }
+        }
+    }
+
+    @MainActor
+    private func uploadOneImage(
+        _ item: ImageUploadItem,
+        context: AccountContext,
+        token: String
+    ) async -> Mezon_Api_MessageAttachment? {
+        guard let fileURL = item.fileURL, let fileData = try? Data(contentsOf: fileURL) else { return nil }
+
+        let originalFilename = fileURL.lastPathComponent
+        let ext = fileURL.pathExtension.lowercased()
+        let filetype = SendMessageInputViewController.mimeType(for: ext)
+        let width = Int(item.image.size.width)
+        let height = Int(item.image.size.height)
+        let sanitized = originalFilename.replacingOccurrences(
+            of: "[^a-zA-Z0-9._-]", with: "_", options: .regularExpression)
+
+        do {
+            let uploadInfo = try await context.account.network.uploadAttachmentFile(
+                filename: sanitized, filetype: filetype, size: fileData.count,
+                width: width, height: height, token: token)
+            try await context.account.network.uploadToMinIO(
+                url: uploadInfo.url, data: fileData, contentType: filetype)
+            let cdnURL = "\(MezonConfig.baseImgURL)/\(uploadInfo.filename)"
+            if !filetype.hasPrefix("video/") {
+                ImageCache.shared.setImage(item.image, data: fileData, forKey: cdnURL)
+            }
+            var att = Mezon_Api_MessageAttachment()
+            att.filename = originalFilename
+            att.url = cdnURL
+            att.filetype = filetype
+            att.size = Int32(fileData.count)
+            att.width = Int32(width)
+            att.height = Int32(height)
+            try? FileManager.default.removeItem(at: fileURL)
+            return att
+        } catch {
+            SentryLogger.capture(error, extras: [
+                "where": "AttachmentUploadCoordinator.uploadOneImage",
+                "filename": originalFilename,
+            ])
+            return nil
+        }
+    }
+
+    // MARK: - Helpers
+
+    @MainActor
+    private func nudge(_ session: ImageUploadSession, context: AccountContext) {
+        let serverKey = "\(session.serverMessageId)"
+        let localId = session.params.localId
+        context.account.postbox.write { tx in
+            if session.serverMessageId != 0, let r = tx.getMessageById(serverKey) {
+                tx.addMessages([r])
+            } else if let r = tx.getMessageById(localId) {
+                tx.addMessages([r])
+            }
+        }
+    }
+
+    @MainActor
+    private func clearDocumentPlaceholders(_ session: ImageUploadSession) {
+        guard !session.params.files.isEmpty else { return }
+        ParsedAttachment.pendingDocumentPlaceholders.removeValue(forKey: session.params.localId)
+        if session.serverMessageId != 0 {
+            ParsedAttachment.pendingDocumentPlaceholders.removeValue(forKey: "\(session.serverMessageId)")
+        }
+    }
+}

--- a/MezonChat/Features/SendMessageInput/MediaPickerViewController.swift
+++ b/MezonChat/Features/SendMessageInput/MediaPickerViewController.swift
@@ -11,6 +11,9 @@ struct MediaPickerResult {
 final class MediaPickerViewController: UIViewController {
 
     var onPicked: (([MediaPickerResult]) -> Void)?
+    var selectionLimit: Int = .max
+
+    private static let maxUploadImageDimension: CGFloat = 2048
 
     private let cachingImageManager = PHCachingImageManager()
     private var fetchResult: PHFetchResult<PHAsset>?
@@ -688,12 +691,22 @@ final class MediaPickerViewController: UIViewController {
                 selectedOrder[a.localIdentifier] = i + 1
             }
         } else {
+            guard selectedAssets.count < selectionLimit else {
+                Toast.info("You can select up to \(selectionLimit) item\(selectionLimit == 1 ? "" : "s").")
+                return
+            }
             selectedAssets.append(asset)
             selectedOrder[id] = selectedAssets.count
         }
         updateSendButton()
-        UIView.performWithoutAnimation {
-            collectionView.reloadItems(at: collectionView.indexPathsForVisibleItems)
+        refreshVisibleSelectionBadges()
+    }
+
+    private func refreshVisibleSelectionBadges() {
+        for case let cell as MediaPickerCell in collectionView.visibleCells {
+            let id = cell.assetIdentifier
+            guard !id.isEmpty else { continue }
+            cell.updateSelectionOrder(selectedOrder[id])
         }
     }
 
@@ -714,42 +727,42 @@ final class MediaPickerViewController: UIViewController {
     private func confirmSelection(shouldDismiss: Bool = true) {
         guard !selectedAssets.isEmpty else { return }
         didSendResults = true
+        sendButton.isEnabled = false
 
-        let group = DispatchGroup()
-        var results = [(Int, MediaPickerResult)]()
-        let lock = NSLock()
+        let assets = selectedAssets
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self else { return }
+            let group = DispatchGroup()
+            let semaphore = DispatchSemaphore(value: 3)
+            var results = [(Int, MediaPickerResult)]()
+            let lock = NSLock()
 
-        for (order, asset) in selectedAssets.enumerated() {
-            group.enter()
-            let isVideo = asset.mediaType == .video
-
-            if isVideo {
-                exportVideo(asset: asset) { result in
+            for (order, asset) in assets.enumerated() {
+                semaphore.wait()
+                group.enter()
+                let isVideo = asset.mediaType == .video
+                let done: (MediaPickerResult?) -> Void = { result in
                     if let r = result {
                         lock.lock()
                         results.append((order, r))
                         lock.unlock()
                     }
+                    semaphore.signal()
                     group.leave()
                 }
-            } else {
-                exportImage(asset: asset) { result in
-                    if let r = result {
-                        lock.lock()
-                        results.append((order, r))
-                        lock.unlock()
-                    }
-                    group.leave()
+                if isVideo {
+                    self.exportVideo(asset: asset, completion: done)
+                } else {
+                    self.exportImage(asset: asset, completion: done)
                 }
             }
-        }
 
-        group.notify(queue: .main) { [weak self] in
-            guard let self else { return }
-            let sorted = results.sorted { $0.0 < $1.0 }.map(\.1)
-            self.onPicked?(sorted)
-            if shouldDismiss {
-                self.dismiss(animated: true)
+            group.notify(queue: .main) {
+                let sorted = results.sorted { $0.0 < $1.0 }.map(\.1)
+                self.onPicked?(sorted)
+                if shouldDismiss {
+                    self.dismiss(animated: true)
+                }
             }
         }
     }
@@ -761,23 +774,42 @@ final class MediaPickerViewController: UIViewController {
         options.isNetworkAccessAllowed = true
         options.isSynchronous = false
 
+        let pixelW = CGFloat(asset.pixelWidth)
+        let pixelH = CGFloat(asset.pixelHeight)
+        let maxDim = Self.maxUploadImageDimension
+        let targetSize: CGSize
+        if pixelW > 0, pixelH > 0, max(pixelW, pixelH) > maxDim {
+            let scale = maxDim / max(pixelW, pixelH)
+            targetSize = CGSize(width: max(1, pixelW * scale), height: max(1, pixelH * scale))
+        } else if pixelW > 0, pixelH > 0 {
+            targetSize = CGSize(width: pixelW, height: pixelH)
+        } else {
+            targetSize = CGSize(width: maxDim, height: maxDim)
+        }
+
+        var didComplete = false
         cachingImageManager.requestImage(
             for: asset,
-            targetSize: PHImageManagerMaximumSize,
-            contentMode: .default,
+            targetSize: targetSize,
+            contentMode: .aspectFit,
             options: options
         ) { image, info in
             let isDegraded = (info?[PHImageResultIsDegradedKey] as? Bool) ?? false
-            guard !isDegraded, let image else { return }
+            if isDegraded { return }
+            guard !didComplete else { return }
+            didComplete = true
+            guard let image else { completion(nil); return }
 
-            let tempDir = FileManager.default.temporaryDirectory
-            let filename = "picked-\(UUID().uuidString).jpg"
-            let fileURL = tempDir.appendingPathComponent(filename)
-            if let data = image.jpegData(compressionQuality: 0.9) {
-                try? data.write(to: fileURL)
-                completion(MediaPickerResult(image: image, fileURL: fileURL, isVideo: false))
-            } else {
-                completion(MediaPickerResult(image: image, fileURL: nil, isVideo: false))
+            DispatchQueue.global(qos: .userInitiated).async {
+                let tempDir = FileManager.default.temporaryDirectory
+                let filename = "picked-\(UUID().uuidString).jpg"
+                let fileURL = tempDir.appendingPathComponent(filename)
+                if let data = image.jpegData(compressionQuality: 0.9) {
+                    try? data.write(to: fileURL)
+                    completion(MediaPickerResult(image: image, fileURL: fileURL, isVideo: false))
+                } else {
+                    completion(MediaPickerResult(image: image, fileURL: nil, isVideo: false))
+                }
             }
         }
     }
@@ -1074,6 +1106,10 @@ private final class MediaPickerCell: UICollectionViewCell {
             gradientLayer.isHidden = true
         }
 
+        updateSelectionOrder(selectionOrder)
+    }
+
+    func updateSelectionOrder(_ selectionOrder: Int?) {
         if let order = selectionOrder {
             selectionBadge.isHidden = false
             selectionBadge.text = "\(order)"
@@ -1089,9 +1125,10 @@ private final class MediaPickerCell: UICollectionViewCell {
 
 extension MediaPickerViewController {
 
-    static func present(from viewController: UIViewController, onPicked: @escaping ([MediaPickerResult]) -> Void) {
+    static func present(from viewController: UIViewController, selectionLimit: Int = .max, onPicked: @escaping ([MediaPickerResult]) -> Void) {
         let picker = MediaPickerViewController()
         picker.onPicked = onPicked
+        picker.selectionLimit = selectionLimit
         picker.modalPresentationStyle = .pageSheet
 
         if #available(iOS 15.0, *) {

--- a/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
+++ b/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
@@ -503,6 +503,21 @@ final class SendMessageInputViewController: UIViewController {
     private var editingRemoteImageAttachments: [ParsedAttachment] = []
     private var editingRemoteFileAttachments: [ParsedAttachment] = []
 
+    static let maxAttachmentsPerMessage = 20
+
+    private var currentAttachmentCount: Int {
+        pickedImages.count + pickedFiles.count
+            + editingRemoteImageAttachments.count + editingRemoteFileAttachments.count
+    }
+
+    private var remainingAttachmentSlots: Int {
+        max(0, Self.maxAttachmentsPerMessage - currentAttachmentCount)
+    }
+
+    private func notifyAttachmentLimitReached() {
+        Toast.info("You can attach up to \(Self.maxAttachmentsPerMessage) items per message.")
+    }
+
     private var allMentionMembers: [MentionMember] = []
     private var allMentionSuggestionItems: [MentionSuggestionItem] = []
     private var activeMentions: [ComposerMention] = []
@@ -1968,9 +1983,14 @@ final class SendMessageInputViewController: UIViewController {
 
     private func openPhotoPicker() {
         guard !isEditingShareContactMessage else { return }
-        MediaPickerViewController.present(from: self) { [weak self] results in
+        let remaining = remainingAttachmentSlots
+        guard remaining > 0 else {
+            notifyAttachmentLimitReached()
+            return
+        }
+        MediaPickerViewController.present(from: self, selectionLimit: remaining) { [weak self] results in
             guard let self else { return }
-            for result in results {
+            for result in results.prefix(self.remainingAttachmentSlots) {
                 let index = self.pickedImages.count
                 self.pickedImages.append(result.image)
                 if result.isVideo {
@@ -2201,6 +2221,10 @@ final class SendMessageInputViewController: UIViewController {
 
     private func addPickedImage(_ image: UIImage) {
         guard !isEditingShareContactMessage else { return }
+        guard remainingAttachmentSlots > 0 else {
+            notifyAttachmentLimitReached()
+            return
+        }
         pickedImages.append(image)
         attachmentPreviewView.addImage(image)
         saveToCache()
@@ -2212,7 +2236,9 @@ final class SendMessageInputViewController: UIViewController {
     private func handlePastedImages(_ pasted: [PastedImage]) {
         guard !isEditingShareContactMessage else { return }
         let tempDir = FileManager.default.temporaryDirectory
+        var didHitLimit = false
         for item in pasted {
+            guard remainingAttachmentSlots > 0 else { didHitLimit = true; break }
             let resolvedData: Data
             let resolvedExt: String
             if let originalData = item.data,
@@ -2238,12 +2264,17 @@ final class SendMessageInputViewController: UIViewController {
             attachmentPreviewView.addImage(item.image)
             pickedFileURLs[index] = fileURL
         }
+        if didHitLimit { notifyAttachmentLimitReached() }
         saveToCache()
         updatePreviewVisibility()
     }
 
     private func handlePastedGIF(_ data: Data) {
         guard !isEditingShareContactMessage else { return }
+        guard remainingAttachmentSlots > 0 else {
+            notifyAttachmentLimitReached()
+            return
+        }
         let tempDir = FileManager.default.temporaryDirectory
         let filename = "pasted-\(UUID().uuidString).gif"
         let fileURL = tempDir.appendingPathComponent(filename)
@@ -4866,7 +4897,8 @@ final class SendMessageInputViewController: UIViewController {
         let imagesToUpload = images
         let fileURLsToUpload = pickedFileURLs
         let filesToUpload = pickedFiles
-        if !skipOptimisticPendingMessageOnSend, !isEdit, !imagesToUpload.isEmpty, !sendAsAnonymous {
+        let useIncrementalImagePath = !isEdit && !sendAsAnonymous && !imagesToUpload.isEmpty && !skipOptimisticPendingMessageOnSend
+        if !skipOptimisticPendingMessageOnSend, !isEdit, !imagesToUpload.isEmpty, !sendAsAnonymous, !useIncrementalImagePath {
             ParsedAttachment.pendingImageCache[localId] = imagesToUpload
         }
         if !skipOptimisticPendingMessageOnSend, !isEdit, !filesToUpload.isEmpty, !sendAsAnonymous {
@@ -5028,7 +5060,7 @@ final class SendMessageInputViewController: UIViewController {
         }
         let pendingCreatedAt = Date()
 
-        if !skipOptimisticPendingMessageOnSend, !isEdit, !sendAsAnonymous, let sender = context.currentUser {
+        if !skipOptimisticPendingMessageOnSend, !isEdit, !sendAsAnonymous, !useIncrementalImagePath, let sender = context.currentUser {
             let pendingRecord = MessageRecord.pending(
                 localId: localId,
                 text: displayText,
@@ -5075,6 +5107,40 @@ final class SendMessageInputViewController: UIViewController {
         let isPublic = channel.channelPrivate == 0
         let avatar: String = context.currentUser?.avatarURL?.absoluteString ?? ""
         let references: [Mezon_Api_MessageRef] = replyRef.map { [$0] } ?? []
+
+        if useIncrementalImagePath {
+            let imageSendParams = ImageSendParams(
+                localId: localId,
+                channelIdStr: channelIdStr,
+                clanId: clanId,
+                channelId: channel.channelID,
+                mode: mode,
+                isPublic: isPublic,
+                topicId: self.topicId,
+                hasText: !text.isEmpty,
+                contentStr: contentStr,
+                outgoingContentData: outgoingContentData,
+                mentionList: mentionList,
+                mentionsPayload: mentionsPayload,
+                references: references,
+                pendingReferencesData: pendingReferencesData,
+                avatar: avatar,
+                pendingSenderDisplayName: pendingSenderDisplayName,
+                pendingSenderAvatarURL: pendingSenderAvatarURL,
+                images: imagesToUpload,
+                fileURLs: fileURLsToUpload,
+                files: filesToUpload
+            )
+            AttachmentUploadCoordinator.shared.startImageSend(
+                context: context,
+                params: imageSendParams,
+                prepare: { [weak self] token in
+                    try? await self?.addUsersFromParentMentionsToThreadIfNeeded(
+                        mentionList: mentionList, editTargetSenderId: nil, token: token)
+                }
+            )
+            return
+        }
 
         Task { @MainActor in
             guard let token = await self.context.getToken() else {
@@ -5844,7 +5910,9 @@ private final class OverflowHitTestView: UIView {
 extension SendMessageInputViewController: UIDocumentPickerDelegate {
 
     func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+        var didHitLimit = false
         for url in urls {
+            guard remainingAttachmentSlots > 0 else { didHitLimit = true; break }
             let filename = url.lastPathComponent
             let ext = url.pathExtension.lowercased()
             let filetype = Self.mimeType(for: ext)
@@ -5854,6 +5922,7 @@ extension SendMessageInputViewController: UIDocumentPickerDelegate {
             pickedFiles.append(fileInfo)
             attachmentPreviewView.addFile(fileInfo)
         }
+        if didHitLimit { notifyAttachmentLimitReached() }
         updatePreviewVisibility()
     }
 

--- a/MezonChat/Features/VoiceChannel/VoiceCallReactionFlightView.swift
+++ b/MezonChat/Features/VoiceChannel/VoiceCallReactionFlightView.swift
@@ -298,10 +298,7 @@ private final class OneShotAudioPlayback: NSObject, AVAudioPlayerDelegate {
     func play(url: URL, completion: @escaping (Bool) -> Void) {
         isCancelled = false
         finish = completion
-        do {
-            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [.mixWithOthers])
-            try AVAudioSession.sharedInstance().setActive(true)
-        } catch {}
+        configureSessionForPlaybackIfSafe()
 
         let task = URLSession.shared.dataTask(with: url) { [weak self] data, _, error in
             guard let self else { return }
@@ -339,6 +336,17 @@ private final class OneShotAudioPlayback: NSObject, AVAudioPlayerDelegate {
         player?.delegate = nil
         player = nil
         finish = nil
+    }
+
+    private func configureSessionForPlaybackIfSafe() {
+        let session = AVAudioSession.sharedInstance()
+        if session.category == .playAndRecord {
+            return
+        }
+        do {
+            try session.setCategory(.playback, mode: .default, options: [.mixWithOthers])
+            try session.setActive(true)
+        } catch {}
     }
 
     private func complete(_ flag: Bool) {


### PR DESCRIPTION
# Optimize: Incremental Multi-Image Upload

> Commit: `optimize: break upload images mutiple`

## Overview

Reworks the multi-image send flow from a single-shot upload into an **incremental upload pipeline** (`AttachmentUploadCoordinator`). Images now appear in the conversation as soon as the first one is ready, upload in parallel, support per-image retry, and are capped at a sane attachment limit.

---

## 1. Root Cause

The previous single-shot send flow had several issues:

| # | Problem | Impact |
|---|---------|--------|
| 1 | Message was sent only **after ALL images finished uploading** (single `sendChannelMessage` call) | Long wait before the message appears for both sender and receiver, especially with many or heavy images |
| 2 | Images uploaded **sequentially** | Total upload time grows linearly with the number of images |
| 3 | **No limit** on the number of attachments | Oversized requests, higher failure risk |
| 4 | **No per-image retry** | A single failed image breaks the whole message; user must resend everything |

---

## 2. Solution

Extracted upload logic into a dedicated `AttachmentUploadCoordinator` implementing an incremental pipeline.

### Incremental send
- As soon as the **first image** finishes uploading, `sendChannelMessage` is called (first send).
- Remaining images keep uploading and are merged into the same message via `updateChannelMessage`.

### Parallel uploads with backpressure
- `maxConcurrentUploads = 4` via `withTaskGroup` to speed up overall upload time.

### Batched updates
- Completed images are flushed in batches (`editBatchSize = 4`, or when all items resolve) to reduce the number of `updateChannelMessage` calls.

### Per-image state & retry
- Each image tracks `uploading / uploaded / failed`.
- `MessageMediaContentNode` renders the matching overlay, including a failure overlay (`arrow.clockwise.circle.fill`).
- Per-image retry via `retry(messageId:itemIndex:)`.

### Attachment limit
- `maxAttachmentsPerMessage = 20`, enforced across the photo picker, image/GIF paste, and `addPickedImage`.
- `MediaPickerViewController` accepts a `selectionLimit` and shows a Toast when exceeded.

### Optimistic message handling
- Optimistic pending message is created in the coordinator (`MessageRecord.pending`) and marked sent/failed based on the result.
- Failures are reported through `SentryLogger`.

---

## 3. Self Test

- [ ] Send a single image → appears immediately, uploads and is marked sent.
- [ ] Send multiple images (5–10) → message appears early with the first image; remaining images merge into the same message progressively.
- [ ] Send text + multiple images → text and all images render correctly after all resolve.
- [ ] Send files + images → both files and images upload correctly.
- [ ] Drop network mid-upload → failed images show the error overlay; tapping retry re-uploads and merges into the message.
- [ ] Select more than 20 items in picker / paste → limit Toast appears, never exceeds 20.
- [ ] Reply + mention with images → references and mentions are preserved.
- [ ] Receiver sees the message update in correct image order, without duplicated messages.
