### PR TITLE
update: show grid layout media & thumb upload video 

### DIFF
--- a/MezonChat/Core/Postbox/Messages/MessageRecord.swift
+++ b/MezonChat/Core/Postbox/Messages/MessageRecord.swift
@@ -16,7 +16,7 @@ struct MessageRecord: PostboxCoding, Equatable {
     let senderId: String
     let content: Data
     let createdAt: Date
-    let editedAt: Date?
+    var editedAt: Date?
     let isDeleted: Bool
     let code: Int32
 
@@ -124,9 +124,15 @@ extension MessageRecord {
     }
 
     static func fromApi(_ api: Mezon_Api_ChannelMessage, merging previous: MessageRecord?, customId: String? = nil) -> MessageRecord {
-        let fresh = MessageRecord(from: api, customId: customId)
+        var fresh = MessageRecord(from: api, customId: customId)
         guard let prev = previous, prev.id == fresh.id else { return fresh }
         if prev.senderId != fresh.senderId { return fresh }
+        let bodyTextUnchanged = prev.content == fresh.content
+            && prev.mentionsJSON == fresh.mentionsJSON
+            && prev.referencesData == fresh.referencesData
+        if bodyTextUnchanged {
+            fresh.editedAt = prev.editedAt
+        }
         let sameBodyForMerge = prev.content == fresh.content
             && prev.attachmentsJSON == fresh.attachmentsJSON
             && prev.referencesData == fresh.referencesData

--- a/MezonChat/Features/Chat/Cells/MediaMosaicLayout.swift
+++ b/MezonChat/Features/Chat/Cells/MediaMosaicLayout.swift
@@ -1,0 +1,354 @@
+import Foundation
+import UIKit
+
+struct MediaMosaicItemPosition: OptionSet {
+    var rawValue: Int32
+
+    init(rawValue: Int32) {
+        self.rawValue = rawValue
+    }
+
+    static let top = MediaMosaicItemPosition(rawValue: 1)
+    static let bottom = MediaMosaicItemPosition(rawValue: 2)
+    static let left = MediaMosaicItemPosition(rawValue: 4)
+    static let right = MediaMosaicItemPosition(rawValue: 8)
+    static let inside = MediaMosaicItemPosition(rawValue: 16)
+    static let unknown = MediaMosaicItemPosition(rawValue: 65536)
+
+    var isWide: Bool {
+        return self.contains(.left) && self.contains(.right) && (self.contains(.top) || self.contains(.bottom))
+    }
+}
+
+private struct MediaMosaicItemInfo {
+    let index: Int
+    let imageSize: CGSize
+    let aspectRatio: CGFloat
+
+    var layoutFrame: CGRect = CGRect()
+    var position: MediaMosaicItemPosition = []
+}
+
+private struct MediaMosaicLayoutAttempt {
+    let lineCounts: [Int]
+    let heights: [CGFloat]
+}
+
+func mediaMosaicLayout(maxSize: CGSize, itemSizes: [CGSize], spacing: CGFloat = 2.0, fillWidth: Bool = false) -> ([(CGRect, MediaMosaicItemPosition)], CGSize) {
+    var proportions = ""
+    var averageAspectRatio: CGFloat = 1.0
+    var forceCalc = false
+
+    var itemInfos = itemSizes.enumerated().map { index, itemSize -> MediaMosaicItemInfo in
+        let aspectRatio = itemSize.height.isZero ? 1.0 : itemSize.width / itemSize.height
+        if aspectRatio > 1.2 {
+            proportions += "w"
+        } else if aspectRatio < 0.8 {
+            proportions += "n"
+        } else {
+            proportions += "q"
+        }
+
+        if aspectRatio > 2.0 {
+            forceCalc = true
+        }
+        averageAspectRatio += aspectRatio
+
+        return MediaMosaicItemInfo(index: index, imageSize: itemSize, aspectRatio: aspectRatio, layoutFrame: CGRect(), position: [])
+    }
+
+    let minWidth: CGFloat = 68.0
+    let minHeight: CGFloat = 81.0
+    let maxAspectRatio = maxSize.width / maxSize.height
+    if !itemInfos.isEmpty {
+        averageAspectRatio = averageAspectRatio / CGFloat(itemInfos.count)
+    }
+
+    if !forceCalc {
+        if itemInfos.count == 2 {
+            if proportions == "ww" && averageAspectRatio > 1.4 * maxAspectRatio && itemInfos[1].aspectRatio - itemInfos[0].aspectRatio < 0.2 {
+                let width = maxSize.width
+                let height = floor(min(width / itemInfos[0].aspectRatio, min(width / itemInfos[1].aspectRatio, (maxSize.height - spacing) / 2.0)))
+
+                itemInfos[0].layoutFrame = CGRect(x: 0.0, y: 0.0, width: width, height: height)
+                itemInfos[0].position = [.top, .left, .right]
+
+                itemInfos[1].layoutFrame = CGRect(x: 0.0, y: height + spacing, width: width, height: height)
+                itemInfos[1].position = [.bottom, .left, .right]
+            } else if proportions == "ww" || proportions == "qq" {
+                let width = (maxSize.width - spacing) / 2.0
+                let height = floor(min(width / itemInfos[0].aspectRatio, min(width / itemInfos[1].aspectRatio, maxSize.height)))
+
+                itemInfos[0].layoutFrame = CGRect(x: 0.0, y: 0.0, width: width, height: height)
+                itemInfos[0].position = [.top, .left, .bottom]
+
+                itemInfos[1].layoutFrame = CGRect(x: width + spacing, y: 0.0, width: width, height: height)
+                itemInfos[1].position = [.top, .right, .bottom]
+            } else {
+                let secondWidth = floor(min(0.5 * (maxSize.width - spacing), round((maxSize.width - spacing) / itemInfos[0].aspectRatio / (1.0 / itemInfos[0].aspectRatio + 1.0 / itemInfos[1].aspectRatio))))
+                let firstWidth = maxSize.width - secondWidth - spacing
+                let height = floor(min(maxSize.height, round(min(firstWidth / itemInfos[0].aspectRatio, secondWidth / itemInfos[1].aspectRatio))))
+
+                itemInfos[0].layoutFrame = CGRect(x: 0.0, y: 0.0, width: firstWidth, height: height)
+                itemInfos[0].position = [.top, .left, .bottom]
+
+                itemInfos[1].layoutFrame = CGRect(x: firstWidth + spacing, y: 0.0, width: secondWidth, height: height)
+                itemInfos[1].position = [.top, .right, .bottom]
+            }
+        } else if itemInfos.count == 3 {
+            if proportions.hasPrefix("n") {
+                let firstHeight = maxSize.height
+
+                let thirdHeight = min((maxSize.height - spacing) * 0.5, round(itemInfos[1].aspectRatio * (maxSize.width - spacing) / (itemInfos[2].aspectRatio + itemInfos[1].aspectRatio)))
+                let secondHeight = maxSize.height - thirdHeight - spacing
+                var rightWidth = max(minWidth, min((maxSize.width - spacing) * 0.5, round(min(thirdHeight * itemInfos[2].aspectRatio, secondHeight * itemInfos[1].aspectRatio))))
+                if fillWidth {
+                    rightWidth = floorToScreenPixels(maxSize.width / 2.0)
+                }
+                var leftWidth = round(min(firstHeight * itemInfos[0].aspectRatio, (maxSize.width - spacing - rightWidth)))
+                if fillWidth {
+                    leftWidth = maxSize.width - spacing - rightWidth
+                }
+                itemInfos[0].layoutFrame = CGRect(x: 0.0, y: 0.0, width: leftWidth, height: firstHeight)
+                itemInfos[0].position = [.top, .left, .bottom]
+
+                itemInfos[1].layoutFrame = CGRect(x: leftWidth + spacing, y: 0.0, width: rightWidth, height: secondHeight)
+                itemInfos[1].position = [.right, .top]
+
+                itemInfos[2].layoutFrame = CGRect(x: leftWidth + spacing, y: secondHeight + spacing, width: rightWidth, height: thirdHeight)
+                itemInfos[2].position = [.right, .bottom]
+            } else {
+                var width = maxSize.width
+                let firstHeight = floor(min(width / itemInfos[0].aspectRatio, (maxSize.height - spacing) * 0.66))
+                itemInfos[0].layoutFrame = CGRect(x: 0.0, y: 0.0, width: width, height: firstHeight)
+                itemInfos[0].position = [.top, .left, .right]
+
+                width = (maxSize.width - spacing) / 2.0
+                let secondHeight = min(maxSize.height - firstHeight - spacing, round(min(width / itemInfos[1].aspectRatio, width / itemInfos[2].aspectRatio)))
+                itemInfos[1].layoutFrame = CGRect(x: 0.0, y: firstHeight + spacing, width: width, height: secondHeight)
+                itemInfos[1].position = [.left, .bottom]
+
+                itemInfos[2].layoutFrame = CGRect(x: width + spacing, y: firstHeight + spacing, width: width, height: secondHeight)
+                itemInfos[2].position = [.right, .bottom]
+            }
+        } else if itemInfos.count == 4 {
+            if proportions == "wwww" || proportions.hasPrefix("w") {
+                let w = maxSize.width
+                let h0 = round(min(w / itemInfos[0].aspectRatio, (maxSize.height - spacing) * 0.66))
+                itemInfos[0].layoutFrame = CGRect(x: 0.0, y: 0.0, width: w, height: h0)
+                itemInfos[0].position = [.top, .left, .right]
+
+                var h = round((maxSize.width - 2 * spacing) / (itemInfos[1].aspectRatio + itemInfos[2].aspectRatio + itemInfos[3].aspectRatio))
+                let w0 = max(minWidth, min((maxSize.width - 2 * spacing) * 0.4, h * itemInfos[1].aspectRatio))
+                let w2 = max(max(minWidth, (maxSize.width - 2 * spacing) * 0.33), h * itemInfos[3].aspectRatio)
+                let w1 = w - w0 - w2 - 2 * spacing
+                h = max(minHeight, min(maxSize.height - h0 - spacing, h))
+                itemInfos[1].layoutFrame = CGRect(x: 0.0, y: h0 + spacing, width: w0, height: h)
+                itemInfos[1].position = [.left, .bottom]
+
+                itemInfos[2].layoutFrame = CGRect(x: w0 + spacing, y: h0 + spacing, width: w1, height: h)
+                itemInfos[2].position = [.bottom]
+
+                itemInfos[3].layoutFrame = CGRect(x: w0 + w1 + 2 * spacing, y: h0 + spacing, width: w2, height: h)
+                itemInfos[3].position = [.right, .bottom]
+            } else {
+                let h = maxSize.height
+                let w0 = round(min(h * itemInfos[0].aspectRatio, (maxSize.width - spacing) * 0.6))
+                itemInfos[0].layoutFrame = CGRect(x: 0.0, y: 0.0, width: w0, height: h)
+                itemInfos[0].position = [.top, .left, .bottom]
+
+                var w = round((maxSize.height - 2 * spacing) / (1.0 / itemInfos[1].aspectRatio + 1.0 / itemInfos[2].aspectRatio + 1.0 / itemInfos[3].aspectRatio))
+                let h0 = floor(w / itemInfos[1].aspectRatio)
+                let h1 = floor(w / itemInfos[2].aspectRatio)
+                let h2 = h - h0 - h1 - 2.0 * spacing
+                w = max(minWidth, min(maxSize.width - w0 - spacing, w))
+                itemInfos[1].layoutFrame = CGRect(x: w0 + spacing, y: 0.0, width: w, height: h0)
+                itemInfos[1].position = [.right, .top]
+
+                itemInfos[2].layoutFrame = CGRect(x: w0 + spacing, y: h0 + spacing, width: w, height: h1)
+                itemInfos[2].position = [.right]
+
+                itemInfos[3].layoutFrame = CGRect(x: w0 + spacing, y: h0 + h1 + 2 * spacing, width: w, height: h2)
+                itemInfos[3].position = [.right, .bottom]
+            }
+        }
+    }
+
+    if forceCalc || itemInfos.count >= 5 {
+        var croppedRatios: [CGFloat] = []
+        for itemInfo in itemInfos {
+            let aspectRatio = itemInfo.aspectRatio
+            var croppedRatio = aspectRatio
+            if averageAspectRatio > 1.1 {
+                croppedRatio = max(1.0, aspectRatio)
+            } else {
+                croppedRatio = min(1.0, aspectRatio)
+            }
+
+            croppedRatio = max(0.66667, min(1.7, croppedRatio))
+            croppedRatios.append(croppedRatio)
+        }
+
+        func multiHeight(_ ratios: [CGFloat]) -> CGFloat {
+            var ratioSum: CGFloat = 0.0
+            for ratio in ratios {
+                ratioSum += ratio
+            }
+            return (maxSize.width - CGFloat(ratios.count - 1) * spacing) / ratioSum
+        }
+
+        var attempts: [MediaMosaicLayoutAttempt] = []
+        func addAttempt(_ lineCounts: [Int], _ heights: [CGFloat], _ attempts: inout [MediaMosaicLayoutAttempt]) {
+            attempts.append(MediaMosaicLayoutAttempt(lineCounts: lineCounts, heights: heights))
+        }
+
+        for firstLine in 1 ..< croppedRatios.count {
+            let secondLine = croppedRatios.count - firstLine
+            if firstLine > 3 || secondLine > 3 {
+                continue
+            }
+
+            addAttempt([firstLine, croppedRatios.count - firstLine], [multiHeight(Array(croppedRatios[0..<firstLine])), multiHeight(Array(croppedRatios[firstLine..<croppedRatios.count]))], &attempts)
+        }
+
+        for firstLine in 1 ..< croppedRatios.count - 1 {
+            for secondLine in 1 ..< croppedRatios.count - firstLine {
+                let thirdLine = croppedRatios.count - firstLine - secondLine
+                if firstLine > 3 || secondLine > (averageAspectRatio < 0.85 ? 4 : 3) || thirdLine > 3 {
+                    continue
+                }
+
+                addAttempt([firstLine, secondLine, thirdLine], [multiHeight(Array(croppedRatios[0 ..< firstLine])), multiHeight(Array(croppedRatios[firstLine ..< croppedRatios.count - thirdLine])), multiHeight(Array(croppedRatios[firstLine + secondLine ..< croppedRatios.count]))], &attempts)
+            }
+        }
+
+        if croppedRatios.count - 2 >= 1 {
+            outer: for firstLine in 1 ..< croppedRatios.count - 2 {
+                if croppedRatios.count - firstLine < 1 {
+                    continue outer
+                }
+                for secondLine in 1 ..< croppedRatios.count - firstLine {
+                    for thirdLine in 1 ..< croppedRatios.count - firstLine - secondLine {
+                        let fourthLine = croppedRatios.count - firstLine - secondLine - thirdLine
+                        if firstLine > 3 || secondLine > 3 || thirdLine > 3 || fourthLine > 3 {
+                            continue
+                        }
+
+                        addAttempt([firstLine, secondLine, thirdLine, fourthLine], [multiHeight(Array(croppedRatios[0 ..< firstLine])), multiHeight(Array(croppedRatios[firstLine ..< croppedRatios.count - thirdLine - fourthLine])), multiHeight(Array(croppedRatios[firstLine + secondLine ..< croppedRatios.count - fourthLine])), multiHeight(Array(croppedRatios[firstLine + secondLine + thirdLine ..< croppedRatios.count]))], &attempts)
+                    }
+                }
+            }
+        }
+
+        let maxHeight = floor(maxSize.width / 3.0 * 4.0)
+        var optimal: MediaMosaicLayoutAttempt? = nil
+        var optimalDiff: CGFloat = 0.0
+        for attempt in attempts {
+            var totalHeight = spacing * CGFloat(attempt.heights.count - 1)
+            var minLineHeight: CGFloat = .greatestFiniteMagnitude
+            var maxLineHeight: CGFloat = 0.0
+            for h in attempt.heights {
+                totalHeight += floor(h)
+                if totalHeight < minLineHeight {
+                    minLineHeight = totalHeight
+                }
+                if totalHeight > maxLineHeight {
+                    maxLineHeight = totalHeight
+                }
+            }
+
+            var diff = abs(totalHeight - maxHeight)
+
+            if attempt.lineCounts.count > 1 {
+                if (attempt.lineCounts[0] > attempt.lineCounts[1]) || (attempt.lineCounts.count > 2 && attempt.lineCounts[1] > attempt.lineCounts[2]) || (attempt.lineCounts.count > 3 && attempt.lineCounts[2] > attempt.lineCounts[3]) {
+                    diff *= 1.5
+                }
+            }
+
+            if minLineHeight < minWidth {
+                diff *= 1.5
+            }
+
+            if optimal == nil || diff < optimalDiff {
+                optimal = attempt
+                optimalDiff = diff
+            }
+        }
+
+        var index = 0
+        var y: CGFloat = 0.0
+        if let optimal = optimal {
+            for i in 0 ..< optimal.lineCounts.count {
+                let count = optimal.lineCounts[i]
+                let lineHeight = ceil(optimal.heights[i])
+                var x: CGFloat = 0.0
+
+                var positionFlags: MediaMosaicItemPosition = []
+                if i == 0 {
+                    positionFlags.insert(.top)
+                }
+                if i == optimal.lineCounts.count - 1 {
+                    positionFlags.insert(.bottom)
+                }
+
+                for k in 0 ..< count {
+                    var innerPositionFlags = positionFlags
+
+                    if k == 0 {
+                        innerPositionFlags.insert(.left)
+                    }
+                    if k == count - 1 {
+                        innerPositionFlags.insert(.right)
+                    }
+
+                    if positionFlags == [] {
+                        innerPositionFlags = .inside
+                    }
+
+                    let ratio = croppedRatios[index]
+                    let width = ceil(ratio * lineHeight)
+                    itemInfos[index].layoutFrame = CGRect(x: x, y: y, width: width, height: lineHeight)
+                    itemInfos[index].position = innerPositionFlags
+
+                    x += width + spacing
+                    index += 1
+                }
+
+                y += lineHeight + spacing
+            }
+
+            index = 0
+            var maxWidth: CGFloat = 0.0
+            for i in 0 ..< optimal.lineCounts.count {
+                let count = optimal.lineCounts[i]
+                for k in 0 ..< count {
+                    if k == count - 1 {
+                        maxWidth = max(maxWidth, itemInfos[index].layoutFrame.maxX)
+                    }
+                    index += 1
+                }
+            }
+
+            index = 0
+            for i in 0 ..< optimal.lineCounts.count {
+                let count = optimal.lineCounts[i]
+                for k in 0 ..< count {
+                    if k == count - 1 {
+                        var frame = itemInfos[index].layoutFrame
+                        frame.size.width = max(frame.width, maxWidth - frame.minX)
+                        itemInfos[index].layoutFrame = frame
+                    }
+                    index += 1
+                }
+            }
+        }
+    }
+
+    var dimensions = CGSize()
+    for itemInfo in itemInfos {
+        dimensions.width = max(dimensions.width, round(itemInfo.layoutFrame.maxX))
+        dimensions.height = max(dimensions.height, round(itemInfo.layoutFrame.maxY))
+    }
+
+    return (itemInfos.map { ($0.layoutFrame, $0.position) }, dimensions)
+}

--- a/MezonChat/Features/Chat/Cells/MessageMediaContentNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageMediaContentNode.swift
@@ -47,16 +47,16 @@ final class MessageMediaContentNode: ASDisplayNode {
     private var imageNodes: [TransformImageNode] = []
     private var videoOverlayNodes: [ASDisplayNode] = []
     private var shimmerNodes: [ShimmerPlaceholderNode] = []
-    private var overlayCountNode: ASTextNode2?
-    private var overlayBgNode: ASDisplayNode?
     private var stickerNode: ASDisplayNode?
     private var attachments: [ParsedAttachment] = []
     private(set) var isUploading: Bool = false
 
     var onImageTapped: ((Int) -> Void)?
 
+    private static let gridSpacing: CGFloat = 2.0
 
     private var cachedImageFrames: [CGRect] = []
+    private var cachedPositions: [MediaMosaicItemPosition] = []
     private var cachedTotalSize: CGSize = .zero
     private var isSingleImage = false
     private var isSticker = false
@@ -68,10 +68,127 @@ final class MessageMediaContentNode: ASDisplayNode {
         super.init()
     }
 
+    private static func mosaicItemSize(for att: ParsedAttachment) -> CGSize {
+        if let local = att.localImage, local.size.width > 0, local.size.height > 0 {
+            return local.size
+        }
+        let w = att.width ?? 0
+        let h = att.height ?? 0
+        if w > 0 && h > 0 {
+            return CGSize(width: w, height: h)
+        }
+        return CGSize(width: 1, height: 1)
+    }
+
+    private func uniformGridLayout(count: Int, maxWidth: CGFloat, spacing: CGFloat) -> ([CGRect], [MediaMosaicItemPosition]) {
+        let columns = count <= 9 ? 3 : 4
+        let rows = Int(ceil(CGFloat(count) / CGFloat(columns)))
+        let itemW = floor((maxWidth - spacing * CGFloat(columns - 1)) / CGFloat(columns))
+        let itemH = itemW
+
+        var frames: [CGRect] = []
+        var positions: [MediaMosaicItemPosition] = []
+        for i in 0..<count {
+            let row = i / columns
+            let col = i % columns
+            let lineCount = min(columns, count - row * columns)
+            let x = CGFloat(col) * (itemW + spacing)
+            let y = CGFloat(row) * (itemH + spacing)
+            frames.append(CGRect(x: x, y: y, width: itemW, height: itemH))
+
+            var position: MediaMosaicItemPosition = []
+            if row == 0 { position.insert(.top) }
+            if row == rows - 1 { position.insert(.bottom) }
+            if col == 0 { position.insert(.left) }
+            if col == lineCount - 1 { position.insert(.right) }
+            if position.isEmpty { position = .inside }
+            positions.append(position)
+        }
+        return (frames, positions)
+    }
+
+    private func splitIntoChunks(count: Int) -> [Int] {
+        guard count > 10 else { return [count] }
+        var chunks: [Int] = []
+        var remaining = count
+        while remaining > 0 {
+            if remaining <= 10 {
+                chunks.append(remaining)
+                remaining = 0
+            } else if remaining == 11 {
+                chunks.append(6)
+                chunks.append(5)
+                remaining = 0
+            } else if remaining == 12 {
+                chunks.append(6)
+                chunks.append(6)
+                remaining = 0
+            } else {
+                chunks.append(10)
+                remaining -= 10
+            }
+        }
+        return chunks
+    }
+
+    private func dynamicGridLayout(attachments: [ParsedAttachment], maxWidth: CGFloat, maxHeight: CGFloat, spacing: CGFloat) -> ([CGRect], [MediaMosaicItemPosition]) {
+        let chunkSizes = splitIntoChunks(count: attachments.count)
+
+        var allFrames: [CGRect] = []
+        var allPositions: [MediaMosaicItemPosition] = []
+        var offsetY: CGFloat = 0
+        var startIndex = 0
+
+        for chunkSize in chunkSizes {
+            let chunk = Array(attachments[startIndex ..< startIndex + chunkSize])
+            startIndex += chunkSize
+
+            let itemSizes = chunk.map { Self.mosaicItemSize(for: $0) }
+            let (framesAndPositions, dimensions) = mediaMosaicLayout(
+                maxSize: CGSize(width: maxWidth, height: maxHeight),
+                itemSizes: itemSizes,
+                spacing: spacing,
+                fillWidth: true
+            )
+
+            var frames = framesAndPositions.map { $0.0 }
+            var positions = framesAndPositions.map { $0.1 }
+
+            let mosaicValid = !frames.isEmpty
+                && frames.count == chunk.count
+                && dimensions.width > 0
+                && dimensions.height > 0
+                && !frames.contains { $0.width <= 0 || $0.height <= 0 }
+
+            if mosaicValid {
+                if abs(dimensions.width - maxWidth) > 0.5 {
+                    let scale = maxWidth / dimensions.width
+                    frames = frames.map {
+                        CGRect(x: $0.minX * scale, y: $0.minY * scale, width: $0.width * scale, height: $0.height * scale)
+                    }
+                }
+            } else {
+                (frames, positions) = uniformGridLayout(count: chunk.count, maxWidth: maxWidth, spacing: spacing)
+            }
+
+            var chunkMaxY: CGFloat = 0
+            for frame in frames {
+                let shifted = CGRect(x: frame.minX, y: frame.minY + offsetY, width: frame.width, height: frame.height)
+                allFrames.append(shifted)
+                chunkMaxY = max(chunkMaxY, shifted.maxY)
+            }
+            allPositions.append(contentsOf: positions)
+            offsetY = chunkMaxY + spacing
+        }
+
+        return (allFrames, allPositions)
+    }
+
     func prepareForMeasurement(media: [ParsedAttachment]) {
         attachments = media
         lastRemoteProxyURLByIndex.removeAll()
         cachedImageFrames = []
+        cachedPositions = []
         isUploading = media.contains { $0.isUploading }
         isSticker = false
         isGifSticker = false
@@ -97,15 +214,12 @@ final class MessageMediaContentNode: ASDisplayNode {
         videoOverlayNodes.removeAll()
         shimmerNodes.forEach { $0.removeFromSupernode() }
         shimmerNodes.removeAll()
-        overlayCountNode?.removeFromSupernode()
-        overlayCountNode = nil
-        overlayBgNode?.removeFromSupernode()
-        overlayBgNode = nil
         stickerNode?.removeFromSupernode()
         stickerNode = nil
         attachments = media
         lastRemoteProxyURLByIndex.removeAll()
         cachedImageFrames = []
+        cachedPositions = []
 
         isUploading = media.contains { $0.isUploading }
 
@@ -163,7 +277,7 @@ final class MessageMediaContentNode: ASDisplayNode {
             isSticker = false
             isSingleImage = false
             isMultiple = true
-            let items = Array(media.prefix(4))
+            let items = media
             for (i, att) in items.enumerated() {
                 let shimmer = ShimmerPlaceholderNode()
                 shimmerNodes.append(shimmer)
@@ -194,22 +308,6 @@ final class MessageMediaContentNode: ASDisplayNode {
                     placeholder.isHidden = true
                     videoOverlayNodes.append(placeholder)
                 }
-            }
-            if media.count > 4 {
-                let countNode = ASTextNode2()
-                countNode.attributedText = NSAttributedString(
-                    string: "+\(media.count - 3)",
-                    attributes: [
-                        .font: UIFont.systemFont(ofSize: 20.sf, weight: .bold),
-                        .foregroundColor: UIColor.white,
-                    ]
-                )
-                overlayCountNode = countNode
-                let bg = ASDisplayNode()
-                bg.backgroundColor = UIColor.black.withAlphaComponent(0.5)
-                overlayBgNode = bg
-                addSubnode(bg)
-                addSubnode(countNode)
             }
         }
     }
@@ -269,44 +367,41 @@ final class MessageMediaContentNode: ASDisplayNode {
         }
 
         if isMultiple {
-            let thumbH: CGFloat = max(120.sh, 1)
-            let spacing: CGFloat = 4.sw
-            let itemW = max((maxWidth - spacing) / 2, 1)
-            let mediaCount = min(attachments.count, 4)
-            let items = Array(imageNodes.prefix(4))
+            let spacing = Self.gridSpacing
+            let gridAttachments = attachments
+            let items = imageNodes
 
-            var frames: [CGRect] = []
-            let row1Count = min(mediaCount, 2)
-            for i in 0..<row1Count {
-                frames.append(CGRect(x: CGFloat(i) * (itemW + spacing), y: 0, width: itemW, height: thumbH))
-            }
-
-            if mediaCount > 2 {
-                let row2Count = mediaCount - 2
-                for i in 0..<row2Count {
-                    frames.append(CGRect(x: CGFloat(i) * (itemW + spacing), y: thumbH + spacing, width: itemW, height: thumbH))
-                }
-            }
-
+            let (frames, positions) = dynamicGridLayout(
+                attachments: gridAttachments,
+                maxWidth: maxWidth,
+                maxHeight: maxH,
+                spacing: spacing
+            )
 
             for (i, node) in items.enumerated() {
+                guard i < frames.count else { break }
+                let frame = frames[i]
                 let args = TransformImageArguments(
-                    corners: ImageCorners(radius: 8.swh),
-                    imageSize: CGSize(width: itemW, height: thumbH),
-                    boundingSize: CGSize(width: itemW, height: thumbH),
+                    corners: ImageCorners(radius: 0),
+                    imageSize: frame.size,
+                    boundingSize: frame.size,
                     intrinsicInsets: .zero
                 )
                 let layout = node.asyncLayout()
                 let apply = layout(args)
                 apply()
-                if i < attachments.count {
-                    ensureRemoteImageLoaded(at: i, media: attachments[i], isMultiple: true)
+                if i < gridAttachments.count {
+                    ensureRemoteImageLoaded(at: i, media: gridAttachments[i], isMultiple: true)
                 }
             }
 
             cachedImageFrames = frames
-            let totalH = mediaCount > 2 ? thumbH * 2 + spacing : thumbH
-            cachedTotalSize = CGSize(width: maxWidth, height: totalH)
+            cachedPositions = positions
+            var totalH: CGFloat = 0
+            for frame in frames {
+                totalH = max(totalH, frame.maxY)
+            }
+            cachedTotalSize = CGSize(width: maxWidth, height: ceil(totalH))
             return cachedTotalSize
         }
 
@@ -326,7 +421,8 @@ final class MessageMediaContentNode: ASDisplayNode {
             guard i < cachedImageFrames.count else { break }
             node.frame = cachedImageFrames[i]
             if i < shimmerNodes.count {
-                shimmerNodes[i].frame = cachedImageFrames[i]
+                let shimmer = shimmerNodes[i]
+                shimmer.frame = cachedImageFrames[i]
             }
         }
 
@@ -348,25 +444,14 @@ final class MessageMediaContentNode: ASDisplayNode {
         } else if isMultiple {
             for (i, overlay) in videoOverlayNodes.enumerated() {
                 guard i < cachedImageFrames.count, !overlay.isHidden else { continue }
+                let imgFrame = cachedImageFrames[i]
                 if i < attachments.count, attachments[i].isVideo {
-                    let imgFrame = cachedImageFrames[i]
                     let sz: CGFloat = 48
                     overlay.frame = CGRect(x: imgFrame.midX - sz / 2, y: imgFrame.midY - sz / 2, width: sz, height: sz)
                 } else if i < attachments.count, attachments[i].isUploading || attachments[i].uploadFailed {
-                    overlay.frame = cachedImageFrames[i]
+                    overlay.frame = imgFrame
+                    overlay.cornerRadius = 0
                 }
-            }
-
-
-            if let countNode = overlayCountNode, let bg = overlayBgNode,
-               let lastFrame = cachedImageFrames.last {
-                bg.frame = lastFrame
-                let countSz = countNode.measure(lastFrame.size)
-                countNode.frame = CGRect(
-                    x: lastFrame.midX - countSz.width / 2,
-                    y: lastFrame.midY - countSz.height / 2,
-                    width: countSz.width, height: countSz.height
-                )
             }
         }
     }

--- a/MezonChat/Features/Chat/Cells/MessageMediaContentNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageMediaContentNode.swift
@@ -494,14 +494,21 @@ final class MessageMediaContentNode: ASDisplayNode {
     }
 
     private func ensureRemoteImageLoaded(at index: Int, media: ParsedAttachment, isMultiple: Bool) {
-        guard !media.isVideo, media.localImage == nil else { return }
+        guard media.localImage == nil else { return }
+        let sourceURL: String
+        if media.isVideo {
+            guard !media.thumbnail.isEmpty else { return }
+            sourceURL = media.thumbnail
+        } else {
+            sourceURL = media.url
+        }
         guard index < imageNodes.count else { return }
         let node = imageNodes[index]
         let w = 400
         let h = 400
         let resizeMode: ImageResizeMode = isMultiple ? .fill : .fit
         let proxyURL = ImgproxyURL.attachmentURL(
-            from: media.url,
+            from: sourceURL,
             width: w,
             height: h,
             resizeType: isMultiple ? "fill" : "fit"
@@ -516,9 +523,9 @@ final class MessageMediaContentNode: ASDisplayNode {
             }
         }
         let hasMem = ImageCache.shared.memoryImage(forKey: proxyURL) != nil
-            || ImageCache.shared.memoryImage(forKey: media.url) != nil
+            || ImageCache.shared.memoryImage(forKey: sourceURL) != nil
         node.setSignal(
-            remoteAttachmentImageSignal(proxyURL: proxyURL, originalURL: media.url, resizeMode: resizeMode),
+            remoteAttachmentImageSignal(proxyURL: proxyURL, originalURL: sourceURL, resizeMode: resizeMode),
             attemptSynchronously: hasMem
         )
     }
@@ -526,7 +533,7 @@ final class MessageMediaContentNode: ASDisplayNode {
     private func loadImage(at index: Int, into node: TransformImageNode, media: ParsedAttachment, isMultiple: Bool, measuredPtSize: CGSize?) {
         if let localImage = media.localImage {
             node.setSignal(staticImageSignal(image: localImage), attemptSynchronously: true)
-        } else if media.isVideo {
+        } else if media.isVideo && media.thumbnail.isEmpty {
             node.setSignal(videoThumbnailSignal(url: media.url, resizeMode: .fill), attemptSynchronously: false)
         } else if measuredPtSize != nil {
             ensureRemoteImageLoaded(at: index, media: media, isMultiple: isMultiple)

--- a/MezonChat/Features/Chat/ChatViewController.swift
+++ b/MezonChat/Features/Chat/ChatViewController.swift
@@ -21,6 +21,7 @@ struct ParsedAttachment: Equatable {
     let width: Int?
     let height: Int?
     let durationSeconds: Int?
+    var thumbnail: String = ""
     var localImage: UIImage?
     var isUploading: Bool = false
     var uploadFailed: Bool = false
@@ -59,6 +60,7 @@ struct ParsedAttachment: Equatable {
     static func ==(lhs: ParsedAttachment, rhs: ParsedAttachment) -> Bool {
         lhs.url == rhs.url && lhs.filename == rhs.filename && lhs.filetype == rhs.filetype
             && lhs.width == rhs.width && lhs.height == rhs.height && lhs.durationSeconds == rhs.durationSeconds
+            && lhs.thumbnail == rhs.thumbnail
             && lhs.isUploading == rhs.isUploading && lhs.uploadFailed == rhs.uploadFailed
     }
 
@@ -2965,7 +2967,8 @@ final class ChatViewController: ViewController {
                     filetype: att.filetype,
                     width: att.width != 0 ? Int(att.width) : nil,
                     height: att.height != 0 ? Int(att.height) : nil,
-                    durationSeconds: att.duration > 0 ? Int(att.duration) : nil
+                    durationSeconds: att.duration > 0 ? Int(att.duration) : nil,
+                    thumbnail: att.thumbnail
                 )
             }
         }
@@ -2996,7 +2999,8 @@ final class ChatViewController: ViewController {
                         filetype: item["filetype"] as? String ?? "",
                         width: w,
                         height: h,
-                        durationSeconds: d
+                        durationSeconds: d,
+                        thumbnail: item["thumbnail"] as? String ?? ""
                     )
                 }
             }

--- a/MezonChat/Features/SendMessageInput/AttachmentUploadCoordinator.swift
+++ b/MezonChat/Features/SendMessageInput/AttachmentUploadCoordinator.swift
@@ -430,21 +430,21 @@ final class AttachmentUploadCoordinator {
     @MainActor
     private func uploadFiles(_ session: ImageUploadSession, context: AccountContext, token: String) async {
         for file in session.params.files {
-            guard let fileData = try? Data(contentsOf: file.url) else { continue }
+            guard let size = await Self.fileSize(of: file.url) else { continue }
             let sanitized = file.filename.replacingOccurrences(
                 of: "[^a-zA-Z0-9._-]", with: "_", options: .regularExpression)
             do {
                 let uploadInfo = try await context.account.network.uploadAttachmentFile(
-                    filename: sanitized, filetype: file.filetype, size: fileData.count,
+                    filename: sanitized, filetype: file.filetype, size: size,
                     width: 0, height: 0, token: token)
                 try await context.account.network.uploadToMinIO(
-                    url: uploadInfo.url, data: fileData, contentType: file.filetype)
+                    url: uploadInfo.url, fileURL: file.url, contentType: file.filetype)
                 let cdnURL = "\(MezonConfig.baseImgURL)/\(uploadInfo.filename)"
                 var att = Mezon_Api_MessageAttachment()
                 att.filename = file.filename
                 att.url = cdnURL
                 att.filetype = file.filetype
-                att.size = Int32(fileData.count)
+                att.size = Int32(size)
                 session.fileAttachments.append(att)
                 try? FileManager.default.removeItem(at: file.url)
             } catch {
@@ -462,33 +462,54 @@ final class AttachmentUploadCoordinator {
         context: AccountContext,
         token: String
     ) async -> Mezon_Api_MessageAttachment? {
-        guard let fileURL = item.fileURL, let fileData = try? Data(contentsOf: fileURL) else { return nil }
+        guard let fileURL = item.fileURL else { return nil }
 
+        let image = item.image
         let originalFilename = fileURL.lastPathComponent
         let ext = fileURL.pathExtension.lowercased()
         let filetype = SendMessageInputViewController.mimeType(for: ext)
-        let width = Int(item.image.size.width)
-        let height = Int(item.image.size.height)
+        let width = Int(image.size.width)
+        let height = Int(image.size.height)
         let sanitized = originalFilename.replacingOccurrences(
             of: "[^a-zA-Z0-9._-]", with: "_", options: .regularExpression)
+        let isVideo = filetype.hasPrefix("video/")
 
         do {
-            let uploadInfo = try await context.account.network.uploadAttachmentFile(
-                filename: sanitized, filetype: filetype, size: fileData.count,
-                width: width, height: height, token: token)
-            try await context.account.network.uploadToMinIO(
-                url: uploadInfo.url, data: fileData, contentType: filetype)
-            let cdnURL = "\(MezonConfig.baseImgURL)/\(uploadInfo.filename)"
-            if !filetype.hasPrefix("video/") {
-                ImageCache.shared.setImage(item.image, data: fileData, forKey: cdnURL)
-            }
             var att = Mezon_Api_MessageAttachment()
             att.filename = originalFilename
-            att.url = cdnURL
             att.filetype = filetype
-            att.size = Int32(fileData.count)
             att.width = Int32(width)
             att.height = Int32(height)
+
+            if isVideo {
+                guard let size = await Self.fileSize(of: fileURL) else { return nil }
+                let uploadInfo = try await context.account.network.uploadAttachmentFile(
+                    filename: sanitized, filetype: filetype, size: size,
+                    width: width, height: height, token: token)
+                try await context.account.network.uploadToMinIO(
+                    url: uploadInfo.url, fileURL: fileURL, contentType: filetype)
+                att.url = "\(MezonConfig.baseImgURL)/\(uploadInfo.filename)"
+                att.size = Int32(size)
+                att.thumbnail = await uploadVideoThumbnail(
+                    image, originalFilename: sanitized, context: context, token: token)
+            } else {
+                let isGif = filetype == "image/gif" || ext == "gif"
+                guard let payload = await Self.imageUploadPayload(
+                    image: image, fileURL: fileURL, filetype: filetype,
+                    filename: sanitized, isGif: isGif) else { return nil }
+                let uploadInfo = try await context.account.network.uploadAttachmentFile(
+                    filename: payload.filename, filetype: payload.filetype, size: payload.data.count,
+                    width: width, height: height, token: token)
+                try await context.account.network.uploadToMinIO(
+                    url: uploadInfo.url, data: payload.data, contentType: payload.filetype)
+                let cdnURL = "\(MezonConfig.baseImgURL)/\(uploadInfo.filename)"
+                ImageCache.shared.setImage(image, data: payload.data, forKey: cdnURL)
+                att.filename = payload.filename
+                att.filetype = payload.filetype
+                att.url = cdnURL
+                att.size = Int32(payload.data.count)
+            }
+
             try? FileManager.default.removeItem(at: fileURL)
             return att
         } catch {
@@ -498,6 +519,68 @@ final class AttachmentUploadCoordinator {
             ])
             return nil
         }
+    }
+
+    @MainActor
+    private func uploadVideoThumbnail(
+        _ thumbnail: UIImage,
+        originalFilename: String,
+        context: AccountContext,
+        token: String
+    ) async -> String {
+        guard let thumbData = await Self.encodeJPEG(thumbnail, quality: 0.7) else { return "" }
+
+        let baseName = (originalFilename as NSString).deletingPathExtension
+        let thumbFilename = "\(baseName.isEmpty ? "video" : baseName)_thumb.jpg"
+        let width = Int(thumbnail.size.width)
+        let height = Int(thumbnail.size.height)
+
+        do {
+            let uploadInfo = try await context.account.network.uploadAttachmentFile(
+                filename: thumbFilename, filetype: "image/jpeg", size: thumbData.count,
+                width: width, height: height, token: token)
+            try await context.account.network.uploadToMinIO(
+                url: uploadInfo.url, data: thumbData, contentType: "image/jpeg")
+            let thumbCdnURL = "\(MezonConfig.baseImgURL)/\(uploadInfo.filename)"
+            ImageCache.shared.setImage(thumbnail, data: thumbData, forKey: thumbCdnURL)
+            return thumbCdnURL
+        } catch {
+            return ""
+        }
+    }
+
+    // MARK: - Background I/O
+
+    private static let imageCompressionQuality: CGFloat = 0.9
+
+    private struct ImageUploadPayload {
+        let data: Data
+        let filetype: String
+        let filename: String
+    }
+
+    private nonisolated static func imageUploadPayload(
+        image: UIImage, fileURL: URL, filetype: String, filename: String, isGif: Bool
+    ) async -> ImageUploadPayload? {
+        await Task.detached(priority: .utility) {
+            if !isGif, let jpeg = image.jpegData(compressionQuality: imageCompressionQuality) {
+                let base = (filename as NSString).deletingPathExtension
+                let name = "\(base.isEmpty ? "image" : base).jpg"
+                return ImageUploadPayload(data: jpeg, filetype: "image/jpeg", filename: name)
+            }
+            guard let raw = try? Data(contentsOf: fileURL) else { return nil }
+            return ImageUploadPayload(data: raw, filetype: filetype, filename: filename)
+        }.value
+    }
+
+    private nonisolated static func fileSize(of url: URL) async -> Int? {
+        await Task.detached(priority: .utility) {
+            (try? FileManager.default.attributesOfItem(atPath: url.path))?[.size] as? NSNumber
+        }.value?.intValue
+    }
+
+    private nonisolated static func encodeJPEG(_ image: UIImage, quality: CGFloat) async -> Data? {
+        await Task.detached(priority: .utility) { image.jpegData(compressionQuality: quality) }.value
     }
 
     // MARK: - Helpers

--- a/MezonChat/Features/SendMessageInput/AttachmentUploadCoordinator.swift
+++ b/MezonChat/Features/SendMessageInput/AttachmentUploadCoordinator.swift
@@ -54,7 +54,7 @@ final class ImageUploadSession {
     var hasSent = false
     var aborted = false
     var finished = false
-    var lastFlushCompletedCount = 0
+    var lastSentAttachmentCount = 0
 
     init(params: ImageSendParams) {
         self.params = params
@@ -265,13 +265,13 @@ final class AttachmentUploadCoordinator {
                 if allResolved { finalizeAllFailed(session, context: context) }
                 return
             }
-            session.lastFlushCompletedCount = completedCount
+            session.lastSentAttachmentCount = ready.count
             await doFirstSend(session, context: context, token: token, attachments: ready)
         } else if session.serverMessageId != 0 {
-            let newlyCompleted = completedCount - session.lastFlushCompletedCount
-            let shouldUpdate = forceFlush || newlyCompleted >= Self.editBatchSize || (allResolved && newlyCompleted > 0)
+            let pendingNew = ready.count - session.lastSentAttachmentCount
+            let shouldUpdate = pendingNew > 0 && (forceFlush || pendingNew >= Self.editBatchSize || allResolved)
             guard shouldUpdate else { return }
-            session.lastFlushCompletedCount = completedCount
+            session.lastSentAttachmentCount = ready.count
             await doUpdate(session, context: context, token: token, attachments: ready)
         }
 

--- a/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
+++ b/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
@@ -5181,6 +5181,7 @@ final class SendMessageInputViewController: UIViewController {
                 }
 
                 if isEdit {
+                    let hideEditted = !imagesToUpload.isEmpty || !filesToUpload.isEmpty
                     let ack = try await self.context.account.network.updateChannelMessage(
                         clanId: clanId,
                         channelId: channel.channelID,
@@ -5190,22 +5191,23 @@ final class SendMessageInputViewController: UIViewController {
                         content: contentStr,
                         mentions: mentionList,
                         attachments: uploadedAttachments,
-                        hideEditted: false,
+                        hideEditted: hideEditted,
                         topicId: self.topicId,
                         isUpdateMsgTopic: false,
                         token: token
                     )
-                    let editedAt: Date = {
-                        if ack.updateTimeSeconds > 0 {
-                            return Date(timeIntervalSince1970: TimeInterval(ack.updateTimeSeconds))
-                        }
-                        return Date()
-                    }()
                     self.context.account.postbox.write { tx in
                         let lookup = "\(editingMessageId)"
                         guard let old = tx.getMessageById(lookup) else {
                             return
                         }
+                        let editedAt: Date? = {
+                            if hideEditted { return old.editedAt }
+                            if ack.updateTimeSeconds > 0 {
+                                return Date(timeIntervalSince1970: TimeInterval(ack.updateTimeSeconds))
+                            }
+                            return Date()
+                        }()
                         let newAttachmentsJSON: Data = {
                             guard !uploadedAttachments.isEmpty else { return old.attachmentsJSON }
                             var list = Mezon_Api_MessageAttachmentList()

--- a/project.yml
+++ b/project.yml
@@ -119,7 +119,7 @@ targets:
         ENABLE_USER_SCRIPT_SANDBOXING: NO
         PRODUCT_BUNDLE_IDENTIFIER: mezon.mobile
         PRODUCT_NAME: Mezon
-        MARKETING_VERSION: "1.2.97"
+        MARKETING_VERSION: "1.2.98"
         CURRENT_PROJECT_VERSION: "1"
         INFOPLIST_FILE: MezonChat/Resources/Info.plist
         DEVELOPMENT_TEAM: ""
@@ -220,7 +220,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: mezon.mobile.MezonSharing
         PRODUCT_NAME: MezonSharing
-        MARKETING_VERSION: "1.2.97"
+        MARKETING_VERSION: "1.2.98"
         CURRENT_PROJECT_VERSION: "1"
         DEVELOPMENT_TEAM: ""
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
# Optimize: Video Thumbnail Upload, Background-Thread Offloading & Image Compression

## Overview

Improves the attachment upload pipeline (`AttachmentUploadCoordinator`) and the media render layer:
- Uploads a JPEG **thumbnail** for videos and sends its CDN URL with the attachment.
- Moves CPU/disk work (file read, JPEG encode) **off the main thread**.
- **Streams** large videos/files from disk instead of loading them fully into memory.
- Applies a consistent **JPEG 0.9 compression** to every image upload, regardless of source.
- Renders videos from the server-provided thumbnail when available, falling back to local generation otherwise.

---

## 1. Root Cause

| # | Problem | Impact |
|---|---------|--------|
| 1 | Video uploads sent **no thumbnail**; `att.thumbnail` was never set | Receivers had to download the full video to build a poster; no lightweight preview |
| 2 | The render layer always generated the video poster from the video URL (`videoThumbnailSignal(url:)`) and ignored any server thumbnail | Wasted bandwidth/CPU even when a thumbnail existed |
| 3 | `ParsedAttachment` had no `thumbnail` field, and neither the proto nor JSON parser read it | The thumbnail returned by the server was dropped on the client |
| 4 | File read (`Data(contentsOf:)`) and JPEG encode (`jpegData`) ran on the **main thread** (everything is `@MainActor`) | UI jank when sending heavy/multiple media |
| 5 | Videos and documents were loaded **entirely into memory** (`Data`) before upload | Memory spikes / potential crash on large files |
| 6 | Image compression was inconsistent across entry points (gallery compressed, paste/camera often did not) | Oversized uploads from some sources |

---

## 2. Solution

### Video thumbnail upload
- `uploadOneImage` now uploads the locally generated thumbnail (`item.image`) as a JPEG to MinIO and sets `att.thumbnail` to the resulting CDN URL (`uploadVideoThumbnail`).
- On failure, returns an empty string so the video still sends normally.

### Background-thread offloading
- Added `nonisolated static` helpers running on `Task.detached(priority: .utility)`:
  - `imageUploadPayload(...)` — JPEG-encode (or raw fallback) off-main.
  - `fileSize(of:)` — read file size off-main.
  - `encodeJPEG(_:quality:)` — thumbnail encode off-main.
- Cache writes (`ImageCache`) and attachment/state mutations stay on `@MainActor`.

### Streaming large media
- Videos and documents now upload via `uploadToMinIO(url:fileURL:)`, streaming from disk (size read via `FileManager`) instead of loading the whole file into RAM.

### Consistent image compression
- All non-GIF images are re-encoded to **JPEG quality 0.9** at the upload boundary, so every source (gallery, paste, camera/PHPicker) is compressed uniformly.
- **GIF** keeps its original data (preserves animation); **video** is streamed untouched.

### Thumbnail-aware rendering
- `ParsedAttachment` gains a `thumbnail` field, parsed from both the proto (`att.thumbnail`) and JSON (`item["thumbnail"]`) paths, and included in `Equatable`.
- `MessageMediaContentNode`:
  - When a video has a `thumbnail`, it loads that image directly (via imgproxy + cache, like a normal image).
  - When it does not, it falls back to the existing `videoThumbnailSignal(url:)` generation.

---

## 3. Self Test

- [ ] Send a video → a thumbnail is uploaded and `att.thumbnail` carries a CDN URL.
- [ ] Receiver opens a message whose video has a thumbnail → poster shows immediately **without** downloading the video.
- [ ] Receiver opens a video **without** a server thumbnail → poster is generated locally (fallback) as before.
- [ ] Send a single image, multiple images, text + images → all render correctly and uploads are JPEG ~0.9.
- [ ] Send a GIF → still animates (not re-encoded).
- [ ] Paste/camera image → uploaded compressed at 0.9 (consistent with gallery).
- [ ] Send a large video and a large document → no memory spike/crash; upload streams from disk.
- [ ] Send heavy/multiple media → UI stays responsive (no main-thread jank during encode/read).
- [ ] Drop network mid-upload → failed item shows error overlay; retry re-uploads (incl. video thumbnail).
