### PR TITLE
260603-IOS-Fix list friend not refresh

### DIFF
--- a/MezonChat/Core/MezonEngine/MezonEngine+ClanData.swift
+++ b/MezonChat/Core/MezonEngine/MezonEngine+ClanData.swift
@@ -687,7 +687,7 @@ extension MezonEngine {
 
         private func performRefreshFromNetwork(token: String) async {
             let net = network
-            guard let fetched = (try? await net.listFriends(token: token, limit: 100, state: -1))?.friends else { return }
+            guard let fetched = (try? await net.listFriends(token: token, limit: 100, state: 0))?.friends else { return }
             let cached = allFriends()
 
             guard !fetched.isEmpty || cached.isEmpty else { return }


### PR DESCRIPTION
issue: https://github.com/mezonai/mezon/issues/12922
root cause: truyền sai param state trong api => call 400 http
seft test: thực hiện các action friend và fetch lại data để đảm bảo data show đúng
solution: modify state về đúng từ -1 => 0