### PR TITLE
260603-IOS-Fix bug change category

### DIFF
--- a/MezonChat/Core/MezonEngine/MezonEngine+Channels.swift
+++ b/MezonChat/Core/MezonEngine/MezonEngine+Channels.swift
@@ -42,6 +42,11 @@ extension MezonEngine {
                 token: token
             )
 
+            let prevCh = self.postbox.resolvedChannelDescription(clanId: clanId, channelId: channelId)
+            let prevCatName = prevCh?.categoryName ?? ""
+            let newCatName = categoryId == 0 ? "" : (result.categoryName.isEmpty ? prevCatName : result.categoryName)
+
+
             self.postbox.write { tx in
                 tx.updateChannelDescription(
                     clanId: clanId,
@@ -50,7 +55,7 @@ extension MezonEngine {
                     topic: topic,
                     channelAvatar: channelAvatar,
                     categoryId: categoryId,
-                    categoryName: categoryId == 0 ? "" : result.categoryName
+                    categoryName: newCatName
                 )
             }
             
@@ -61,7 +66,7 @@ extension MezonEngine {
                     if let topic { arr[idx].topic = topic }
                     if let categoryId {
                         arr[idx].categoryID = categoryId
-                        arr[idx].categoryName = categoryId == 0 ? "" : result.categoryName
+                        arr[idx].categoryName = newCatName
                     }
                     if let data = ChannelPreferenceListCodec.encode(arr) {
                         self.postbox.setPreferenceDataSync(
@@ -77,7 +82,7 @@ extension MezonEngine {
                     if let topic { list.channeldesc[idx].topic = topic }
                     if let categoryId {
                         list.channeldesc[idx].categoryID = categoryId
-                        list.channeldesc[idx].categoryName = categoryId == 0 ? "" : result.categoryName
+                        list.channeldesc[idx].categoryName = newCatName
                     }
                     if let data = try? list.serializedData() {
                         self.postbox.setPreferenceDataSync(

--- a/MezonChat/Features/ChannelSettings/ChangeCategoryViewController.swift
+++ b/MezonChat/Features/ChannelSettings/ChangeCategoryViewController.swift
@@ -7,7 +7,7 @@ final class ChangeCategoryViewController: BaseViewController {
     private let clanId: Int64
     private let channelId: Int64
     private let currentCategoryId: Int64
-    private let currentCategoryName: String
+    private var currentCategoryName: String
     private let channelLabel: String
     private let channelTopic: String
     private var categories: [Mezon_Api_CategoryDesc] = []
@@ -105,12 +105,11 @@ final class ChangeCategoryViewController: BaseViewController {
 
         headerLabel.font = .systemFont(ofSize: 12.sf, weight: .semibold)
         headerLabel.textColor = t.textDisabled
-        headerLabel.text = L(L10n.ChannelSetting.changeCategoryMoveFrom)
-            .replacingOccurrences(of: "%@", with: currentCategoryName)
-            .uppercased()
         headerLabel.numberOfLines = 0
         stackView.addArrangedSubview(headerLabel)
         stackView.setCustomSpacing(10.sh, after: headerLabel)
+
+        updateHeaderLabel()
 
         activityIndicator = UIActivityIndicatorView(style: .medium)
         activityIndicator.color = t.textDisabled
@@ -121,14 +120,28 @@ final class ChangeCategoryViewController: BaseViewController {
         fetchCategories()
     }
 
+    private func updateHeaderLabel() {
+        headerLabel.text = L(L10n.ChannelSetting.changeCategoryMoveFrom)
+            .replacingOccurrences(of: "%@", with: currentCategoryName)
+            .uppercased()
+    }
+
+    private func processCategories(_ list: [Mezon_Api_CategoryDesc]) {
+        if let cat = list.first(where: { $0.categoryID == self.currentCategoryId }) {
+            self.currentCategoryName = cat.categoryName
+            self.updateHeaderLabel()
+        }
+        categories = list.filter { $0.categoryID != currentCategoryId }
+        activityIndicator.stopAnimating()
+        buildCategoryRows()
+    }
+
     private func fetchCategories() {
         let postbox = context.account.postbox
         let key = PreferencesKeys.channelListMeta(clanId: clanId)
         if let data = postbox.getPreferenceData(key: key) {
             if let meta = ChannelListMetaCodec.decode(data)?.categoryDescs, !meta.isEmpty {
-                categories = meta.filter { $0.categoryID != currentCategoryId }
-                activityIndicator.stopAnimating()
-                buildCategoryRows()
+                processCategories(meta)
                 return
             }
         }
@@ -147,9 +160,7 @@ final class ChangeCategoryViewController: BaseViewController {
                 result.append(cat)
             }
             if !result.isEmpty {
-                categories = result.filter { $0.categoryID != currentCategoryId }
-                activityIndicator.stopAnimating()
-                buildCategoryRows()
+                processCategories(result)
                 return
             }
         }
@@ -169,9 +180,7 @@ final class ChangeCategoryViewController: BaseViewController {
                 let allCategories = try await MezonHTTPClient.shared.listCategoryDescs(
                     clanId: self.clanId, token: token
                 )
-                self.categories = allCategories.filter { $0.categoryID != self.currentCategoryId }
-                self.activityIndicator.stopAnimating()
-                self.buildCategoryRows()
+                self.processCategories(allCategories)
             } catch {
                 self.activityIndicator.stopAnimating()
                 self.showEmptyState()


### PR DESCRIPTION
issue: https://github.com/mezonai/mezon-ios/issues/147

Root Cause
Missing Category Name (Bug 1): When updating a channel's settings (such as its name) without changing its category, the API returned an empty categoryName. The app mistakenly took this empty string and overwrote the valid category name in the local database, causing it to go missing on the UI.
Stale Category Name (Bug 2): The ChangeCategoryViewController was initialized with a static category name. If a category was renamed elsewhere (like in Clan Settings), the screen still used the outdated static name instead of fetching the latest name from the updated categories list.

Solution
Preserve Category Name: Modified the channel update logic in MezonEngine+Channels.swift to check if the API returns an empty category name; if it does, it now falls back to preserving the existing cached category name from the local database.
Dynamic Name Binding: Refactored ChangeCategoryViewController.swift so that whenever it fetches the latest list of categories (from cache or API), it actively searches for the currentCategoryId to find its latest name, and dynamically refreshes the MOVE FROM [...] TO label.

Self Test Cases
Open the Change Category screen and verify the current category name is displayed correctly in the "MOVE FROM [...] TO" label.
Edit and save the channel name, then verify the category name is still displayed correctly in the Change Category screen.
Change the channel to a different category, then verify the new category name is correctly reflected in the "MOVE FROM [...] TO" label.
Rename a category in Clan Settings, then verify the new category name appears correctly in the channel's Change Category screen.