### PR TITLE
feat: upload multipart file

### DIFF
--- a/MezonChat/Core/UI/ImgproxyURL.swift
+++ b/MezonChat/Core/UI/ImgproxyURL.swift
@@ -11,24 +11,50 @@ enum ImgproxyURL {
 
     private static let attachmentOutputSuffix = "@webp"
 
+    private static func sourceExtension(_ sourceURL: String) -> String {
+        let s = sourceURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !s.isEmpty else { return "" }
+        if let components = URLComponents(string: s), !components.path.isEmpty {
+            return (components.path as NSString).pathExtension.lowercased()
+        }
+        return (s as NSString).pathExtension.lowercased()
+    }
+
+    private static func shouldSkipProxy(_ sourceURL: String) -> Bool {
+        skipExtensions.contains(sourceExtension(sourceURL))
+    }
+
+    static func secureURLString(from sourceURL: String) -> String {
+        let s = sourceURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard s.hasPrefix("http://"),
+              cdnHosts.contains(where: { s.contains($0) }) else {
+            return s
+        }
+        if var components = URLComponents(string: s) {
+            components.scheme = "https"
+            return components.string ?? "https://" + String(s.dropFirst("http://".count))
+        }
+        return "https://" + String(s.dropFirst("http://".count))
+    }
+
     static func attachmentURL(
         from sourceURL: String,
         width: Int,
         height: Int,
         resizeType: String = "fit"
     ) -> String {
-        guard !sourceURL.isEmpty else { return sourceURL }
-        guard cdnHosts.contains(where: { sourceURL.contains($0) }) else {
-            return sourceURL
+        let resolvedSourceURL = secureURLString(from: sourceURL)
+        guard !resolvedSourceURL.isEmpty else { return resolvedSourceURL }
+        guard cdnHosts.contains(where: { resolvedSourceURL.contains($0) }) else {
+            return resolvedSourceURL
         }
-        let ext = (sourceURL as NSString).pathExtension.lowercased()
-        if skipExtensions.contains(ext) {
-            return sourceURL
+        if shouldSkipProxy(resolvedSourceURL) {
+            return resolvedSourceURL
         }
         let w = max(1, width)
         let h = max(1, height)
         let processingOptions = "rs:\(resizeType):\(w):\(h):1/mb:2097152"
-        let encodedSource = sourceURL.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? sourceURL
+        let encodedSource = resolvedSourceURL.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? resolvedSourceURL
         return "\(proxyBase)/\(processingOptions)/plain/\(encodedSource)\(attachmentOutputSuffix)"
     }
 
@@ -38,27 +64,27 @@ enum ImgproxyURL {
         height: Int = 100,
         resizeType: String = "fit"
     ) -> String {
-        guard !sourceURL.isEmpty else { return sourceURL }
-        if sourceURL.contains("imgproxy.mezon") {
-            return sourceURL
+        let resolvedSourceURL = secureURLString(from: sourceURL)
+        guard !resolvedSourceURL.isEmpty else { return resolvedSourceURL }
+        if resolvedSourceURL.contains("imgproxy.mezon") {
+            return resolvedSourceURL
         }
 
-        let ext = (sourceURL as NSString).pathExtension.lowercased()
-        if skipExtensions.contains(ext) {
-            return sourceURL
+        if shouldSkipProxy(resolvedSourceURL) {
+            return resolvedSourceURL
         }
 
-        guard cdnHosts.contains(where: { sourceURL.contains($0) }) else {
-            return sourceURL
+        guard cdnHosts.contains(where: { resolvedSourceURL.contains($0) }) else {
+            return resolvedSourceURL
         }
 
         let processingOptions = "rs:\(resizeType):\(width):\(height):1/mb:2097152"
-        let encodedSource = sourceURL.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? sourceURL
+        let encodedSource = resolvedSourceURL.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? resolvedSourceURL
         return "\(proxyBase)/\(processingOptions)/plain/\(encodedSource)@webp"
     }
 
     static func avatarProxyURL(from sourceURL: String, width: Int = 100, height: Int = 100) -> String {
-        let s = sourceURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let s = secureURLString(from: sourceURL)
         guard !s.isEmpty else { return s }
         if s.contains("imgproxy.mezon") {
             return s
@@ -69,8 +95,7 @@ enum ImgproxyURL {
         guard cdnHosts.contains(where: { s.contains($0) }) else {
             return s
         }
-        let ext = (s as NSString).pathExtension.lowercased()
-        if ext == "gif" {
+        if shouldSkipProxy(s) {
             return s
         }
         let w = max(1, width)
@@ -82,12 +107,16 @@ enum ImgproxyURL {
 
 
     static func createEmoji(from sourceURL: String, width: Int, height: Int, resizeType: String = "fit") -> String {
-        guard !sourceURL.isEmpty else { return sourceURL }
-        guard cdnHosts.contains(where: { sourceURL.contains($0) }) else {
-            return sourceURL
+        let resolvedSourceURL = secureURLString(from: sourceURL)
+        guard !resolvedSourceURL.isEmpty else { return resolvedSourceURL }
+        if shouldSkipProxy(resolvedSourceURL) {
+            return resolvedSourceURL
+        }
+        guard cdnHosts.contains(where: { resolvedSourceURL.contains($0) }) else {
+            return resolvedSourceURL
         }
         let processingOptions = "rs:\(resizeType):\(width):\(height):1/mb:2097152"
-        let encodedSource = sourceURL.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? sourceURL
+        let encodedSource = resolvedSourceURL.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? resolvedSourceURL
         return "\(proxyBase)/\(processingOptions)/plain/\(encodedSource)@webp"
     }
 }

--- a/MezonChat/Features/Chat/Cells/MessageFileAttachmentNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageFileAttachmentNode.swift
@@ -63,10 +63,12 @@ final class FileItemNode: ASDisplayNode {
     private let nameNode = ASTextNode2()
     private let bgNode = ASDisplayNode()
     private let spinnerNode: ASDisplayNode?
+    private let progressLabelNode: ASTextNode2?
     private let showsUploadSpinner: Bool
 
     private static let spinnerSide: CGFloat = 24
     private static let spinnerLeadingGap: CGFloat = 8
+    private static let progressLabelWidth: CGFloat = 40
 
     var onTapped: (() -> Void)?
     var tag: Int = 0
@@ -77,7 +79,9 @@ final class FileItemNode: ASDisplayNode {
 
     init(attachment: ParsedAttachment) {
         let shows = attachment.isUploading
+        let progress = attachment.uploadProgress
         let spinner: ASDisplayNode?
+        let progressLabel: ASTextNode2?
         if shows {
             let s = ASDisplayNode()
             s.isUserInteractionEnabled = false
@@ -89,11 +93,28 @@ final class FileItemNode: ASDisplayNode {
             }
             s.style.preferredSize = CGSize(width: Self.spinnerSide, height: Self.spinnerSide)
             spinner = s
+
+            if progress > 0 {
+                let label = ASTextNode2()
+                label.attributedText = NSAttributedString(
+                    string: "\(Int(progress * 100))%",
+                    attributes: [
+                        .font: UIFont.systemFont(ofSize: 12, weight: .semibold),
+                        .foregroundColor: UIColor.theme.textNormal,
+                    ]
+                )
+                label.maximumNumberOfLines = 1
+                progressLabel = label
+            } else {
+                progressLabel = nil
+            }
         } else {
             spinner = nil
+            progressLabel = nil
         }
         self.showsUploadSpinner = shows
         self.spinnerNode = spinner
+        self.progressLabelNode = progressLabel
         super.init()
 
         let t = UIColor.theme
@@ -123,6 +144,9 @@ final class FileItemNode: ASDisplayNode {
         if let spinner {
             addSubnode(spinner)
         }
+        if let progressLabelNode {
+            addSubnode(progressLabelNode)
+        }
     }
 
     override func didLoad() {
@@ -141,7 +165,8 @@ final class FileItemNode: ASDisplayNode {
         let insetTrailing: CGFloat = 14
         let insetV: CGFloat = 10
         let spacing: CGFloat = 10
-        let spinnerReserve: CGFloat = showsUploadSpinner ? Self.spinnerSide + Self.spinnerLeadingGap : 0
+        let progressReserve: CGFloat = progressLabelNode != nil ? Self.progressLabelWidth + Self.spinnerLeadingGap : 0
+        let spinnerReserve: CGFloat = showsUploadSpinner ? Self.spinnerSide + Self.spinnerLeadingGap + progressReserve : 0
         let nameMaxW = maxWidth * 0.7 - cachedIconSize.width - spacing - insetLeading - insetTrailing - spinnerReserve
 
         cachedNameSize = nameNode.measure(CGSize(width: max(nameMaxW, 50), height: .greatestFiniteMagnitude))
@@ -168,13 +193,20 @@ final class FileItemNode: ASDisplayNode {
         let nameX = iconX + cachedIconSize.width + spacing
         let spinnerW: CGFloat = showsUploadSpinner ? Self.spinnerSide : 0
         let gap: CGFloat = showsUploadSpinner ? Self.spinnerLeadingGap : 0
-        let nameAvailableW = bounds.width - nameX - insetTrailing - gap - spinnerW
+        let progressW: CGFloat = progressLabelNode != nil ? Self.progressLabelWidth : 0
+        let progressGap: CGFloat = progressLabelNode != nil ? Self.spinnerLeadingGap : 0
+        let nameAvailableW = bounds.width - nameX - insetTrailing - gap - spinnerW - progressGap - progressW
         let nameW = min(cachedNameSize.width, max(0, nameAvailableW))
         nameNode.frame = CGRect(x: nameX, y: centerY - cachedNameSize.height / 2, width: nameW, height: cachedNameSize.height)
 
         if let spinnerNode, showsUploadSpinner {
             let sx = bounds.width - insetTrailing - spinnerW
             spinnerNode.frame = CGRect(x: sx, y: centerY - spinnerW / 2, width: spinnerW, height: spinnerW)
+
+            if let progressLabelNode {
+                let px = sx - progressGap - progressW
+                progressLabelNode.frame = CGRect(x: px, y: centerY - 9, width: progressW, height: 18)
+            }
         }
     }
 

--- a/MezonChat/Features/Chat/Cells/MessageMediaContentNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageMediaContentNode.swift
@@ -60,7 +60,7 @@ final class MessageMediaContentNode: ASDisplayNode {
     private var cachedTotalSize: CGSize = .zero
     private var isSingleImage = false
     private var isSticker = false
-    private var isGifSticker = false
+    private var isAnimatedStandaloneImage = false
     private var isMultiple = false
     private var lastRemoteProxyURLByIndex: [Int: String] = [:]
 
@@ -191,14 +191,14 @@ final class MessageMediaContentNode: ASDisplayNode {
         cachedPositions = []
         isUploading = media.contains { $0.isUploading }
         isSticker = false
-        isGifSticker = false
+        isAnimatedStandaloneImage = false
         isSingleImage = false
         isMultiple = false
         guard !media.isEmpty else { return }
-        let isGifType = media.count == 1 && media[0].filetype == "image/gif"
-        if media.count == 1, media[0].isSticker || isGifType {
+        let isAnimatedType = media.count == 1 && Self.isAnimatedImageAttachment(media[0])
+        if media.count == 1, media[0].isSticker || isAnimatedType {
             isSticker = true
-            isGifSticker = isGifType && !media[0].isSticker
+            isAnimatedStandaloneImage = isAnimatedType && !media[0].isSticker
         } else if media.count == 1 {
             isSingleImage = true
         } else {
@@ -226,10 +226,10 @@ final class MessageMediaContentNode: ASDisplayNode {
         guard !media.isEmpty else { return }
 
 
-        let isGifType = media.count == 1 && media[0].filetype == "image/gif"
-        if media.count == 1, media[0].isSticker || isGifType {
+        let isAnimatedType = media.count == 1 && Self.isAnimatedImageAttachment(media[0])
+        if media.count == 1, media[0].isSticker || isAnimatedType {
             isSticker = true
-            isGifSticker = isGifType && !media[0].isSticker
+            isAnimatedStandaloneImage = isAnimatedType && !media[0].isSticker
             isSingleImage = false
             isMultiple = false
             let node = ASDisplayNode()
@@ -241,7 +241,7 @@ final class MessageMediaContentNode: ASDisplayNode {
             }
             stickerNode = node
             addSubnode(node)
-            loadStickerImage(url: media[0].url, into: node)
+            loadStickerImage(media: media[0], into: node)
         } else if media.count == 1 {
             isSticker = false
             isSingleImage = true
@@ -264,7 +264,7 @@ final class MessageMediaContentNode: ASDisplayNode {
                 addSubnode(overlay)
             }
             if media[0].isUploading {
-                let overlay = makeUploadingOverlay()
+                let overlay = makeUploadingOverlay(progress: media[0].uploadProgress)
                 videoOverlayNodes.append(overlay)
                 addSubnode(overlay)
             }
@@ -296,7 +296,7 @@ final class MessageMediaContentNode: ASDisplayNode {
                     videoOverlayNodes.append(overlay)
                     addSubnode(overlay)
                 } else if att.isUploading {
-                    let overlay = makeUploadingOverlay()
+                    let overlay = makeUploadingOverlay(progress: att.uploadProgress)
                     videoOverlayNodes.append(overlay)
                     addSubnode(overlay)
                 } else if att.uploadFailed {
@@ -317,7 +317,7 @@ final class MessageMediaContentNode: ASDisplayNode {
         cachedImageFrames = []
 
         if isSticker {
-            if isGifSticker {
+            if isAnimatedStandaloneImage {
                 let att = attachments[0]
                 let hasSize = (att.width ?? 0) > 0 && (att.height ?? 0) > 0
                 if hasSize {
@@ -457,11 +457,35 @@ final class MessageMediaContentNode: ASDisplayNode {
     }
 
 
-    private func loadStickerImage(url: String, into node: ASDisplayNode) {
+    private static func isAnimatedImageAttachment(_ attachment: ParsedAttachment) -> Bool {
+        let filetype = attachment.filetype
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let mime = filetype.split(separator: ";", maxSplits: 1).first
+            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) } ?? filetype
+        if mime == "image/gif" || mime == "image/webp" || mime == "gif" || mime == "webp" {
+            return true
+        }
+        return ["gif", "webp"].contains(pathExtension(from: attachment.filename))
+            || ["gif", "webp"].contains(pathExtension(from: attachment.url))
+    }
+
+    private static func pathExtension(from value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "" }
+        if let components = URLComponents(string: trimmed), !components.path.isEmpty {
+            return (components.path as NSString).pathExtension.lowercased()
+        }
+        return (trimmed as NSString).pathExtension.lowercased()
+    }
+
+    private func loadStickerImage(media: ParsedAttachment, into node: ASDisplayNode) {
+        let url = ImgproxyURL.secureURLString(from: media.url)
         guard let imageURL = URL(string: url), !url.isEmpty else { return }
+        let isAnimatedImage = Self.isAnimatedImageAttachment(media)
 
         if let cachedData = ImageCache.shared.cachedData(forKey: url) {
-            if let animated = UIImage.animatedImage(from: cachedData) {
+            if let animated = UIImage.animatedImage(from: cachedData) ?? UIImage.decodeImage(from: cachedData) {
                 DispatchQueue.main.async {
                     (node.view as? UIImageView)?.image = animated
                 }
@@ -472,18 +496,22 @@ final class MessageMediaContentNode: ASDisplayNode {
             DispatchQueue.main.async {
                 (node.view as? UIImageView)?.image = cached
             }
-            return
+            if !isAnimatedImage || (cached.images?.count ?? 0) > 1 {
+                return
+            }
         }
 
         URLSession.shared.dataTask(with: imageURL) { data, _, error in
             if let error {
                 SentryLogger.captureMediaError(error, extras: [
-                    "where": "MessageMediaContentNode.loadImage",
+                    "where": "MessageMediaContentNode.loadStickerImage",
                     "url": url,
                 ])
             }
             guard let data else { return }
-            let image = UIImage.animatedImage(from: data) ?? UIImage.decodeImage(from: data)
+            let image = isAnimatedImage
+                ? (UIImage.animatedImage(from: data) ?? UIImage.decodeImage(from: data))
+                : UIImage.decodeImage(from: data)
             if let image {
                 ImageCache.shared.setImage(image, data: data, forKey: url)
                 DispatchQueue.main.async {
@@ -560,7 +588,7 @@ final class MessageMediaContentNode: ASDisplayNode {
         return imageNodes[index].image
     }
 
-    private func makeUploadingOverlay() -> ASDisplayNode {
+    private func makeUploadingOverlay(progress: Double = 0) -> ASDisplayNode {
         let overlay = ASDisplayNode()
         overlay.backgroundColor = UIColor.black.withAlphaComponent(0.4)
         overlay.cornerRadius = 8.swh
@@ -577,8 +605,28 @@ final class MessageMediaContentNode: ASDisplayNode {
         spinner.style.preferredSize = CGSize(width: 36, height: 36)
         overlay.addSubnode(spinner)
 
-        overlay.layoutSpecBlock = { _, _ in
-            ASCenterLayoutSpec(centeringOptions: .XY, sizingOptions: [], child: spinner)
+        if progress > 0 {
+            let label = ASTextNode2()
+            label.attributedText = NSAttributedString(
+                string: "\(Int(progress * 100))%",
+                attributes: [
+                    .font: UIFont.systemFont(ofSize: 13, weight: .semibold),
+                    .foregroundColor: UIColor.white,
+                ]
+            )
+            label.maximumNumberOfLines = 1
+            overlay.addSubnode(label)
+            overlay.layoutSpecBlock = { _, _ in
+                let stack = ASStackLayoutSpec.vertical()
+                stack.spacing = 6
+                stack.horizontalAlignment = .middle
+                stack.children = [spinner, label]
+                return ASCenterLayoutSpec(centeringOptions: .XY, sizingOptions: [], child: stack)
+            }
+        } else {
+            overlay.layoutSpecBlock = { _, _ in
+                ASCenterLayoutSpec(centeringOptions: .XY, sizingOptions: [], child: spinner)
+            }
         }
 
         return overlay

--- a/MezonChat/Features/Chat/Cells/MessageReplyNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageReplyNode.swift
@@ -80,12 +80,14 @@ final class MessageReplyNode: ASDisplayNode {
         )
 
         let isAnonymous = ref.messageSenderID == MezonConstants.anonymousUserId
+        let isSystemSender = Self.isSystemSender(ref)
 
         if isAnonymous {
             hasAvatar = true
             avatarPlaceholderNode.isHidden = true
             avatarImageNode.isHidden = false
             avatarImageNode.url = nil
+            avatarImageNode.contentMode = .scaleAspectFit
             avatarImageNode.backgroundColor = UIColor.theme.tertiary
             
             if let raw = UIImage(named: "Chat/AnonymousIcon") {
@@ -107,11 +109,24 @@ final class MessageReplyNode: ASDisplayNode {
             avatarContainerNode.removeFromSupernode()
             avatarPlaceholderNode.removeFromSupernode()
             if avatarImageNode.supernode == nil { addSubnode(avatarImageNode) }
+        } else if isSystemSender, let logo = Self.systemAvatarImage() {
+            hasAvatar = true
+            avatarPlaceholderNode.isHidden = true
+            avatarImageNode.isHidden = false
+            avatarImageNode.url = nil
+            avatarImageNode.image = logo
+            avatarImageNode.contentMode = .scaleAspectFit
+            avatarImageNode.backgroundColor = .clear
+            avatarContainerNode.removeFromSupernode()
+            avatarPlaceholderNode.removeFromSupernode()
+            if avatarImageNode.supernode == nil { addSubnode(avatarImageNode) }
         } else if !ref.messageSenderAvatar.isEmpty, let url = URL(string: ref.messageSenderAvatar) {
             hasAvatar = true
             avatarPlaceholderNode.isHidden = true
             avatarImageNode.isHidden = false
+            avatarImageNode.image = nil
             avatarImageNode.url = url
+            avatarImageNode.contentMode = .scaleAspectFill
             avatarImageNode.backgroundColor = UIColor.theme.primary
             avatarContainerNode.removeFromSupernode()
             avatarPlaceholderNode.removeFromSupernode()
@@ -221,6 +236,25 @@ final class MessageReplyNode: ASDisplayNode {
 
     private static func isShareContactValue(_ value: String) -> Bool {
         value == MezonConstants.shareContactKey || value == "share_contact_key"
+    }
+
+    private static func isSystemSender(_ ref: Mezon_Api_MessageRef) -> Bool {
+        guard ref.messageSenderID == 0 else { return false }
+        let senderNames = [
+            ref.messageSenderUsername,
+            ref.messageSenderDisplayName,
+            ref.messageSenderClanNick
+        ]
+        return senderNames.contains { name in
+            name.trimmingCharacters(in: .whitespacesAndNewlines)
+                .localizedCaseInsensitiveCompare("System") == .orderedSame
+        }
+    }
+
+    private static func systemAvatarImage() -> UIImage? {
+        UIImage(named: "NewMezonLogo")
+            ?? UIImage(named: "Setting/LogoMezon")
+            ?? UIImage(named: "MezonLogo")
     }
 
     func measureSize(maxWidth: CGFloat) -> CGSize {

--- a/MezonChat/Features/Chat/ChatContainerNode.swift
+++ b/MezonChat/Features/Chat/ChatContainerNode.swift
@@ -556,7 +556,7 @@ final class ChatContainerNode: ASDisplayNode {
     private static func listFingerprint(_ m: ChatMessageDisplay) -> String {
         let edited = m.message.editedAt.map { String($0.timeIntervalSince1970) } ?? ""
         let att = m.attachments
-            .map { "\($0.url)|\($0.filename)|\($0.filetype)|\($0.isUploading)" }
+            .map { "\($0.url)|\($0.filename)|\($0.filetype)|\($0.isUploading)|\(Int($0.uploadProgress * 100))" }
             .joined(separator: ";")
         let grouping = [
             m.isCombine ? "1" : "0",

--- a/MezonChat/Features/Chat/ChatViewController.swift
+++ b/MezonChat/Features/Chat/ChatViewController.swift
@@ -25,6 +25,8 @@ struct ParsedAttachment: Equatable {
     var localImage: UIImage?
     var isUploading: Bool = false
     var uploadFailed: Bool = false
+    var uploadProgress: Double = 0
+    var uploadProgressKey: String = ""
 
     var isImage: Bool {
         filetype.hasPrefix("image/") || filetype == "sticker"
@@ -62,6 +64,7 @@ struct ParsedAttachment: Equatable {
             && lhs.width == rhs.width && lhs.height == rhs.height && lhs.durationSeconds == rhs.durationSeconds
             && lhs.thumbnail == rhs.thumbnail
             && lhs.isUploading == rhs.isUploading && lhs.uploadFailed == rhs.uploadFailed
+            && lhs.uploadProgress == rhs.uploadProgress
     }
 
     private static let maxPendingCacheEntries = 50
@@ -453,6 +456,8 @@ final class ChatViewController: ViewController {
     private var hasPerformedInitialUnreadScroll = false
     private var pendingSendingFeedbackBeganAtByMessageId: [String: Date] = [:]
     private var sendingFeedbackRefreshWorkItem: DispatchWorkItem?
+    private var attachmentProgressReloadWorkItem: DispatchWorkItem?
+    private static let attachmentProgressReloadInterval: TimeInterval = 0.25
 
     private struct RemoteTyperState {
         var displayName: String
@@ -865,6 +870,7 @@ final class ChatViewController: ViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(handleMessageTypingReceived(_:)), name: .mezonMessageTypingReceived, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleNetworkStatusChanged(_:)), name: NetworkMonitor.statusDidChangeNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleChannelPinsNeedRefresh(_:)), name: .mezonChannelPinsNeedRefresh, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleAttachmentUploadProgress(_:)), name: .mezonAttachmentUploadProgress, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleChannelMetadataChanged(_:)), name: .mezonChannelDescriptionDidUpdate, object: nil)
     }
 
@@ -1332,6 +1338,24 @@ final class ChatViewController: ViewController {
         let t = UIColor.theme
         remoteTypingStripView.backgroundColor = t.primaryGradient
         remoteTypingLabel.textColor = t.textDisabled
+    }
+
+    @objc private func handleAttachmentUploadProgress(_ notification: Notification) {
+        guard let key = notification.userInfo?["key"] as? String, !key.isEmpty else { return }
+        let isRelevant = ParsedAttachment.pendingDocumentPlaceholders.values
+            .contains { docs in docs.contains { $0.uploadProgressKey == key } }
+            || AttachmentUploadCoordinator.shared.hasActiveProgressKey(key)
+        guard isRelevant else { return }
+        guard attachmentProgressReloadWorkItem == nil else { return }
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.attachmentProgressReloadWorkItem = nil
+            self.reloadDisplaysForPendingSendingFeedback()
+            self.needsReloadPipe.putNext(())
+        }
+        attachmentProgressReloadWorkItem = workItem
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + Self.attachmentProgressReloadInterval, execute: workItem)
     }
 
     @objc private func handleChannelPinsNeedRefresh(_ notification: Notification) {
@@ -2391,7 +2415,7 @@ final class ChatViewController: ViewController {
     private static func messageUpdateToken(_ m: ChatMessageDisplay) -> String {
         let edited = m.message.editedAt.map { String($0.timeIntervalSince1970) } ?? ""
         let att = m.attachments
-            .map { "\($0.url)|\($0.filename)|\($0.filetype)|\($0.isUploading)" }
+            .map { "\($0.url)|\($0.filename)|\($0.filetype)|\($0.isUploading)|\(Int($0.uploadProgress * 100))" }
             .joined(separator: ";")
         let pin = m.message.isPinned ? "1" : "0"
         let pollHash: String
@@ -2658,7 +2682,11 @@ final class ChatViewController: ViewController {
                                 height: doc.height,
                                 durationSeconds: doc.durationSeconds,
                                 localImage: doc.localImage,
-                                isUploading: stillUploading
+                                isUploading: stillUploading,
+                                uploadProgress: doc.uploadProgressKey.isEmpty
+                                    ? doc.uploadProgress
+                                    : AttachmentUploadProgressStore.shared.progress(forKey: doc.uploadProgressKey),
+                                uploadProgressKey: doc.uploadProgressKey
                             )
                         })
                     }

--- a/MezonChat/Features/PeerCall/PeerWebRTCCallSession.swift
+++ b/MezonChat/Features/PeerCall/PeerWebRTCCallSession.swift
@@ -211,13 +211,8 @@ final class PeerWebRTCCallSession: NSObject {
         self.pendingOfferCompressed = initialCompressedOffer
         self.signalingDestinationUserId = peerUserId
         super.init()
-        print("[DMCall:INIT] direction=\(direction) ch=\(channelId) my=\(myUserId) peer=\(peerUserId) wantsVideo=\(wantsVideo) hasOffer=\(initialCompressedOffer?.isEmpty == false)")
     }
 
-    private func callLog(_ msg: String) {
-        let dir = direction == .outgoing ? "OUT" : "IN"
-        print("[DMCall:\(dir)] ch=\(channelId) my=\(myUserId) peer=\(peerUserId) | \(msg)")
-    }
 
     private func setPreWarmingNoSignal(_ value: Bool) {
         isPreWarmingNoSignal = value
@@ -256,9 +251,7 @@ final class PeerWebRTCCallSession: NSObject {
     }
 
     private func sendRealtimePeerSignaling(receiverId: Int64, dataType: Int32, jsonData: String) {
-        callLog("sendRealtimePeerSignaling dataType=\(dataType) to=\(receiverId) isPreWarming=\(isPreWarmingNoSignal)")
         if isPreWarmingNoSignal && dataType != WebRTCSignalingDataType.sdpQuit {
-            callLog("sendRealtimePeerSignaling deferred (preWarming) dataType=\(dataType)")
             deferredOutgoingSignaling.append((receiverId, dataType, jsonData))
             return
         }
@@ -286,7 +279,6 @@ final class PeerWebRTCCallSession: NSObject {
     }
 
     func beginOutgoingCall() {
-        callLog("beginOutgoingCall wantsVideo=\(wantsVideo)")
         onStatusLabel?(direction == .outgoing ? PeerCallLocalizedStrings.statusRinging : "")
         beginOutgoingCallTask?.cancel()
         beginOutgoingCallTask = Task { @MainActor [weak self] in
@@ -393,7 +385,6 @@ final class PeerWebRTCCallSession: NSObject {
     }
 
     func answerIncomingCall() {
-        callLog("answerIncomingCall incomingAnswerFlowStarted=\(incomingAnswerFlowStarted) isAnswerPrepared=\(isAnswerPrepared) hasOffer=\(pendingOfferCompressed?.isEmpty == false)")
         guard !incomingAnswerFlowStarted else { return }
         incomingAnswerFlowStarted = true
         cancelIncomingRingTimer()
@@ -435,12 +426,10 @@ final class PeerWebRTCCallSession: NSObject {
     }
 
     func prepareIncomingAnswerInBackground() async throws {
-        callLog("prepareIncomingAnswerInBackground ended=\(ended) isAnswerPrepared=\(isAnswerPrepared) hasPc=\(peerConnection != nil) preWarmInFlight=\(preWarmInFlight) hasOffer=\(pendingOfferCompressed?.isEmpty == false)")
         guard !ended, !isAnswerPrepared, peerConnection == nil, !preWarmInFlight else { return }
         guard direction == .incoming else { return }
         guard let offerCompressed = pendingOfferCompressed?.trimmingCharacters(in: .whitespacesAndNewlines),
               !offerCompressed.isEmpty else {
-            callLog("prepareIncomingAnswerInBackground skipped: no offer")
             return
         }
 
@@ -449,10 +438,8 @@ final class PeerWebRTCCallSession: NSObject {
         do {
             try await performPreWarmBuild(offerCompressed: offerCompressed)
             preWarmInFlight = false
-            callLog("prepareIncomingAnswerInBackground done isAnswerPrepared=\(isAnswerPrepared)")
         } catch {
             preWarmInFlight = false
-            callLog("prepareIncomingAnswerInBackground failed: \(error)")
             resetAfterFailedPreWarm()
             throw error
         }
@@ -540,7 +527,6 @@ final class PeerWebRTCCallSession: NSObject {
     }
 
     private func sendPreparedAnswerAndGoActive() throws {
-        callLog("sendPreparedAnswerAndGoActive hasPc=\(peerConnection != nil) hasPreparedAnswer=\(preparedAnswerCompressed != nil)")
         try ensureCallStillActive()
         guard let pc = peerConnection else {
             throw PeerWebRTCCallSessionError.peerConnectionCreateFailed
@@ -613,7 +599,6 @@ final class PeerWebRTCCallSession: NSObject {
     }
 
     func declineIncoming() {
-        callLog("declineIncoming")
         cancelIncomingRingTimer()
         PeerCallSoundPlayer.shared.stopRinging()
         finishCall(sendQuit: true)
@@ -621,14 +606,11 @@ final class PeerWebRTCCallSession: NSObject {
 
     func handleIncomingSignaling(_ msg: Mezon_Realtime_WebrtcSignalingFwd) {
         guard msg.channelID == channelId else {
-            callLog("handleIncomingSignaling ignored: channelId mismatch msg.ch=\(msg.channelID)")
             return
         }
         guard signalingMessageTargetsThisSession(msg) else {
-            callLog("handleIncomingSignaling ignored: not targeting this session caller=\(msg.callerID) receiver=\(msg.receiverID)")
             return
         }
-        callLog("handleIncomingSignaling dataType=\(msg.dataType) from=\(msg.callerID) phase=\(phase)")
 
         switch msg.dataType {
         case WebRTCSignalingDataType.sdpOffer:
@@ -638,54 +620,43 @@ final class PeerWebRTCCallSession: NSObject {
                     let next = msg.jsonData.trimmingCharacters(in: .whitespacesAndNewlines)
                     if !next.isEmpty {
                         pendingOfferCompressed = next
-                        callLog("handleIncomingSignaling sdpOffer stored (ringing)")
                     }
-                } else {
-                    callLog("handleIncomingSignaling sdpOffer ignored: already have offer (ringing)")
                 }
                 return
             }
-            callLog("handleIncomingSignaling sdpOffer -> renegotiation")
             Task {
                 await handleRenegotiationOffer(msg.jsonData)
             }
         case WebRTCSignalingDataType.sdpAnswer:
-            callLog("handleIncomingSignaling sdpAnswer received")
             Task {
                 await applyCompressedAnswer(msg.jsonData)
             }
         case WebRTCSignalingDataType.iceCandidate:
-            callLog("handleIncomingSignaling iceCandidate hasPc=\(peerConnection != nil)")
             Task {
                 await queueOrApplyIce(msg.jsonData)
             }
         case WebRTCSignalingDataType.sdpStatusRemoteMedia:
             guard msg.callerID == peerUserId else { return }
-            callLog("handleIncomingSignaling sdpStatusRemoteMedia json=\(msg.jsonData)")
             applyRemoteMediaWire(msg.jsonData)
         case WebRTCSignalingDataType.sdpJoinedOtherCall:
-            callLog("handleIncomingSignaling sdpJoinedOtherCall -> finishCall")
             if !didEstablishMediaConnection {
                 remoteQuitBeforeConnect = true
                 onStatusLabel?(PeerCallLocalizedStrings.statusBusyOnAnotherCall)
             }
             finishCall(sendQuit: false)
         case WebRTCSignalingDataType.sdpNotAvailable:
-            callLog("handleIncomingSignaling sdpNotAvailable -> finishCall")
             if !didEstablishMediaConnection {
                 remoteQuitBeforeConnect = true
                 onStatusLabel?(PeerCallLocalizedStrings.statusUserOffline)
             }
             finishCall(sendQuit: false)
         case WebRTCSignalingDataType.sdpTimeout:
-            callLog("handleIncomingSignaling sdpTimeout -> finishCall")
             if !didEstablishMediaConnection {
                 ringTimeoutFired = true
                 onStatusLabel?(PeerCallLocalizedStrings.statusNoAnswer)
             }
             finishCall(sendQuit: false)
         case WebRTCSignalingDataType.sdpQuit:
-            callLog("handleIncomingSignaling sdpQuit didEstablishMedia=\(didEstablishMediaConnection) -> finishCall")
             if !didEstablishMediaConnection {
                 remoteQuitBeforeConnect = true
                 onStatusLabel?(PeerCallLocalizedStrings.statusRemoteDeclined)
@@ -694,16 +665,13 @@ final class PeerWebRTCCallSession: NSObject {
             }
             finishCall(sendQuit: false)
         case WebRTCSignalingDataType.clearCall:
-            callLog("handleIncomingSignaling clearCall -> finishCall")
             finishCall(sendQuit: false)
         default:
-            callLog("handleIncomingSignaling unhandled dataType=\(msg.dataType)")
             break
         }
     }
 
     func hangUp() {
-        callLog("hangUp ended=\(ended)")
         finishCall(sendQuit: true)
     }
 
@@ -796,7 +764,6 @@ final class PeerWebRTCCallSession: NSObject {
                 }
             }
         } catch {
-            callLog("enableCameraMidCall FAILED error=\(error)")
             videoCapturer?.stopCapture(completionHandler: {})
             localVideoTrack?.isEnabled = false
             localCameraEnabled = false
@@ -846,7 +813,6 @@ final class PeerWebRTCCallSession: NSObject {
     }
 
     private func finishCall(sendQuit: Bool) {
-        callLog("finishCall sendQuit=\(sendQuit) alreadyEnded=\(ended) direction=\(direction) didEstablishMedia=\(didEstablishMediaConnection) remoteQuitBeforeConnect=\(remoteQuitBeforeConnect) ringTimeoutFired=\(ringTimeoutFired) connectTimeoutFired=\(connectTimeoutFired)")
         guard !ended else { return }
         ended = true
         clearPreWarmDeferralPipeline()
@@ -898,7 +864,6 @@ final class PeerWebRTCCallSession: NSObject {
             ]
             if let data = try? JSONSerialization.data(withJSONObject: body),
                let s = String(data: data, encoding: .utf8) {
-                print("[CallKitDebug] finishCall sending CANCEL_CALL push receiverId=\(peerUserId) callerId=\(myUserId) channelId=\(channelId)")
                 MezonSocket.shared.makeCallPush(
                     receiverId: peerUserId,
                     jsonData: s,
@@ -1234,7 +1199,6 @@ final class PeerWebRTCCallSession: NSObject {
     }
 
     private func startOutgoingPeerConnection() async throws {
-        callLog("startOutgoingPeerConnection wantsVideo=\(wantsVideo)")
         try ensureCallStillActive()
         Self.ensureSSL()
         let factory = Self.makePeerConnectionFactory()
@@ -1311,7 +1275,6 @@ final class PeerWebRTCCallSession: NSObject {
             throw PeerWebRTCCallSessionError.encodingFailed
         }
 
-        callLog("startOutgoingPeerConnection offer+push sent to peer=\(peerUserId)")
         MezonSocket.shared.makeCallPush(
             receiverId: peerUserId,
             jsonData: pushJson,
@@ -1335,10 +1298,8 @@ final class PeerWebRTCCallSession: NSObject {
     }
 
     private func buildIncomingPeerConnectionAndAnswer() async throws {
-        callLog("buildIncomingPeerConnectionAndAnswer start hasOffer=\(pendingOfferCompressed?.isEmpty == false)")
         try ensureCallStillActive()
         guard let offerCompressed = pendingOfferCompressed, !offerCompressed.isEmpty else {
-            callLog("buildIncomingPeerConnectionAndAnswer failed: no offer")
             throw PeerWebRTCCallSessionError.missingSDP
         }
 
@@ -1398,7 +1359,6 @@ final class PeerWebRTCCallSession: NSObject {
         let answerJson = try answerJSONString(from: localSDP)
         let compressedAnswer = try PeerWebRTCStringCompression.gzipCompressUtf8(answerJson)
 
-        callLog("buildIncomingPeerConnectionAndAnswer sending answer offerHasVideo=\(offerHasVideo)")
         sendRealtimePeerSignaling(
             receiverId: peerUserId,
             dataType: WebRTCSignalingDataType.sdpAnswer,
@@ -1416,7 +1376,6 @@ final class PeerWebRTCCallSession: NSObject {
         scanTransceiversForRemoteVideo()
         scheduleDeferredRemoteVideoScan()
         scheduleRemoteVideoPostConnectWork()
-        callLog("buildIncomingPeerConnectionAndAnswer done -> phase=active")
     }
 
     private func offerJSONString(from sd: LKRTCSessionDescription) throws -> String {
@@ -1669,7 +1628,6 @@ final class PeerWebRTCCallSession: NSObject {
         guard let data = try? JSONSerialization.data(withJSONObject: body),
               let jsonData = String(data: data, encoding: .utf8)
         else { return }
-        callLog("makeCallPush CANCEL_CALL isConnected=true receiverId=\(peerUserId) callerId=\(myUserId) channelId=\(channelId)")
         MezonSocket.shared.makeCallPush(
             receiverId: peerUserId,
             jsonData: jsonData,
@@ -1681,7 +1639,6 @@ final class PeerWebRTCCallSession: NSObject {
     private func postConnectedStatusToUIIfNeeded() {
         guard !didPostConnectedStatusToUI else { return }
         guard !ended else { return }
-        callLog("postConnectedStatusToUIIfNeeded -> posting connected")
         didPostConnectedStatusToUI = true
         let mediaConnectedAt = Date()
         onCallMediaConnectedAt?(mediaConnectedAt)
@@ -2036,16 +1993,15 @@ extension PeerWebRTCCallSession: LKRTCPeerConnectionDelegate {
     nonisolated func peerConnection(_: LKRTCPeerConnection, didChange state: LKRTCPeerConnectionState) {
         if preWarmBackgroundIceFlag.get() { return }
         Task { @MainActor in
-            callLog("peerConnection didChange PeerConnectionState=\(state.rawValue)")
             switch state {
             case .connected:
                 peerConnectionReportedConnectedForUI = true
+                sendConnectedOutgoingCallerCancelPushIfNeeded()
                 tryPresentFullyConnectedCallUI()
                 scanTransceiversForRemoteVideo()
                 scheduleDeferredRemoteVideoScan()
                 scheduleRemoteVideoPostConnectWork()
             case .failed:
-                callLog("peerConnection PeerConnectionState=failed direction=\(direction) didEstablishMedia=\(didEstablishMediaConnection)")
                 if direction == .outgoing && !didEstablishMediaConnection {
                     onStatusLabel?(PeerCallLocalizedStrings.statusCouldNotConnect)
                     return
@@ -2060,7 +2016,6 @@ extension PeerWebRTCCallSession: LKRTCPeerConnectionDelegate {
     nonisolated func peerConnection(_: LKRTCPeerConnection, didChange state: LKRTCIceConnectionState) {
         if preWarmBackgroundIceFlag.get() { return }
         Task { @MainActor in
-            callLog("peerConnection didChange IceConnectionState=\(state.rawValue)")
             switch state {
             case .connected, .completed:
                 disconnectRecoveryTask?.cancel()
@@ -2088,15 +2043,12 @@ extension PeerWebRTCCallSession: LKRTCPeerConnectionDelegate {
                 scheduleDeferredRemoteVideoScan()
                 scheduleRemoteVideoPostConnectWork()
             case .checking:
-                callLog("peerConnection IceConnectionState=checking")
                 PeerCallSoundPlayer.shared.stopDialTone()
                 onNetworkBanner?(PeerCallLocalizedStrings.statusConnecting)
             case .disconnected:
-                callLog("peerConnection IceConnectionState=disconnected -> scheduleDisconnectRecovery")
                 onNetworkBanner?(PeerCallLocalizedStrings.bannerWeakNetwork)
                 scheduleDisconnectRecoveryIfNeeded()
             case .failed:
-                callLog("peerConnection IceConnectionState=failed direction=\(direction) didEstablishMedia=\(didEstablishMediaConnection)")
                 if direction == .outgoing && !didEstablishMediaConnection {
                     onStatusLabel?(PeerCallLocalizedStrings.statusCouldNotConnect)
                     return

--- a/MezonChat/Features/SendMessageInput/AttachmentUploadCoordinator.swift
+++ b/MezonChat/Features/SendMessageInput/AttachmentUploadCoordinator.swift
@@ -97,6 +97,18 @@ final class AttachmentUploadCoordinator {
         return Set(sessionsByKey.keys)
     }
 
+    /// True if any active upload session has an item whose file is the given
+    /// progress key, so the chat view knows a progress notification for that
+    /// key should trigger a reload.
+    func hasActiveProgressKey(_ key: String) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        for session in sessionsByKey.values {
+            if session.items.contains(where: { $0.fileURL?.path == key }) { return true }
+            if session.params.files.contains(where: { $0.url.path == key }) { return true }
+        }
+        return false
+    }
+
     func pruneSessions(keepingMessageIds keep: Set<String>) {
         lock.lock(); defer { lock.unlock() }
         sessionsByKey = sessionsByKey.filter { keep.contains($0.key) }
@@ -130,7 +142,11 @@ final class AttachmentUploadCoordinator {
                     durationSeconds: nil,
                     localImage: item.image,
                     isUploading: true,
-                    uploadFailed: false
+                    uploadFailed: false,
+                    uploadProgress: item.fileURL.map {
+                        AttachmentUploadProgressStore.shared.progress(forKey: $0.path)
+                    } ?? 0,
+                    uploadProgressKey: item.fileURL?.path ?? ""
                 )
             case .failed:
                 return ParsedAttachment(
@@ -430,24 +446,41 @@ final class AttachmentUploadCoordinator {
     @MainActor
     private func uploadFiles(_ session: ImageUploadSession, context: AccountContext, token: String) async {
         for file in session.params.files {
-            guard let size = await Self.fileSize(of: file.url) else { continue }
+            guard FileManager.default.fileExists(atPath: file.url.path),
+                  let size = await Self.fileSize(of: file.url) else {
+                AttachmentUploadProgressStore.shared.clear(forKey: file.url.path)
+                SentryLogger.capture(
+                    NSError(domain: "AttachmentUpload", code: -1,
+                            userInfo: [NSLocalizedDescriptionKey: "Picked file missing before upload"]),
+                    extras: [
+                        "where": "AttachmentUploadCoordinator.uploadFiles.missingFile",
+                        "filename": file.filename,
+                        "path": file.url.path,
+                    ])
+                continue
+            }
             let sanitized = file.filename.replacingOccurrences(
                 of: "[^a-zA-Z0-9._-]", with: "_", options: .regularExpression)
+            let progressKey = file.url.path
             do {
-                let uploadInfo = try await context.account.network.uploadAttachmentFile(
-                    filename: sanitized, filetype: file.filetype, size: size,
-                    width: 0, height: 0, token: token)
-                try await context.account.network.uploadToMinIO(
-                    url: uploadInfo.url, fileURL: file.url, contentType: file.filetype)
-                let cdnURL = "\(MezonConfig.baseImgURL)/\(uploadInfo.filename)"
+                let uploaded = try await AttachmentUploader.shared.uploadFile(
+                    fileURL: file.url,
+                    filename: sanitized,
+                    filetype: file.filetype,
+                    fileSize: size,
+                    token: token,
+                    progressKey: progressKey,
+                    network: context.account.network)
                 var att = Mezon_Api_MessageAttachment()
                 att.filename = file.filename
-                att.url = cdnURL
+                att.url = uploaded.cdnURL
                 att.filetype = file.filetype
                 att.size = Int32(size)
                 session.fileAttachments.append(att)
+                AttachmentUploadProgressStore.shared.clear(forKey: progressKey)
                 try? FileManager.default.removeItem(at: file.url)
             } catch {
+                AttachmentUploadProgressStore.shared.clear(forKey: progressKey)
                 SentryLogger.capture(error, extras: [
                     "where": "AttachmentUploadCoordinator.uploadFiles",
                     "filename": file.filename,
@@ -483,12 +516,19 @@ final class AttachmentUploadCoordinator {
 
             if isVideo {
                 guard let size = await Self.fileSize(of: fileURL) else { return nil }
-                let uploadInfo = try await context.account.network.uploadAttachmentFile(
-                    filename: sanitized, filetype: filetype, size: size,
-                    width: width, height: height, token: token)
-                try await context.account.network.uploadToMinIO(
-                    url: uploadInfo.url, fileURL: fileURL, contentType: filetype)
-                att.url = "\(MezonConfig.baseImgURL)/\(uploadInfo.filename)"
+                let progressKey = fileURL.path
+                let uploaded = try await AttachmentUploader.shared.uploadFile(
+                    fileURL: fileURL,
+                    filename: sanitized,
+                    filetype: filetype,
+                    fileSize: size,
+                    width: width,
+                    height: height,
+                    token: token,
+                    progressKey: progressKey,
+                    network: context.account.network)
+                AttachmentUploadProgressStore.shared.clear(forKey: progressKey)
+                att.url = uploaded.cdnURL
                 att.size = Int32(size)
                 att.thumbnail = await uploadVideoThumbnail(
                     image, originalFilename: sanitized, context: context, token: token)

--- a/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
+++ b/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
@@ -4536,7 +4536,6 @@ final class SendMessageInputViewController: UIViewController {
 
         for (index, image) in images.enumerated() {
             guard let fileURL = fileURLs[index] else { continue }
-            guard let fileData = try? Data(contentsOf: fileURL) else { continue }
 
             let originalFilename = fileURL.lastPathComponent
             let ext = fileURL.pathExtension.lowercased()
@@ -4546,6 +4545,37 @@ final class SendMessageInputViewController: UIViewController {
             let height = Int(image.size.height)
 
             let sanitizedFilename = originalFilename.replacingOccurrences(of: "[^a-zA-Z0-9._-]", with: "_", options: .regularExpression)
+
+            if filetype.hasPrefix("video/") {
+                let size = (try? FileManager.default.attributesOfItem(atPath: fileURL.path)[.size] as? NSNumber)?.intValue ?? 0
+                guard size > 0 else { continue }
+                let progressKey = fileURL.path
+                let uploaded = try await AttachmentUploader.shared.uploadFile(
+                    fileURL: fileURL,
+                    filename: sanitizedFilename,
+                    filetype: filetype,
+                    fileSize: size,
+                    width: width,
+                    height: height,
+                    token: token,
+                    progressKey: progressKey,
+                    network: context.account.network)
+                AttachmentUploadProgressStore.shared.clear(forKey: progressKey)
+
+                var att = Mezon_Api_MessageAttachment()
+                att.filename = originalFilename
+                att.url = uploaded.cdnURL
+                att.filetype = filetype
+                att.size = Int32(size)
+                att.width = Int32(width)
+                att.height = Int32(height)
+                attachments.append(att)
+
+                try? FileManager.default.removeItem(at: fileURL)
+                continue
+            }
+
+            guard let fileData = try? Data(contentsOf: fileURL) else { continue }
 
             let uploadInfo = try await context.account.network.uploadAttachmentFile(
                 filename: sanitizedFilename,
@@ -4564,9 +4594,7 @@ final class SendMessageInputViewController: UIViewController {
 
             let cdnURL = "\(MezonConfig.baseImgURL)/\(uploadInfo.filename)"
 
-            if !filetype.hasPrefix("video/") {
-                ImageCache.shared.setImage(image, data: fileData, forKey: cdnURL)
-            }
+            ImageCache.shared.setImage(image, data: fileData, forKey: cdnURL)
 
             var att = Mezon_Api_MessageAttachment()
             att.filename = originalFilename
@@ -4587,32 +4615,30 @@ final class SendMessageInputViewController: UIViewController {
         var attachments: [Mezon_Api_MessageAttachment] = []
 
         for file in files {
-            guard let fileData = try? Data(contentsOf: file.url) else { continue }
+            let size: Int = {
+                if file.filesize > 0 { return file.filesize }
+                return (try? FileManager.default.attributesOfItem(atPath: file.url.path)[.size] as? NSNumber)?.intValue ?? 0
+            }()
+            guard size > 0 else { continue }
 
             let sanitizedFilename = file.filename.replacingOccurrences(of: "[^a-zA-Z0-9._-]", with: "_", options: .regularExpression)
+            let progressKey = file.url.path
 
-            let uploadInfo = try await context.account.network.uploadAttachmentFile(
+            let uploaded = try await AttachmentUploader.shared.uploadFile(
+                fileURL: file.url,
                 filename: sanitizedFilename,
                 filetype: file.filetype,
-                size: fileData.count,
-                width: 0,
-                height: 0,
-                token: token
-            )
-
-            try await context.account.network.uploadToMinIO(
-                url: uploadInfo.url,
-                data: fileData,
-                contentType: file.filetype
-            )
-
-            let cdnURL = "\(MezonConfig.baseImgURL)/\(uploadInfo.filename)"
+                fileSize: size,
+                token: token,
+                progressKey: progressKey,
+                network: context.account.network)
+            AttachmentUploadProgressStore.shared.clear(forKey: progressKey)
 
             var att = Mezon_Api_MessageAttachment()
             att.filename = file.filename
-            att.url = cdnURL
+            att.url = uploaded.cdnURL
             att.filetype = file.filetype
-            att.size = Int32(fileData.count)
+            att.size = Int32(size)
             attachments.append(att)
 
             try? FileManager.default.removeItem(at: file.url)
@@ -4911,7 +4937,8 @@ final class SendMessageInputViewController: UIViewController {
                     height: nil,
                     durationSeconds: nil,
                     localImage: nil,
-                    isUploading: true
+                    isUploading: true,
+                    uploadProgressKey: file.url.path
                 )
             }
         }
@@ -4980,7 +5007,8 @@ final class SendMessageInputViewController: UIViewController {
                         height: nil,
                         durationSeconds: nil,
                         localImage: nil,
-                        isUploading: true
+                        isUploading: true,
+                        uploadProgressKey: file.url.path
                     )
                 }
             }
@@ -5460,7 +5488,9 @@ final class SendMessageInputViewController: UIViewController {
         ref.messageSenderID = Int64(display.message.senderId) ?? 0
         ref.messageSenderUsername = display.senderUsername
         ref.messageSenderDisplayName = display.senderDisplayName
-        ref.messageSenderAvatar = display.avatarURL ?? ""
+        ref.messageSenderAvatar = display.isSystemMessage
+            ? MezonConstants.waveSenderAvatarURL
+            : (display.avatarURL ?? "")
         ref.hasAttachment_p = !display.attachments.isEmpty
         if display.shareContactData != nil {
             ref.content = display.replyRefSourceContent
@@ -5918,14 +5948,39 @@ extension SendMessageInputViewController: UIDocumentPickerDelegate {
             let filename = url.lastPathComponent
             let ext = url.pathExtension.lowercased()
             let filetype = Self.mimeType(for: ext)
-            let fileSize = (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int) ?? 0
 
-            let fileInfo = PickedFileInfo(url: url, filename: filename, filesize: fileSize, filetype: filetype)
+            guard let stableURL = Self.copyPickedFileToStableLocation(from: url, ext: ext) else { continue }
+            let fileSize = (try? FileManager.default.attributesOfItem(atPath: stableURL.path)[.size] as? Int) ?? 0
+
+            let fileInfo = PickedFileInfo(url: stableURL, filename: filename, filesize: fileSize, filetype: filetype)
             pickedFiles.append(fileInfo)
             attachmentPreviewView.addFile(fileInfo)
         }
         if didHitLimit { notifyAttachmentLimitReached() }
         updatePreviewVisibility()
+    }
+
+    static func copyPickedFileToStableLocation(from url: URL, ext: String) -> URL? {
+        let didScope = url.startAccessingSecurityScopedResource()
+        defer { if didScope { url.stopAccessingSecurityScopedResource() } }
+
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("mezon-uploads", isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            var dest = dir.appendingPathComponent(UUID().uuidString)
+            if !ext.isEmpty { dest.appendPathExtension(ext) }
+            if FileManager.default.fileExists(atPath: dest.path) {
+                try? FileManager.default.removeItem(at: dest)
+            }
+            try FileManager.default.copyItem(at: url, to: dest)
+            return dest
+        } catch {
+            SentryLogger.capture(error, extras: [
+                "where": "SendMessageInputViewController.copyPickedFileToStableLocation",
+                "filename": url.lastPathComponent,
+            ])
+            return nil
+        }
     }
 
     func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {

--- a/MezonChat/Generated/api/api.pb.swift
+++ b/MezonChat/Generated/api/api.pb.swift
@@ -4693,6 +4693,12 @@ struct Mezon_Api_UploadAttachmentRequest: Sendable {
   /// Height
   var height: Int32 = 0
 
+  /// part count
+  var partCount: Int32 = 0
+
+  /// parts (only part_number is set at start; e_tag filled at finish)
+  var parts: [Mezon_Api_MultipartUploadAttachmentPart] = []
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
@@ -4774,6 +4780,8 @@ struct Mezon_Api_MultipartUploadAttachmentFinishRequest: Sendable {
   var uploadID: String = String()
 
   var parts: [Mezon_Api_MultipartUploadAttachmentPart] = []
+
+  var filename: String = String()
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -17293,7 +17301,7 @@ extension Mezon_Api_PermissionUpdate: SwiftProtobuf.Message, SwiftProtobuf._Mess
 
 extension Mezon_Api_UploadAttachmentRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UploadAttachmentRequest"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}filename\0\u{1}filetype\0\u{1}size\0\u{1}width\0\u{1}height\0")
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}filename\0\u{1}filetype\0\u{1}size\0\u{1}width\0\u{1}height\0\u{3}part_count\0\u{1}parts\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -17306,6 +17314,8 @@ extension Mezon_Api_UploadAttachmentRequest: SwiftProtobuf.Message, SwiftProtobu
       case 3: try { try decoder.decodeSingularInt32Field(value: &self.size) }()
       case 4: try { try decoder.decodeSingularInt32Field(value: &self.width) }()
       case 5: try { try decoder.decodeSingularInt32Field(value: &self.height) }()
+      case 6: try { try decoder.decodeSingularInt32Field(value: &self.partCount) }()
+      case 7: try { try decoder.decodeRepeatedMessageField(value: &self.parts) }()
       default: break
       }
     }
@@ -17327,6 +17337,12 @@ extension Mezon_Api_UploadAttachmentRequest: SwiftProtobuf.Message, SwiftProtobu
     if self.height != 0 {
       try visitor.visitSingularInt32Field(value: self.height, fieldNumber: 5)
     }
+    if self.partCount != 0 {
+      try visitor.visitSingularInt32Field(value: self.partCount, fieldNumber: 6)
+    }
+    if !self.parts.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.parts, fieldNumber: 7)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -17336,6 +17352,8 @@ extension Mezon_Api_UploadAttachmentRequest: SwiftProtobuf.Message, SwiftProtobu
     if lhs.size != rhs.size {return false}
     if lhs.width != rhs.width {return false}
     if lhs.height != rhs.height {return false}
+    if lhs.partCount != rhs.partCount {return false}
+    if lhs.parts != rhs.parts {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -17493,7 +17511,7 @@ extension Mezon_Api_MultipartUploadAttachmentPart: SwiftProtobuf.Message, SwiftP
 
 extension Mezon_Api_MultipartUploadAttachmentFinishRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MultipartUploadAttachmentFinishRequest"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}upload_id\0\u{1}parts\0")
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}upload_id\0\u{1}parts\0\u{1}filename\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -17503,6 +17521,7 @@ extension Mezon_Api_MultipartUploadAttachmentFinishRequest: SwiftProtobuf.Messag
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularStringField(value: &self.uploadID) }()
       case 2: try { try decoder.decodeRepeatedMessageField(value: &self.parts) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.filename) }()
       default: break
       }
     }
@@ -17515,12 +17534,16 @@ extension Mezon_Api_MultipartUploadAttachmentFinishRequest: SwiftProtobuf.Messag
     if !self.parts.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.parts, fieldNumber: 2)
     }
+    if !self.filename.isEmpty {
+      try visitor.visitSingularStringField(value: self.filename, fieldNumber: 3)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Mezon_Api_MultipartUploadAttachmentFinishRequest, rhs: Mezon_Api_MultipartUploadAttachmentFinishRequest) -> Bool {
     if lhs.uploadID != rhs.uploadID {return false}
     if lhs.parts != rhs.parts {return false}
+    if lhs.filename != rhs.filename {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/MezonChat/Generated/rtapi/realtime.pb.swift
+++ b/MezonChat/Generated/rtapi/realtime.pb.swift
@@ -908,6 +908,24 @@ struct Mezon_Realtime_Envelope: @unchecked Sendable {
     set {_uniqueStorage()._message = .refreshSessionEvent(newValue)}
   }
 
+  /// Channel archive / unarchive event
+  var channelArchiveEvent: Mezon_Realtime_ChannelArchiveEvent {
+    get {
+      if case .channelArchiveEvent(let v)? = _storage._message {return v}
+      return Mezon_Realtime_ChannelArchiveEvent()
+    }
+    set {_uniqueStorage()._message = .channelArchiveEvent(newValue)}
+  }
+
+  /// Topic in message event
+  var topicInMessageEvent: Mezon_Realtime_TopicInMessageEvent {
+    get {
+      if case .topicInMessageEvent(let v)? = _storage._message {return v}
+      return Mezon_Realtime_TopicInMessageEvent()
+    }
+    set {_uniqueStorage()._message = .topicInMessageEvent(newValue)}
+  }
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   enum OneOf_Message: Equatable, Sendable {
@@ -1100,12 +1118,32 @@ struct Mezon_Realtime_Envelope: @unchecked Sendable {
     case listChannelUsersBannedEvent(Mezon_Realtime_ListChannelUsersBannedEvent)
     /// Refresh session event
     case refreshSessionEvent(Mezon_Api_Session)
+    /// Channel archive / unarchive event
+    case channelArchiveEvent(Mezon_Realtime_ChannelArchiveEvent)
+    /// Topic in message event
+    case topicInMessageEvent(Mezon_Realtime_TopicInMessageEvent)
 
   }
 
   init() {}
 
   fileprivate var _storage = _StorageClass.defaultInstance
+}
+
+struct Mezon_Realtime_TopicInMessageEvent: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  var messageID: Int64 = 0
+
+  var rpl: Int32 = 0
+
+  var lsnt: Int64 = 0
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
 }
 
 struct Mezon_Realtime_ApiRequestEvent: Sendable {
@@ -1612,27 +1650,40 @@ struct Mezon_Realtime_EphemeralMessageSend: Sendable {
   fileprivate var _message: Mezon_Realtime_ChannelMessageSend? = nil
 }
 
-struct Mezon_Realtime_QuickMenuDataEvent: Sendable {
+struct Mezon_Realtime_QuickMenuDataEvent: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var menuName: String = String()
+  var menuName: String {
+    get {_storage._menuName}
+    set {_uniqueStorage()._menuName = newValue}
+  }
 
   var message: Mezon_Realtime_ChannelMessageSend {
-    get {_message ?? Mezon_Realtime_ChannelMessageSend()}
-    set {_message = newValue}
+    get {_storage._message ?? Mezon_Realtime_ChannelMessageSend()}
+    set {_uniqueStorage()._message = newValue}
   }
   /// Returns true if `message` has been explicitly set.
-  var hasMessage: Bool {self._message != nil}
+  var hasMessage: Bool {_storage._message != nil}
   /// Clears the value of `message`. Subsequent reads from it will return its default value.
-  mutating func clearMessage() {self._message = nil}
+  mutating func clearMessage() {_uniqueStorage()._message = nil}
+
+  var senderID: Int64 {
+    get {_storage._senderID}
+    set {_uniqueStorage()._senderID = newValue}
+  }
+
+  var messageSenderID: Int64 {
+    get {_storage._messageSenderID}
+    set {_uniqueStorage()._messageSenderID = newValue}
+  }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _message: Mezon_Realtime_ChannelMessageSend? = nil
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 struct Mezon_Realtime_VoiceReactionSend: Sendable {
@@ -2701,6 +2752,137 @@ struct Mezon_Realtime_ChannelUpdatedEvent: @unchecked Sendable {
     set {_uniqueStorage()._ageRestricted = newValue}
   }
 
+  var active: Int32 {
+    get {_storage._active}
+    set {_uniqueStorage()._active = newValue}
+  }
+
+  /// count message unread
+  var countMessUnread: Int32 {
+    get {_storage._countMessUnread}
+    set {_uniqueStorage()._countMessUnread = newValue}
+  }
+
+  /// The users to add.
+  var userIds: [Int64] {
+    get {_storage._userIds}
+    set {_uniqueStorage()._userIds = newValue}
+  }
+
+  /// This is the role that needs to be added to the channel
+  var roleIds: [Int64] {
+    get {_storage._roleIds}
+    set {_uniqueStorage()._roleIds = newValue}
+  }
+
+  var channelAvatar: String {
+    get {_storage._channelAvatar}
+    set {_uniqueStorage()._channelAvatar = newValue}
+  }
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+
+  fileprivate var _storage = _StorageClass.defaultInstance
+}
+
+/// Emitted when a channel/thread is archived or activated from archive.
+struct Mezon_Realtime_ChannelArchiveEvent: @unchecked Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// clan id
+  var clanID: Int64 {
+    get {_storage._clanID}
+    set {_uniqueStorage()._clanID = newValue}
+  }
+
+  /// category
+  var categoryID: Int64 {
+    get {_storage._categoryID}
+    set {_uniqueStorage()._categoryID = newValue}
+  }
+
+  /// creator
+  var creatorID: Int64 {
+    get {_storage._creatorID}
+    set {_uniqueStorage()._creatorID = newValue}
+  }
+
+  /// parent id
+  var parentID: Int64 {
+    get {_storage._parentID}
+    set {_uniqueStorage()._parentID = newValue}
+  }
+
+  /// channel id
+  var channelID: Int64 {
+    get {_storage._channelID}
+    set {_uniqueStorage()._channelID = newValue}
+  }
+
+  /// channel label
+  var channelLabel: String {
+    get {_storage._channelLabel}
+    set {_uniqueStorage()._channelLabel = newValue}
+  }
+
+  /// channel type
+  var channelType: Int32 {
+    get {_storage._channelType}
+    set {_uniqueStorage()._channelType = newValue}
+  }
+
+  /// status
+  var status: Int32 {
+    get {_storage._status}
+    set {_uniqueStorage()._status = newValue}
+  }
+
+  /// meeting code
+  var meetingCode: String {
+    get {_storage._meetingCode}
+    set {_uniqueStorage()._meetingCode = newValue}
+  }
+
+  /// error
+  var isError: Bool {
+    get {_storage._isError}
+    set {_uniqueStorage()._isError = newValue}
+  }
+
+  /// channel private
+  var channelPrivate: Bool {
+    get {_storage._channelPrivate}
+    set {_uniqueStorage()._channelPrivate = newValue}
+  }
+
+  /// app url
+  var appID: Int64 {
+    get {_storage._appID}
+    set {_uniqueStorage()._appID = newValue}
+  }
+
+  /// e2ee
+  var e2Ee: Int32 {
+    get {_storage._e2Ee}
+    set {_uniqueStorage()._e2Ee = newValue}
+  }
+
+  /// topic
+  var topic: String {
+    get {_storage._topic}
+    set {_uniqueStorage()._topic = newValue}
+  }
+
+  var ageRestricted: Int32 {
+    get {_storage._ageRestricted}
+    set {_uniqueStorage()._ageRestricted = newValue}
+  }
+
+  /// 0 = archived, 1 = active
   var active: Int32 {
     get {_storage._active}
     set {_uniqueStorage()._active = newValue}
@@ -3825,7 +4007,7 @@ fileprivate let _protobuf_package = "mezon.realtime"
 
 extension Mezon_Realtime_Envelope: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Envelope"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}cid\0\u{1}channel\0\u{3}clan_join\0\u{3}channel_join\0\u{3}channel_leave\0\u{3}channel_message\0\u{3}channel_message_ack\0\u{3}channel_message_send\0\u{3}channel_message_update\0\u{3}channel_message_remove\0\u{3}channel_presence_event\0\u{1}error\0\u{1}notifications\0\u{1}rpc\0\u{1}status\0\u{3}status_follow\0\u{3}status_presence_event\0\u{3}status_unfollow\0\u{3}status_update\0\u{3}stream_data\0\u{3}stream_presence_event\0\u{1}ping\0\u{1}pong\0\u{3}message_typing_event\0\u{3}last_seen_message_event\0\u{3}message_reaction_event\0\u{3}voice_joined_event\0\u{3}voice_leaved_event\0\u{3}voice_started_event\0\u{3}voice_ended_event\0\u{3}channel_created_event\0\u{3}channel_deleted_event\0\u{3}channel_updated_event\0\u{3}last_pin_message_event\0\u{3}custom_status_event\0\u{3}user_channel_added_event\0\u{3}user_channel_removed_event\0\u{3}user_clan_removed_event\0\u{3}clan_updated_event\0\u{3}clan_profile_updated_event\0\u{3}check_name_existed_event\0\u{3}user_profile_updated_event\0\u{3}add_clan_user_event\0\u{3}clan_event_created\0\u{3}role_assign_event\0\u{3}clan_deleted_event\0\u{3}give_coffee_event\0\u{3}sticker_create_event\0\u{3}sticker_update_event\0\u{3}sticker_delete_event\0\u{3}role_event\0\u{3}event_emoji\0\u{3}streaming_joined_event\0\u{3}streaming_leaved_event\0\u{3}streaming_started_event\0\u{3}streaming_ended_event\0\u{3}permission_set_event\0\u{3}permission_changed_event\0\u{3}token_sent_event\0\u{3}message_button_clicked\0\u{3}unmute_event\0\u{3}webrtc_signaling_fwd\0\u{3}list_activity\0\u{3}dropdown_box_selected\0\u{3}incoming_call_push\0\u{3}sd_topic_event\0\u{3}follow_event\0\u{3}channel_app_event\0\u{3}user_status_event\0\u{3}remove_friend\0\u{3}webhook_event\0\u{3}noti_user_channel\0\u{3}join_channel_app_data\0\u{3}canvas_event\0\u{3}unpin_message_event\0\u{3}category_event\0\u{3}handle_participant_meet_state_event\0\u{3}delete_account_event\0\u{3}ephemeral_message_send\0\u{3}block_friend\0\u{3}voice_reaction_send\0\u{3}mark_as_read\0\u{3}list_data_socket\0\u{3}quick_menu_event\0\u{3}un_block_friend\0\u{3}meet_participant_event\0\u{3}transfer_ownership_event\0\u{3}add_friend\0\u{3}ban_user_event\0\u{3}active_archived_thread\0\u{3}allow_anonymous_event\0\u{3}api_request_event\0\u{3}clan_created_event\0\u{3}aiagent_enabled_event\0\u{3}list_channel_users_banned_event\0\u{3}refresh_session_event\0")
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}cid\0\u{1}channel\0\u{3}clan_join\0\u{3}channel_join\0\u{3}channel_leave\0\u{3}channel_message\0\u{3}channel_message_ack\0\u{3}channel_message_send\0\u{3}channel_message_update\0\u{3}channel_message_remove\0\u{3}channel_presence_event\0\u{1}error\0\u{1}notifications\0\u{1}rpc\0\u{1}status\0\u{3}status_follow\0\u{3}status_presence_event\0\u{3}status_unfollow\0\u{3}status_update\0\u{3}stream_data\0\u{3}stream_presence_event\0\u{1}ping\0\u{1}pong\0\u{3}message_typing_event\0\u{3}last_seen_message_event\0\u{3}message_reaction_event\0\u{3}voice_joined_event\0\u{3}voice_leaved_event\0\u{3}voice_started_event\0\u{3}voice_ended_event\0\u{3}channel_created_event\0\u{3}channel_deleted_event\0\u{3}channel_updated_event\0\u{3}last_pin_message_event\0\u{3}custom_status_event\0\u{3}user_channel_added_event\0\u{3}user_channel_removed_event\0\u{3}user_clan_removed_event\0\u{3}clan_updated_event\0\u{3}clan_profile_updated_event\0\u{3}check_name_existed_event\0\u{3}user_profile_updated_event\0\u{3}add_clan_user_event\0\u{3}clan_event_created\0\u{3}role_assign_event\0\u{3}clan_deleted_event\0\u{3}give_coffee_event\0\u{3}sticker_create_event\0\u{3}sticker_update_event\0\u{3}sticker_delete_event\0\u{3}role_event\0\u{3}event_emoji\0\u{3}streaming_joined_event\0\u{3}streaming_leaved_event\0\u{3}streaming_started_event\0\u{3}streaming_ended_event\0\u{3}permission_set_event\0\u{3}permission_changed_event\0\u{3}token_sent_event\0\u{3}message_button_clicked\0\u{3}unmute_event\0\u{3}webrtc_signaling_fwd\0\u{3}list_activity\0\u{3}dropdown_box_selected\0\u{3}incoming_call_push\0\u{3}sd_topic_event\0\u{3}follow_event\0\u{3}channel_app_event\0\u{3}user_status_event\0\u{3}remove_friend\0\u{3}webhook_event\0\u{3}noti_user_channel\0\u{3}join_channel_app_data\0\u{3}canvas_event\0\u{3}unpin_message_event\0\u{3}category_event\0\u{3}handle_participant_meet_state_event\0\u{3}delete_account_event\0\u{3}ephemeral_message_send\0\u{3}block_friend\0\u{3}voice_reaction_send\0\u{3}mark_as_read\0\u{3}list_data_socket\0\u{3}quick_menu_event\0\u{3}un_block_friend\0\u{3}meet_participant_event\0\u{3}transfer_ownership_event\0\u{3}add_friend\0\u{3}ban_user_event\0\u{3}active_archived_thread\0\u{3}allow_anonymous_event\0\u{3}api_request_event\0\u{3}clan_created_event\0\u{3}aiagent_enabled_event\0\u{3}list_channel_users_banned_event\0\u{3}refresh_session_event\0\u{3}channel_archive_event\0\u{3}topic_in_message_event\0")
 
   fileprivate class _StorageClass {
     var _cid: Int32 = 0
@@ -5096,6 +5278,32 @@ extension Mezon_Realtime_Envelope: SwiftProtobuf.Message, SwiftProtobuf._Message
             _storage._message = .refreshSessionEvent(v)
           }
         }()
+        case 97: try {
+          var v: Mezon_Realtime_ChannelArchiveEvent?
+          var hadOneofValue = false
+          if let current = _storage._message {
+            hadOneofValue = true
+            if case .channelArchiveEvent(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {
+            if hadOneofValue {try decoder.handleConflictingOneOf()}
+            _storage._message = .channelArchiveEvent(v)
+          }
+        }()
+        case 98: try {
+          var v: Mezon_Realtime_TopicInMessageEvent?
+          var hadOneofValue = false
+          if let current = _storage._message {
+            hadOneofValue = true
+            if case .topicInMessageEvent(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {
+            if hadOneofValue {try decoder.handleConflictingOneOf()}
+            _storage._message = .topicInMessageEvent(v)
+          }
+        }()
         default: break
         }
       }
@@ -5492,6 +5700,14 @@ extension Mezon_Realtime_Envelope: SwiftProtobuf.Message, SwiftProtobuf._Message
         guard case .refreshSessionEvent(let v)? = _storage._message else { preconditionFailure() }
         try visitor.visitSingularMessageField(value: v, fieldNumber: 96)
       }()
+      case .channelArchiveEvent?: try {
+        guard case .channelArchiveEvent(let v)? = _storage._message else { preconditionFailure() }
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 97)
+      }()
+      case .topicInMessageEvent?: try {
+        guard case .topicInMessageEvent(let v)? = _storage._message else { preconditionFailure() }
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 98)
+      }()
       case nil: break
       }
     }
@@ -5509,6 +5725,46 @@ extension Mezon_Realtime_Envelope: SwiftProtobuf.Message, SwiftProtobuf._Message
       }
       if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Mezon_Realtime_TopicInMessageEvent: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".TopicInMessageEvent"
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}message_id\0\u{1}rpl\0\u{1}lsnt\0")
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularInt64Field(value: &self.messageID) }()
+      case 2: try { try decoder.decodeSingularInt32Field(value: &self.rpl) }()
+      case 3: try { try decoder.decodeSingularInt64Field(value: &self.lsnt) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.messageID != 0 {
+      try visitor.visitSingularInt64Field(value: self.messageID, fieldNumber: 1)
+    }
+    if self.rpl != 0 {
+      try visitor.visitSingularInt32Field(value: self.rpl, fieldNumber: 2)
+    }
+    if self.lsnt != 0 {
+      try visitor.visitSingularInt64Field(value: self.lsnt, fieldNumber: 3)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Mezon_Realtime_TopicInMessageEvent, rhs: Mezon_Realtime_TopicInMessageEvent) -> Bool {
+    if lhs.messageID != rhs.messageID {return false}
+    if lhs.rpl != rhs.rpl {return false}
+    if lhs.lsnt != rhs.lsnt {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -6490,38 +6746,90 @@ extension Mezon_Realtime_EphemeralMessageSend: SwiftProtobuf.Message, SwiftProto
 
 extension Mezon_Realtime_QuickMenuDataEvent: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".QuickMenuDataEvent"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}menu_name\0\u{1}message\0")
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}menu_name\0\u{1}message\0\u{3}sender_id\0\u{3}message_sender_id\0")
+
+  fileprivate class _StorageClass {
+    var _menuName: String = String()
+    var _message: Mezon_Realtime_ChannelMessageSend? = nil
+    var _senderID: Int64 = 0
+    var _messageSenderID: Int64 = 0
+
+      // This property is used as the initial default value for new instances of the type.
+      // The type itself is protecting the reference to its storage via CoW semantics.
+      // This will force a copy to be made of this reference when the first mutation occurs;
+      // hence, it is safe to mark this as `nonisolated(unsafe)`.
+      static nonisolated(unsafe) let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _menuName = source._menuName
+      _message = source._message
+      _senderID = source._senderID
+      _messageSenderID = source._messageSenderID
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeSingularStringField(value: &self.menuName) }()
-      case 2: try { try decoder.decodeSingularMessageField(value: &self._message) }()
-      default: break
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        // The use of inline closures is to circumvent an issue where the compiler
+        // allocates stack space for every case branch when no optimizations are
+        // enabled. https://github.com/apple/swift-protobuf/issues/1034
+        switch fieldNumber {
+        case 1: try { try decoder.decodeSingularStringField(value: &_storage._menuName) }()
+        case 2: try { try decoder.decodeSingularMessageField(value: &_storage._message) }()
+        case 3: try { try decoder.decodeSingularInt64Field(value: &_storage._senderID) }()
+        case 4: try { try decoder.decodeSingularInt64Field(value: &_storage._messageSenderID) }()
+        default: break
+        }
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    // The use of inline closures is to circumvent an issue where the compiler
-    // allocates stack space for every if/case branch local when no optimizations
-    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
-    // https://github.com/apple/swift-protobuf/issues/1182
-    if !self.menuName.isEmpty {
-      try visitor.visitSingularStringField(value: self.menuName, fieldNumber: 1)
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every if/case branch local when no optimizations
+      // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+      // https://github.com/apple/swift-protobuf/issues/1182
+      if !_storage._menuName.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._menuName, fieldNumber: 1)
+      }
+      try { if let v = _storage._message {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      } }()
+      if _storage._senderID != 0 {
+        try visitor.visitSingularInt64Field(value: _storage._senderID, fieldNumber: 3)
+      }
+      if _storage._messageSenderID != 0 {
+        try visitor.visitSingularInt64Field(value: _storage._messageSenderID, fieldNumber: 4)
+      }
     }
-    try { if let v = self._message {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Mezon_Realtime_QuickMenuDataEvent, rhs: Mezon_Realtime_QuickMenuDataEvent) -> Bool {
-    if lhs.menuName != rhs.menuName {return false}
-    if lhs._message != rhs._message {return false}
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._menuName != rhs_storage._menuName {return false}
+        if _storage._message != rhs_storage._message {return false}
+        if _storage._senderID != rhs_storage._senderID {return false}
+        if _storage._messageSenderID != rhs_storage._messageSenderID {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -8464,6 +8772,205 @@ extension Mezon_Realtime_ChannelUpdatedEvent: SwiftProtobuf.Message, SwiftProtob
   }
 
   static func ==(lhs: Mezon_Realtime_ChannelUpdatedEvent, rhs: Mezon_Realtime_ChannelUpdatedEvent) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._clanID != rhs_storage._clanID {return false}
+        if _storage._categoryID != rhs_storage._categoryID {return false}
+        if _storage._creatorID != rhs_storage._creatorID {return false}
+        if _storage._parentID != rhs_storage._parentID {return false}
+        if _storage._channelID != rhs_storage._channelID {return false}
+        if _storage._channelLabel != rhs_storage._channelLabel {return false}
+        if _storage._channelType != rhs_storage._channelType {return false}
+        if _storage._status != rhs_storage._status {return false}
+        if _storage._meetingCode != rhs_storage._meetingCode {return false}
+        if _storage._isError != rhs_storage._isError {return false}
+        if _storage._channelPrivate != rhs_storage._channelPrivate {return false}
+        if _storage._appID != rhs_storage._appID {return false}
+        if _storage._e2Ee != rhs_storage._e2Ee {return false}
+        if _storage._topic != rhs_storage._topic {return false}
+        if _storage._ageRestricted != rhs_storage._ageRestricted {return false}
+        if _storage._active != rhs_storage._active {return false}
+        if _storage._countMessUnread != rhs_storage._countMessUnread {return false}
+        if _storage._userIds != rhs_storage._userIds {return false}
+        if _storage._roleIds != rhs_storage._roleIds {return false}
+        if _storage._channelAvatar != rhs_storage._channelAvatar {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Mezon_Realtime_ChannelArchiveEvent: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".ChannelArchiveEvent"
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}clan_id\0\u{3}category_id\0\u{3}creator_id\0\u{3}parent_id\0\u{3}channel_id\0\u{3}channel_label\0\u{3}channel_type\0\u{1}status\0\u{3}meeting_code\0\u{3}is_error\0\u{3}channel_private\0\u{3}app_id\0\u{1}e2ee\0\u{1}topic\0\u{3}age_restricted\0\u{1}active\0\u{3}count_mess_unread\0\u{3}user_ids\0\u{3}role_ids\0\u{3}channel_avatar\0")
+
+  fileprivate class _StorageClass {
+    var _clanID: Int64 = 0
+    var _categoryID: Int64 = 0
+    var _creatorID: Int64 = 0
+    var _parentID: Int64 = 0
+    var _channelID: Int64 = 0
+    var _channelLabel: String = String()
+    var _channelType: Int32 = 0
+    var _status: Int32 = 0
+    var _meetingCode: String = String()
+    var _isError: Bool = false
+    var _channelPrivate: Bool = false
+    var _appID: Int64 = 0
+    var _e2Ee: Int32 = 0
+    var _topic: String = String()
+    var _ageRestricted: Int32 = 0
+    var _active: Int32 = 0
+    var _countMessUnread: Int32 = 0
+    var _userIds: [Int64] = []
+    var _roleIds: [Int64] = []
+    var _channelAvatar: String = String()
+
+      // This property is used as the initial default value for new instances of the type.
+      // The type itself is protecting the reference to its storage via CoW semantics.
+      // This will force a copy to be made of this reference when the first mutation occurs;
+      // hence, it is safe to mark this as `nonisolated(unsafe)`.
+      static nonisolated(unsafe) let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _clanID = source._clanID
+      _categoryID = source._categoryID
+      _creatorID = source._creatorID
+      _parentID = source._parentID
+      _channelID = source._channelID
+      _channelLabel = source._channelLabel
+      _channelType = source._channelType
+      _status = source._status
+      _meetingCode = source._meetingCode
+      _isError = source._isError
+      _channelPrivate = source._channelPrivate
+      _appID = source._appID
+      _e2Ee = source._e2Ee
+      _topic = source._topic
+      _ageRestricted = source._ageRestricted
+      _active = source._active
+      _countMessUnread = source._countMessUnread
+      _userIds = source._userIds
+      _roleIds = source._roleIds
+      _channelAvatar = source._channelAvatar
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        // The use of inline closures is to circumvent an issue where the compiler
+        // allocates stack space for every case branch when no optimizations are
+        // enabled. https://github.com/apple/swift-protobuf/issues/1034
+        switch fieldNumber {
+        case 1: try { try decoder.decodeSingularInt64Field(value: &_storage._clanID) }()
+        case 2: try { try decoder.decodeSingularInt64Field(value: &_storage._categoryID) }()
+        case 3: try { try decoder.decodeSingularInt64Field(value: &_storage._creatorID) }()
+        case 4: try { try decoder.decodeSingularInt64Field(value: &_storage._parentID) }()
+        case 5: try { try decoder.decodeSingularInt64Field(value: &_storage._channelID) }()
+        case 6: try { try decoder.decodeSingularStringField(value: &_storage._channelLabel) }()
+        case 7: try { try decoder.decodeSingularInt32Field(value: &_storage._channelType) }()
+        case 8: try { try decoder.decodeSingularInt32Field(value: &_storage._status) }()
+        case 9: try { try decoder.decodeSingularStringField(value: &_storage._meetingCode) }()
+        case 10: try { try decoder.decodeSingularBoolField(value: &_storage._isError) }()
+        case 11: try { try decoder.decodeSingularBoolField(value: &_storage._channelPrivate) }()
+        case 12: try { try decoder.decodeSingularInt64Field(value: &_storage._appID) }()
+        case 13: try { try decoder.decodeSingularInt32Field(value: &_storage._e2Ee) }()
+        case 14: try { try decoder.decodeSingularStringField(value: &_storage._topic) }()
+        case 15: try { try decoder.decodeSingularInt32Field(value: &_storage._ageRestricted) }()
+        case 16: try { try decoder.decodeSingularInt32Field(value: &_storage._active) }()
+        case 17: try { try decoder.decodeSingularInt32Field(value: &_storage._countMessUnread) }()
+        case 18: try { try decoder.decodeRepeatedInt64Field(value: &_storage._userIds) }()
+        case 19: try { try decoder.decodeRepeatedInt64Field(value: &_storage._roleIds) }()
+        case 20: try { try decoder.decodeSingularStringField(value: &_storage._channelAvatar) }()
+        default: break
+        }
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if _storage._clanID != 0 {
+        try visitor.visitSingularInt64Field(value: _storage._clanID, fieldNumber: 1)
+      }
+      if _storage._categoryID != 0 {
+        try visitor.visitSingularInt64Field(value: _storage._categoryID, fieldNumber: 2)
+      }
+      if _storage._creatorID != 0 {
+        try visitor.visitSingularInt64Field(value: _storage._creatorID, fieldNumber: 3)
+      }
+      if _storage._parentID != 0 {
+        try visitor.visitSingularInt64Field(value: _storage._parentID, fieldNumber: 4)
+      }
+      if _storage._channelID != 0 {
+        try visitor.visitSingularInt64Field(value: _storage._channelID, fieldNumber: 5)
+      }
+      if !_storage._channelLabel.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._channelLabel, fieldNumber: 6)
+      }
+      if _storage._channelType != 0 {
+        try visitor.visitSingularInt32Field(value: _storage._channelType, fieldNumber: 7)
+      }
+      if _storage._status != 0 {
+        try visitor.visitSingularInt32Field(value: _storage._status, fieldNumber: 8)
+      }
+      if !_storage._meetingCode.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._meetingCode, fieldNumber: 9)
+      }
+      if _storage._isError != false {
+        try visitor.visitSingularBoolField(value: _storage._isError, fieldNumber: 10)
+      }
+      if _storage._channelPrivate != false {
+        try visitor.visitSingularBoolField(value: _storage._channelPrivate, fieldNumber: 11)
+      }
+      if _storage._appID != 0 {
+        try visitor.visitSingularInt64Field(value: _storage._appID, fieldNumber: 12)
+      }
+      if _storage._e2Ee != 0 {
+        try visitor.visitSingularInt32Field(value: _storage._e2Ee, fieldNumber: 13)
+      }
+      if !_storage._topic.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._topic, fieldNumber: 14)
+      }
+      if _storage._ageRestricted != 0 {
+        try visitor.visitSingularInt32Field(value: _storage._ageRestricted, fieldNumber: 15)
+      }
+      if _storage._active != 0 {
+        try visitor.visitSingularInt32Field(value: _storage._active, fieldNumber: 16)
+      }
+      if _storage._countMessUnread != 0 {
+        try visitor.visitSingularInt32Field(value: _storage._countMessUnread, fieldNumber: 17)
+      }
+      if !_storage._userIds.isEmpty {
+        try visitor.visitPackedInt64Field(value: _storage._userIds, fieldNumber: 18)
+      }
+      if !_storage._roleIds.isEmpty {
+        try visitor.visitPackedInt64Field(value: _storage._roleIds, fieldNumber: 19)
+      }
+      if !_storage._channelAvatar.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._channelAvatar, fieldNumber: 20)
+      }
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Mezon_Realtime_ChannelArchiveEvent, rhs: Mezon_Realtime_ChannelArchiveEvent) -> Bool {
     if lhs._storage !== rhs._storage {
       let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
         let _storage = _args.0

--- a/MezonChat/Networking/AttachmentUploader.swift
+++ b/MezonChat/Networking/AttachmentUploader.swift
@@ -1,0 +1,322 @@
+import Foundation
+
+struct UploadedAttachmentFile {
+    let serverFilename: String
+    let cdnURL: String
+}
+
+final class AttachmentUploadProgressStore {
+
+    static let shared = AttachmentUploadProgressStore()
+    private init() {}
+
+    private let lock = NSLock()
+    private var progressByKey: [String: Double] = [:]
+
+    func setProgress(_ value: Double, forKey key: String) {
+        guard !key.isEmpty else { return }
+        let clamped = min(max(value, 0), 1)
+        lock.lock(); progressByKey[key] = clamped; lock.unlock()
+    }
+
+    func progress(forKey key: String) -> Double {
+        guard !key.isEmpty else { return 0 }
+        lock.lock(); defer { lock.unlock() }
+        return progressByKey[key] ?? 0
+    }
+
+    func clear(forKey key: String) {
+        guard !key.isEmpty else { return }
+        lock.lock(); progressByKey.removeValue(forKey: key); lock.unlock()
+    }
+}
+
+final class AttachmentUploader {
+
+    static let shared = AttachmentUploader()
+    private init() {}
+
+    private static let partSize = 10 * 1024 * 1024
+    private static let minMultipartFileSize = 10 * 1024 * 1024
+    private static let maxParallelParts = 3
+
+    private struct MultipartNotApplicable: Error {}
+
+    private let stateLock = NSLock()
+    private var skipMultipartForSession = false
+
+    private var shouldSkipMultipart: Bool {
+        stateLock.lock(); defer { stateLock.unlock() }
+        return skipMultipartForSession
+    }
+
+    private func markMultipartUnavailable() {
+        stateLock.lock(); skipMultipartForSession = true; stateLock.unlock()
+    }
+
+    func uploadFile(
+        fileURL: URL,
+        filename: String,
+        filetype: String,
+        fileSize: Int,
+        width: Int = 0,
+        height: Int = 0,
+        token: String,
+        progressKey: String = "",
+        network: MezonHTTPClient
+    ) async throws -> UploadedAttachmentFile {
+        reportProgress(0, forKey: progressKey)
+
+        if fileSize >= Self.minMultipartFileSize, !shouldSkipMultipart {
+            do {
+                return try await uploadMultipart(
+                    fileURL: fileURL, filename: filename, filetype: filetype,
+                    fileSize: fileSize, width: width, height: height,
+                    token: token, progressKey: progressKey, network: network)
+            } catch is MultipartNotApplicable {
+                markMultipartUnavailable()
+            } catch {
+                SentryLogger.capture(error, extras: [
+                    "where": "AttachmentUploader.uploadMultipart",
+                    "filename": filename,
+                    "fileSize": fileSize,
+                ])
+            }
+        }
+
+        return try await uploadSinglePut(
+            fileURL: fileURL, filename: filename, filetype: filetype,
+            fileSize: fileSize, width: width, height: height,
+            token: token, progressKey: progressKey, network: network)
+    }
+
+    private func uploadSinglePut(
+        fileURL: URL,
+        filename: String,
+        filetype: String,
+        fileSize: Int,
+        width: Int,
+        height: Int,
+        token: String,
+        progressKey: String,
+        network: MezonHTTPClient
+    ) async throws -> UploadedAttachmentFile {
+        let info = try await network.uploadAttachmentFile(
+            filename: filename, filetype: filetype, size: fileSize,
+            width: width, height: height, token: token)
+        _ = try await MinIOStreamingUploader.shared.put(
+            url: info.url, fileURL: fileURL, contentType: filetype
+        ) { [weak self] fraction in
+            self?.reportProgress(fraction, forKey: progressKey)
+        }
+        reportProgress(1, forKey: progressKey)
+        return UploadedAttachmentFile(
+            serverFilename: info.filename,
+            cdnURL: "\(MezonConfig.baseImgURL)/\(info.filename)")
+    }
+
+    private func uploadMultipart(
+        fileURL: URL,
+        filename: String,
+        filetype: String,
+        fileSize: Int,
+        width: Int,
+        height: Int,
+        token: String,
+        progressKey: String,
+        network: MezonHTTPClient
+    ) async throws -> UploadedAttachmentFile {
+        let requestedPartCount = max(1, Int((Double(fileSize) / Double(Self.partSize)).rounded(.up)))
+        let start = try await network.multipartUploadAttachmentFileStart(
+            filename: filename, filetype: filetype, size: fileSize,
+            width: width, height: height, partCount: requestedPartCount, token: token)
+        let urls = start.urls
+        let uploadId = start.uploadID
+
+        if urls.count == 1, uploadId.isEmpty {
+            _ = try await MinIOStreamingUploader.shared.put(
+                url: urls[0], fileURL: fileURL, contentType: filetype
+            ) { [weak self] fraction in
+                self?.reportProgress(fraction, forKey: progressKey)
+            }
+            reportProgress(1, forKey: progressKey)
+            let serverFilename = start.filename.isEmpty ? filename : start.filename
+            return UploadedAttachmentFile(
+                serverFilename: serverFilename,
+                cdnURL: "\(MezonConfig.baseImgURL)/\(serverFilename)")
+        }
+
+        if urls.isEmpty || uploadId.isEmpty {
+            throw MultipartNotApplicable()
+        }
+
+        let partCount = urls.count
+        let total = max(fileSize, 1)
+
+        var collected: [(partNumber: Int, eTag: String)] = []
+        collected.reserveCapacity(partCount)
+        var uploadedBytes = 0
+
+        try await withThrowingTaskGroup(of: (Int, String, Int).self) { group in
+            var nextIndex = 0
+
+            func submit() {
+                guard nextIndex < partCount else { return }
+                let index = nextIndex
+                nextIndex += 1
+                let offset = index * Self.partSize
+                let end = (index == partCount - 1) ? fileSize : offset + Self.partSize
+                let length = max(0, end - offset)
+                let url = urls[index]
+                let ft = filetype
+                let furl = fileURL
+                group.addTask {
+                    let chunk = try Self.readChunk(fileURL: furl, offset: offset, length: length)
+                    let etag = try await network.uploadPartToMinIO(url: url, data: chunk, contentType: ft)
+                    return (index + 1, etag, length)
+                }
+            }
+
+            for _ in 0..<min(Self.maxParallelParts, partCount) { submit() }
+
+            while let (partNumber, etag, length) = try await group.next() {
+                collected.append((partNumber, etag))
+                uploadedBytes += length
+                reportProgress(Double(uploadedBytes) / Double(total), forKey: progressKey)
+                submit()
+            }
+        }
+
+        collected.sort { $0.partNumber < $1.partNumber }
+
+        let finish = try await network.multipartUploadAttachmentFileFinish(
+            uploadId: uploadId, parts: collected, filename: start.filename, token: token)
+        reportProgress(1, forKey: progressKey)
+
+        let serverFilename: String = {
+            if !finish.filename.isEmpty { return finish.filename }
+            if !start.filename.isEmpty { return start.filename }
+            return filename
+        }()
+        return UploadedAttachmentFile(
+            serverFilename: serverFilename,
+            cdnURL: "\(MezonConfig.baseImgURL)/\(serverFilename)")
+    }
+
+    private static func readChunk(fileURL: URL, offset: Int, length: Int) throws -> Data {
+        let handle = try FileHandle(forReadingFrom: fileURL)
+        defer { try? handle.close() }
+        if offset > 0 {
+            try handle.seek(toOffset: UInt64(offset))
+        }
+        return handle.readData(ofLength: length)
+    }
+
+    private func reportProgress(_ value: Double, forKey key: String) {
+        guard !key.isEmpty else { return }
+        let previous = AttachmentUploadProgressStore.shared.progress(forKey: key)
+        let clamped = min(max(value, 0), 1)
+        AttachmentUploadProgressStore.shared.setProgress(clamped, forKey: key)
+
+        let previousBucket = Int(previous * 100)
+        let newBucket = Int(clamped * 100)
+        guard newBucket != previousBucket || clamped >= 1 else { return }
+
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(
+                name: .mezonAttachmentUploadProgress,
+                object: nil,
+                userInfo: ["key": key, "progress": clamped])
+        }
+    }
+}
+
+extension Notification.Name {
+    static let mezonAttachmentUploadProgress = Notification.Name("mezon.attachment.uploadProgress")
+}
+
+final class MinIOStreamingUploader: NSObject, URLSessionTaskDelegate {
+
+    static let shared = MinIOStreamingUploader()
+
+    private var session: URLSession!
+    private let lock = NSLock()
+    private var progressHandlers: [Int: (Double) -> Void] = [:]
+
+    private override init() {
+        super.init()
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 120
+        config.timeoutIntervalForResource = 3600
+        config.waitsForConnectivity = true
+        config.requestCachePolicy = .reloadIgnoringLocalCacheData
+        config.urlCache = nil
+        session = URLSession(configuration: config, delegate: self, delegateQueue: nil)
+    }
+
+    @discardableResult
+    func put(
+        url: String,
+        fileURL: URL,
+        contentType: String,
+        onProgress: @escaping (Double) -> Void
+    ) async throws -> (etag: String?, statusCode: Int) {
+        guard let uploadURL = URL(string: url) else {
+            throw MezonError.httpError(statusCode: 0, message: "Invalid MinIO URL")
+        }
+        var request = URLRequest(url: uploadURL)
+        request.httpMethod = "PUT"
+        request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+
+        return try await withCheckedThrowingContinuation { continuation in
+            let task = session.uploadTask(with: request, fromFile: fileURL) { _, response, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let http = response as? HTTPURLResponse else {
+                    continuation.resume(throwing: MezonError.invalidResponse)
+                    return
+                }
+                guard (200..<300).contains(http.statusCode) else {
+                    continuation.resume(throwing: MezonError.httpError(
+                        statusCode: http.statusCode, message: "MinIO upload failed"))
+                    return
+                }
+                let raw = http.value(forHTTPHeaderField: "Etag") ?? http.value(forHTTPHeaderField: "ETag")
+                let etag = raw?
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+                continuation.resume(returning: (etag?.isEmpty == false ? etag : nil, http.statusCode))
+            }
+            lock.lock()
+            progressHandlers[task.taskIdentifier] = onProgress
+            lock.unlock()
+            task.resume()
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didSendBodyData bytesSent: Int64,
+        totalBytesSent: Int64,
+        totalBytesExpectedToSend: Int64
+    ) {
+        guard totalBytesExpectedToSend > 0 else { return }
+        lock.lock()
+        let handler = progressHandlers[task.taskIdentifier]
+        lock.unlock()
+        handler?(Double(totalBytesSent) / Double(totalBytesExpectedToSend))
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        lock.lock()
+        progressHandlers.removeValue(forKey: task.taskIdentifier)
+        lock.unlock()
+    }
+}

--- a/MezonChat/Networking/MezonHTTPClient.swift
+++ b/MezonChat/Networking/MezonHTTPClient.swift
@@ -1450,6 +1450,81 @@ final class MezonHTTPClient {
         }
     }
 
+    func multipartUploadAttachmentFileStart(
+        filename: String,
+        filetype: String,
+        size: Int,
+        width: Int = 0,
+        height: Int = 0,
+        partCount: Int,
+        token: String
+    ) async throws -> Mezon_Api_MultipartUploadAttachment {
+        var req = Mezon_Api_UploadAttachmentRequest()
+        req.filename = filename
+        req.filetype = filetype
+        req.size = Int32(size)
+        req.width = Int32(width)
+        req.height = Int32(height)
+        req.partCount = Int32(partCount)
+        req.parts = (1...max(1, partCount)).map { index in
+            var part = Mezon_Api_MultipartUploadAttachmentPart()
+            part.partNumber = Int32(index)
+            return part
+        }
+        return try await postProto(
+            path: "/mezon.api.Mezon/MultipartUploadAttachmentFileStart",
+            message: req,
+            auth: .bearer(token)
+        )
+    }
+
+    func multipartUploadAttachmentFileFinish(
+        uploadId: String,
+        parts: [(partNumber: Int, eTag: String)],
+        filename: String,
+        token: String
+    ) async throws -> Mezon_Api_UploadAttachment {
+        var req = Mezon_Api_MultipartUploadAttachmentFinishRequest()
+        req.uploadID = uploadId
+        req.filename = filename
+        req.parts = parts.map { entry in
+            var part = Mezon_Api_MultipartUploadAttachmentPart()
+            part.partNumber = Int32(entry.partNumber)
+            part.eTag = entry.eTag
+            return part
+        }
+        return try await postProto(
+            path: "/mezon.api.Mezon/MultipartUploadAttachmentFileFinish",
+            message: req,
+            auth: .bearer(token)
+        )
+    }
+
+    func uploadPartToMinIO(url: String, data: Data, contentType: String) async throws -> String {
+        guard let uploadURL = URL(string: url) else {
+            throw MezonError.httpError(statusCode: 0, message: "Invalid MinIO URL")
+        }
+        var request = URLRequest(url: uploadURL)
+        request.httpMethod = "PUT"
+        request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+        request.setValue("\(data.count)", forHTTPHeaderField: "Content-Length")
+        request.httpBody = data
+
+        let (_, response) = try await uploadHTTPData(request)
+        guard let http = response as? HTTPURLResponse else { throw MezonError.invalidResponse }
+        guard (200..<300).contains(http.statusCode) else {
+            throw MezonError.httpError(statusCode: http.statusCode, message: "MinIO part upload failed")
+        }
+        let raw = http.value(forHTTPHeaderField: "Etag") ?? http.value(forHTTPHeaderField: "ETag")
+        let etag = raw?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+        guard let etag, !etag.isEmpty else {
+            throw MezonError.httpError(statusCode: http.statusCode, message: "MinIO part upload missing ETag")
+        }
+        return etag
+    }
+
     func uploadToMinIO(url: String, fileURL: URL, contentType: String) async throws {
         guard let uploadURL = URL(string: url) else {
             throw MezonError.httpError(statusCode: 0, message: "Invalid MinIO URL")
@@ -1887,7 +1962,7 @@ final class MezonHTTPClient {
     }
 
     private static let httpOnlyApiNames: Set<String> = [
-        "SessionRefresh"
+        "SessionRefresh",
     ]
     private static let socketFallbackGraceWaitNanoseconds: UInt64 = 2_000_000_000
 


### PR DESCRIPTION
Chunked multipart upload for large attachment files

## Summary
Adds a **multipart upload** flow for large attachments: a file is split into chunks and uploaded in parallel via MinIO presigned URLs instead of a single PUT. This avoids holding the whole file in memory (no OOM on ~1 GB files), enables parallel uploads, and has a safe fallback to single PUT.

## How it works

### Trigger threshold
| Condition | Flow |
|---|---|
| `fileSize >= 10 MB` | **Multipart** (chunked) |
| `fileSize < 10 MB` | **Single PUT** (streamed from file) |

- `minMultipartFileSize = 10 MB` — decides which flow to use.
- `partSize = 10 MB` — size of each chunk.
- `maxParallelParts = 3` — max number of parts uploaded concurrently.

### Chunking
- `partCount = ceil(fileSize / partSize)`.
  Example: a 64 MB file → `ceil(64 / 10) = 7` parts (first 6 parts are 10 MB, last part is the remainder).
- Each chunk is read **lazily from disk** via `FileHandle.seek(toOffset:)` right before its PUT → the whole file is never loaded into memory.
- Part `k` uses exactly `urls[k]` returned by the server; the last part runs to `fileSize`.

### RPC flow
1. **Start** — `MultipartUploadAttachmentFileStart`
   Sends: `filename, filetype, size, width, height, part_count, parts[part_number]`.
   Returns: `{ filename (object key), urls[] (presigned PUT per part), upload_id }`.
2. **PUT part** — PUT each chunk directly to its MinIO presigned URL (up to 3 in parallel), collecting the `ETag` of each part.
3. **Finish** — `MultipartUploadAttachmentFileFinish`
   Sends: `upload_id, parts[{part_number, e_tag}], filename` → server runs `CompleteMultipartUpload` to assemble the object.

### Safe fallback
- Server returns `urls.count == 1 && upload_id empty` → a single presigned PUT (streamed from file).
- Server returns empty `urls` or empty `upload_id` → throws `MultipartNotApplicable` → single PUT; also sets `skipMultipartForSession` so subsequent files in the session don't call Start uselessly.
- Single PUT uses `MinIOStreamingUploader` (`URLSession.uploadTask(fromFile:)`) → streamed from disk, with byte-level progress.

### Progress & UI performance
- `AttachmentUploadProgressStore` keeps per-file progress; posts a `NotificationCenter` event on each 1% change.
- `ChatViewController` **debounces** the message-list rebuild (coalesced to at most ~1 per 250 ms) to avoid lag/flicker when uploading many large files at once.

### Temp-file durability (document picker)
- A picked file (from iCloud/Files or the tmp `-Inbox` import copy) is **copied to `tmp/mezon-uploads/<uuid>.<ext>`** at pick time (handling security-scoped resources), and uploaded from that copy → avoids iOS tmp cleanup / filename collisions / the file disappearing mid-upload.
- `uploadFiles` checks the file exists before uploading; if missing it logs clearly instead of failing with an obscure error.

## Test plan
- [ ] File < 10 MB → single PUT, uploads OK.
- [ ] File >= 10 MB → multipart: flow runs `Start → PUT 1..N → Finish`, file opens on the CDN.
- [ ] ~200 MB file (document) → uploads OK, no memory spike.
- [ ] Pick the same file twice in a row → no "file doesn't exist" error.
- [ ] Upload many large files at once → message list does not lag/flicker heavily.
- [ ] Server without multipart support → auto-fallback to single PUT, no crash.
- [ ] Video: original uploaded via multipart + thumbnail.
