### PR TITLE
update: apply chunk upload file in Sharing and show process uploading

### DIFF
--- a/MezonChat/Core/Localization/L10n.swift
+++ b/MezonChat/Core/Localization/L10n.swift
@@ -603,6 +603,7 @@ enum L10n {
         static let emptySuggestions      = "sharing.emptySuggestions"
         static let commentPlaceholder    = "sharing.commentPlaceholder"
         static let sending               = "sharing.sending"
+        static let uploading             = "sharing.uploading"
         static let filterTitle           = "sharing.filterTitle"
         static let filterAll             = "sharing.filterAll"
         static let filterUsers           = "sharing.filterUsers"
@@ -1536,6 +1537,7 @@ extension L10n {
         "sharing.emptySuggestions":         "No channels or conversations yet. Open the app and browse your servers, then try again.",
         "sharing.commentPlaceholder":       "Add a comment (optional)",
         "sharing.sending":                  "Sending…",
+        "sharing.uploading":                "Uploading",
         "sharing.filterTitle":              "Filter",
         "sharing.filterAll":                "All",
         "sharing.filterUsers":              "Users",
@@ -2524,6 +2526,7 @@ extension L10n {
         "sharing.emptySuggestions":         "Chưa có kênh hoặc cuộc trò chuyện. Mở ứng dụng và vào máy chủ của bạn, rồi thử lại.",
         "sharing.commentPlaceholder":       "Thêm bình luận (tùy chọn)",
         "sharing.sending":                  "Đang gửi…",
+        "sharing.uploading":                "Đang tải lên",
         "sharing.filterTitle":              "Lọc",
         "sharing.filterAll":                "Tất cả",
         "sharing.filterUsers":              "Người dùng",

--- a/MezonChat/Features/Chat/Cells/MessageFileAttachmentNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageFileAttachmentNode.swift
@@ -1,6 +1,38 @@
 import UIKit
 import AsyncDisplayKit
 
+final class UploadProgressBarNode: ASDisplayNode {
+
+    private let fillNode = ASDisplayNode()
+    private let progress: CGFloat
+
+    init(
+        progress: Double,
+        width: CGFloat,
+        height: CGFloat = 4,
+        trackColor: UIColor,
+        fillColor: UIColor
+    ) {
+        self.progress = CGFloat(min(max(progress, 0), 1))
+        super.init()
+        isUserInteractionEnabled = false
+        backgroundColor = trackColor
+        cornerRadius = height / 2
+        clipsToBounds = true
+        if width > 0 {
+            style.preferredSize = CGSize(width: width, height: height)
+        }
+        fillNode.backgroundColor = fillColor
+        fillNode.cornerRadius = height / 2
+        addSubnode(fillNode)
+    }
+
+    override func layout() {
+        super.layout()
+        fillNode.frame = CGRect(x: 0, y: 0, width: bounds.width * progress, height: bounds.height)
+    }
+}
+
 final class MessageFileAttachmentNode: ASDisplayNode {
 
     private var fileNodes: [FileItemNode] = []
@@ -64,11 +96,13 @@ final class FileItemNode: ASDisplayNode {
     private let bgNode = ASDisplayNode()
     private let spinnerNode: ASDisplayNode?
     private let progressLabelNode: ASTextNode2?
+    private let progressBarNode: UploadProgressBarNode?
     private let showsUploadSpinner: Bool
 
     private static let spinnerSide: CGFloat = 24
     private static let spinnerLeadingGap: CGFloat = 8
     private static let progressLabelWidth: CGFloat = 40
+    private static let progressBarHeight: CGFloat = 3
 
     var onTapped: (() -> Void)?
     var tag: Int = 0
@@ -82,6 +116,7 @@ final class FileItemNode: ASDisplayNode {
         let progress = attachment.uploadProgress
         let spinner: ASDisplayNode?
         let progressLabel: ASTextNode2?
+        let progressBar: UploadProgressBarNode?
         if shows {
             let s = ASDisplayNode()
             s.isUserInteractionEnabled = false
@@ -105,16 +140,25 @@ final class FileItemNode: ASDisplayNode {
                 )
                 label.maximumNumberOfLines = 1
                 progressLabel = label
+                progressBar = UploadProgressBarNode(
+                    progress: progress,
+                    width: 0,
+                    height: Self.progressBarHeight,
+                    trackColor: UIColor.theme.borderDim,
+                    fillColor: UIColor.theme.textLink)
             } else {
                 progressLabel = nil
+                progressBar = nil
             }
         } else {
             spinner = nil
             progressLabel = nil
+            progressBar = nil
         }
         self.showsUploadSpinner = shows
         self.spinnerNode = spinner
         self.progressLabelNode = progressLabel
+        self.progressBarNode = progressBar
         super.init()
 
         let t = UIColor.theme
@@ -146,6 +190,9 @@ final class FileItemNode: ASDisplayNode {
         }
         if let progressLabelNode {
             addSubnode(progressLabelNode)
+        }
+        if let progressBarNode {
+            addSubnode(progressBarNode)
         }
     }
 
@@ -207,6 +254,16 @@ final class FileItemNode: ASDisplayNode {
                 let px = sx - progressGap - progressW
                 progressLabelNode.frame = CGRect(x: px, y: centerY - 9, width: progressW, height: 18)
             }
+        }
+
+        if let progressBarNode {
+            let barInset: CGFloat = 12
+            let barY = bounds.height - Self.progressBarHeight - 6
+            progressBarNode.frame = CGRect(
+                x: barInset,
+                y: barY,
+                width: max(0, bounds.width - barInset * 2),
+                height: Self.progressBarHeight)
         }
     }
 

--- a/MezonChat/Features/Chat/Cells/MessageMediaContentNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageMediaContentNode.swift
@@ -616,11 +616,18 @@ final class MessageMediaContentNode: ASDisplayNode {
             )
             label.maximumNumberOfLines = 1
             overlay.addSubnode(label)
+            let bar = UploadProgressBarNode(
+                progress: progress,
+                width: 90,
+                height: 4,
+                trackColor: UIColor.white.withAlphaComponent(0.3),
+                fillColor: .white)
+            overlay.addSubnode(bar)
             overlay.layoutSpecBlock = { _, _ in
                 let stack = ASStackLayoutSpec.vertical()
                 stack.spacing = 6
                 stack.horizontalAlignment = .middle
-                stack.children = [spinner, label]
+                stack.children = [spinner, label, bar]
                 return ASCenterLayoutSpec(centeringOptions: .XY, sizingOptions: [], child: stack)
             }
         } else {

--- a/MezonChat/Features/DirectMessages/DmListItemCell.swift
+++ b/MezonChat/Features/DirectMessages/DmListItemCell.swift
@@ -378,7 +378,14 @@ final class DmListItemCell: UITableViewCell {
             return (Self.previewWhenNoMessageBody(), time)
         }
         let body = Self.normalizeJsonEscapedSlashes(in: preview)
-        return (body.utf8.count >= 31 ? body + "..." : body, time)
+        return (Self.appendPreviewEllipsisIfTruncated(body), time)
+    }
+
+    private static func appendPreviewEllipsisIfTruncated(_ body: String) -> String {
+        let serverLimit = 32
+        let maxUTF8CharWidth = 4
+        let truncationThreshold = serverLimit - maxUTF8CharWidth
+        return body.utf8.count >= truncationThreshold ? body + "..." : body
     }
 
     private static let contentKeysAllowingEmptyAttachmentInference: Set<String> = ["t", "mk", "ej", "hg"]

--- a/MezonChat/Features/Sharing/SharingViewController.swift
+++ b/MezonChat/Features/Sharing/SharingViewController.swift
@@ -29,6 +29,11 @@ final class SharingViewController: UIViewController {
     private var sendTask: Task<Void, Never>?
     private var searchDebounceTimer: Foundation.Timer?
 
+    private var uploadProgressByKey: [String: Double] = [:]
+    private var uploadSizeByKey: [String: Int] = [:]
+    private var uploadTotalBytes: Int = 0
+    private var showsUploadProgress = false
+
     private var diffableDataSource: UITableViewDiffableDataSource<Section, SharingSuggestionItem>!
 
     private var sharedMediaFiles: [SharingManager.SharedMediaFile] = []
@@ -217,6 +222,14 @@ final class SharingViewController: UIViewController {
         return b
     }()
 
+    private let blockingBackdrop: UIView = {
+        let v = UIView()
+        v.translatesAutoresizingMaskIntoConstraints = false
+        v.backgroundColor = UIColor.black.withAlphaComponent(0.25)
+        v.isHidden = true
+        return v
+    }()
+
     private let loadingOverlay: UIView = {
         let v = UIView()
         v.translatesAutoresizingMaskIntoConstraints = false
@@ -240,6 +253,14 @@ final class SharingViewController: UIViewController {
         l.font = .systemFont(ofSize: 13, weight: .medium)
         l.textAlignment = .center
         return l
+    }()
+
+    private let uploadProgressView: UIProgressView = {
+        let p = UIProgressView(progressViewStyle: .default)
+        p.translatesAutoresizingMaskIntoConstraints = false
+        p.progress = 0
+        p.isHidden = true
+        return p
     }()
 
     private var bottomAreaBottomConstraint: NSLayoutConstraint?
@@ -268,6 +289,23 @@ final class SharingViewController: UIViewController {
             self, selector: #selector(handleLanguageChange), name: LanguageManager.didChangeNotification, object: nil)
         NotificationCenter.default.addObserver(
             self, selector: #selector(handleThemeChange), name: ThemeManager.didChangeNotification, object: nil)
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(handleUploadProgress(_:)), name: .mezonAttachmentUploadProgress, object: nil)
+    }
+
+    @objc private func handleUploadProgress(_ note: Notification) {
+        guard isUploading, showsUploadProgress, uploadTotalBytes > 0 else { return }
+        guard let info = note.userInfo,
+              let key = info["key"] as? String,
+              uploadSizeByKey[key] != nil,
+              let progress = info["progress"] as? Double else { return }
+        uploadProgressByKey[key] = min(max(progress, 0), 1)
+        let uploadedBytes = uploadSizeByKey.reduce(0.0) { acc, entry in
+            acc + (uploadProgressByKey[entry.key] ?? 0) * Double(entry.value)
+        }
+        let fraction = min(max(uploadedBytes / Double(uploadTotalBytes), 0), 1)
+        uploadProgressView.setProgress(Float(fraction), animated: true)
+        loadingLabel.text = "\(L(L10n.Sharing.uploading)) \(Int(fraction * 100))%"
     }
 
     @objc private func handleThemeChange() {
@@ -358,9 +396,11 @@ final class SharingViewController: UIViewController {
         inputPill.addSubview(textField)
         inputRow.addSubview(sendButton)
 
+        view.addSubview(blockingBackdrop)
         view.addSubview(loadingOverlay)
         loadingOverlay.addSubview(activityIndicator)
         loadingOverlay.addSubview(loadingLabel)
+        loadingOverlay.addSubview(uploadProgressView)
 
         let safeArea = view.safeAreaLayoutGuide
 
@@ -488,16 +528,27 @@ final class SharingViewController: UIViewController {
         ])
 
         NSLayoutConstraint.activate([
+            blockingBackdrop.topAnchor.constraint(equalTo: view.topAnchor),
+            blockingBackdrop.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            blockingBackdrop.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            blockingBackdrop.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+
             loadingOverlay.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             loadingOverlay.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            loadingOverlay.widthAnchor.constraint(equalToConstant: 140),
-            loadingOverlay.heightAnchor.constraint(equalToConstant: 100),
+            loadingOverlay.widthAnchor.constraint(equalToConstant: 220),
+            loadingOverlay.heightAnchor.constraint(equalToConstant: 110),
 
             activityIndicator.centerXAnchor.constraint(equalTo: loadingOverlay.centerXAnchor),
-            activityIndicator.centerYAnchor.constraint(equalTo: loadingOverlay.centerYAnchor, constant: -10),
+            activityIndicator.topAnchor.constraint(equalTo: loadingOverlay.topAnchor, constant: 20),
 
             loadingLabel.topAnchor.constraint(equalTo: activityIndicator.bottomAnchor, constant: 8),
             loadingLabel.centerXAnchor.constraint(equalTo: loadingOverlay.centerXAnchor),
+            loadingLabel.leadingAnchor.constraint(equalTo: loadingOverlay.leadingAnchor, constant: 20),
+            loadingLabel.trailingAnchor.constraint(equalTo: loadingOverlay.trailingAnchor, constant: -20),
+
+            uploadProgressView.topAnchor.constraint(equalTo: loadingLabel.bottomAnchor, constant: 10),
+            uploadProgressView.leadingAnchor.constraint(equalTo: loadingOverlay.leadingAnchor, constant: 20),
+            uploadProgressView.trailingAnchor.constraint(equalTo: loadingOverlay.trailingAnchor, constant: -20),
         ])
 
         if !sharedMediaFiles.isEmpty {
@@ -977,8 +1028,13 @@ final class SharingViewController: UIViewController {
 
         suggestionsTitle.textColor = t.textDisabled
         emptySuggestionsLabel.textColor = t.textDisabled
+        loadingOverlay.backgroundColor = t.secondary
+        loadingOverlay.layer.borderColor = t.border.cgColor
+        loadingOverlay.layer.borderWidth = 1
         loadingLabel.textColor = t.textStrong
-        activityIndicator.color = t.iconSecondary
+        activityIndicator.color = t.textLink
+        uploadProgressView.progressTintColor = t.textLink
+        uploadProgressView.trackTintColor = t.borderDim
 
         inputPill.backgroundColor = t.charcoal
         textField.textColor = t.textStrong
@@ -1320,12 +1376,69 @@ final class SharingViewController: UIViewController {
         }
     }
 
+    private func uploadSharedVideoThumbnail(
+        thumbnailURL: URL,
+        videoFilename: String,
+        token: String
+    ) async -> String {
+        guard let rawData = try? Data(contentsOf: thumbnailURL),
+              let image = UIImage(data: rawData) else { return "" }
+        let jpegData = image.jpegData(compressionQuality: 0.7) ?? rawData
+
+        let baseName = (videoFilename as NSString).deletingPathExtension
+        let thumbFilename = "\(baseName.isEmpty ? "video" : baseName)_thumb.jpg"
+        let width = Int(image.size.width)
+        let height = Int(image.size.height)
+
+        do {
+            let uploadInfo = try await context.account.network.uploadAttachmentFile(
+                filename: thumbFilename, filetype: "image/jpeg", size: jpegData.count,
+                width: width, height: height, token: token, preferHTTPFirst: true)
+            try await context.account.network.uploadToMinIO(
+                url: uploadInfo.url, data: jpegData, contentType: "image/jpeg")
+            return "\(MezonConfig.baseImgURL)/\(uploadInfo.filename)"
+        } catch {
+            SentryLogger.capture(error, extras: [
+                "where": "Sharing.uploadSharedVideoThumbnail",
+                "filename": thumbFilename,
+            ])
+            return ""
+        }
+    }
+
+    private static let chunkUploadThreshold = 50 * 1024 * 1024
+
+    private func prepareUploadProgress() {
+        uploadProgressByKey.removeAll()
+        uploadSizeByKey.removeAll()
+        uploadTotalBytes = 0
+        showsUploadProgress = false
+
+        var hasLargeFile = false
+        for file in sharedMediaFiles {
+            guard let fileURL = SharingManager.shared.localFileURL(from: file.path),
+                  let attrs = try? FileManager.default.attributesOfItem(atPath: fileURL.path),
+                  let size = (attrs[.size] as? NSNumber)?.intValue, size > 0 else { continue }
+            uploadSizeByKey[fileURL.path] = size
+            uploadTotalBytes += size
+            if size >= Self.chunkUploadThreshold { hasLargeFile = true }
+        }
+        showsUploadProgress = hasLargeFile && uploadTotalBytes > 0
+    }
+
     private func performSend(to channel: Mezon_Api_ChannelDescription) {
         sendTask?.cancel()
+        prepareUploadProgress()
         isUploading = true
         closeButton.isEnabled = false
+        blockingBackdrop.isHidden = false
         loadingOverlay.isHidden = false
         activityIndicator.startAnimating()
+        uploadProgressView.isHidden = !showsUploadProgress
+        uploadProgressView.progress = 0
+        loadingLabel.text = showsUploadProgress
+            ? "\(L(L10n.Sharing.uploading)) 0%"
+            : L(L10n.Sharing.sending)
         updateSendButton()
 
         sendTask = Task { @MainActor [weak self] in
@@ -1347,8 +1460,14 @@ final class SharingViewController: UIViewController {
             func finishUploadingUI() {
                 self.isUploading = false
                 self.closeButton.isEnabled = true
+                self.blockingBackdrop.isHidden = true
                 self.loadingOverlay.isHidden = true
                 self.activityIndicator.stopAnimating()
+                self.uploadProgressView.isHidden = true
+                self.uploadProgressView.progress = 0
+                self.showsUploadProgress = false
+                self.uploadProgressByKey.removeAll()
+                self.loadingLabel.text = L(L10n.Sharing.sending)
                 self.updateSendButton()
                 self.sendTask = nil
             }
@@ -1404,31 +1523,33 @@ final class SharingViewController: UIViewController {
 
                     let sanitized = filename.replacingOccurrences(of: "[^a-zA-Z0-9._-]", with: "_", options: .regularExpression)
 
-                    let uploadInfo = try await self.context.account.network.uploadAttachmentFile(
+                    let uploaded = try await AttachmentUploader.shared.uploadFile(
+                        fileURL: fileURL,
                         filename: sanitized,
                         filetype: filetype,
-                        size: fileSize,
+                        fileSize: fileSize,
                         width: width,
                         height: height,
                         token: token,
-                        preferHTTPFirst: true
+                        progressKey: fileURL.path,
+                        preferHTTPFirst: true,
+                        network: self.context.account.network
                     )
 
-                    try await self.uploadToMinIORetrying(
-                        url: uploadInfo.url,
-                        fileURL: fileURL,
-                        contentType: filetype
-                    )
-
-                    let cdnURL = "\(MezonConfig.baseImgURL)/\(uploadInfo.filename)"
                     var att = Mezon_Api_MessageAttachment()
                     att.filename = filename
-                    att.url = cdnURL
+                    att.url = uploaded.cdnURL
                     att.filetype = filetype
                     att.size = Int32(fileSize)
                     if width > 0 { att.width = Int32(width) }
                     if height > 0 { att.height = Int32(height) }
                     if let duration = file.duration { att.duration = Int32(duration / 1000) }
+                    if file.type == .video,
+                       let thumbPath = file.thumbnail,
+                       let thumbURL = SharingManager.shared.localFileURL(from: thumbPath) {
+                        att.thumbnail = await self.uploadSharedVideoThumbnail(
+                            thumbnailURL: thumbURL, videoFilename: sanitized, token: token)
+                    }
                     uploadedAttachments.append(att)
                 }
 
@@ -1508,16 +1629,6 @@ final class SharingViewController: UIViewController {
                 finishUploadingUI()
                 self.showError(self.userFacingShareError(error))
             }
-        }
-    }
-
-    private func uploadToMinIORetrying(url: String, fileURL: URL, contentType: String) async throws {
-        do {
-            try await context.account.network.uploadToMinIO(url: url, fileURL: fileURL, contentType: contentType)
-        } catch let error as URLError where error.code == .cancelled {
-            try Task.checkCancellation()
-            try await Task.sleep(nanoseconds: 400_000_000)
-            try await context.account.network.uploadToMinIO(url: url, fileURL: fileURL, contentType: contentType)
         }
     }
 

--- a/MezonChat/Networking/AttachmentUploader.swift
+++ b/MezonChat/Networking/AttachmentUploader.swift
@@ -37,7 +37,7 @@ final class AttachmentUploader {
     private init() {}
 
     private static let partSize = 10 * 1024 * 1024
-    private static let minMultipartFileSize = 10 * 1024 * 1024
+    private static let minMultipartFileSize = 50 * 1024 * 1024
     private static let maxParallelParts = 3
 
     private struct MultipartNotApplicable: Error {}
@@ -63,6 +63,7 @@ final class AttachmentUploader {
         height: Int = 0,
         token: String,
         progressKey: String = "",
+        preferHTTPFirst: Bool = false,
         network: MezonHTTPClient
     ) async throws -> UploadedAttachmentFile {
         reportProgress(0, forKey: progressKey)
@@ -72,7 +73,8 @@ final class AttachmentUploader {
                 return try await uploadMultipart(
                     fileURL: fileURL, filename: filename, filetype: filetype,
                     fileSize: fileSize, width: width, height: height,
-                    token: token, progressKey: progressKey, network: network)
+                    token: token, progressKey: progressKey,
+                    preferHTTPFirst: preferHTTPFirst, network: network)
             } catch is MultipartNotApplicable {
                 markMultipartUnavailable()
             } catch {
@@ -87,7 +89,8 @@ final class AttachmentUploader {
         return try await uploadSinglePut(
             fileURL: fileURL, filename: filename, filetype: filetype,
             fileSize: fileSize, width: width, height: height,
-            token: token, progressKey: progressKey, network: network)
+            token: token, progressKey: progressKey,
+            preferHTTPFirst: preferHTTPFirst, network: network)
     }
 
     private func uploadSinglePut(
@@ -99,11 +102,13 @@ final class AttachmentUploader {
         height: Int,
         token: String,
         progressKey: String,
+        preferHTTPFirst: Bool,
         network: MezonHTTPClient
     ) async throws -> UploadedAttachmentFile {
         let info = try await network.uploadAttachmentFile(
             filename: filename, filetype: filetype, size: fileSize,
-            width: width, height: height, token: token)
+            width: width, height: height, token: token,
+            preferHTTPFirst: preferHTTPFirst)
         _ = try await MinIOStreamingUploader.shared.put(
             url: info.url, fileURL: fileURL, contentType: filetype
         ) { [weak self] fraction in
@@ -124,12 +129,14 @@ final class AttachmentUploader {
         height: Int,
         token: String,
         progressKey: String,
+        preferHTTPFirst: Bool,
         network: MezonHTTPClient
     ) async throws -> UploadedAttachmentFile {
         let requestedPartCount = max(1, Int((Double(fileSize) / Double(Self.partSize)).rounded(.up)))
         let start = try await network.multipartUploadAttachmentFileStart(
             filename: filename, filetype: filetype, size: fileSize,
-            width: width, height: height, partCount: requestedPartCount, token: token)
+            width: width, height: height, partCount: requestedPartCount, token: token,
+            preferHTTPFirst: preferHTTPFirst)
         let urls = start.urls
         let uploadId = start.uploadID
 
@@ -190,7 +197,8 @@ final class AttachmentUploader {
         collected.sort { $0.partNumber < $1.partNumber }
 
         let finish = try await network.multipartUploadAttachmentFileFinish(
-            uploadId: uploadId, parts: collected, filename: start.filename, token: token)
+            uploadId: uploadId, parts: collected, filename: start.filename, token: token,
+            preferHTTPFirst: preferHTTPFirst)
         reportProgress(1, forKey: progressKey)
 
         let serverFilename: String = {

--- a/MezonChat/Networking/MezonHTTPClient.swift
+++ b/MezonChat/Networking/MezonHTTPClient.swift
@@ -1457,7 +1457,8 @@ final class MezonHTTPClient {
         width: Int = 0,
         height: Int = 0,
         partCount: Int,
-        token: String
+        token: String,
+        preferHTTPFirst: Bool = false
     ) async throws -> Mezon_Api_MultipartUploadAttachment {
         var req = Mezon_Api_UploadAttachmentRequest()
         req.filename = filename
@@ -1474,7 +1475,8 @@ final class MezonHTTPClient {
         return try await postProto(
             path: "/mezon.api.Mezon/MultipartUploadAttachmentFileStart",
             message: req,
-            auth: .bearer(token)
+            auth: .bearer(token),
+            preferHTTPFirst: preferHTTPFirst
         )
     }
 
@@ -1482,7 +1484,8 @@ final class MezonHTTPClient {
         uploadId: String,
         parts: [(partNumber: Int, eTag: String)],
         filename: String,
-        token: String
+        token: String,
+        preferHTTPFirst: Bool = false
     ) async throws -> Mezon_Api_UploadAttachment {
         var req = Mezon_Api_MultipartUploadAttachmentFinishRequest()
         req.uploadID = uploadId
@@ -1496,7 +1499,8 @@ final class MezonHTTPClient {
         return try await postProto(
             path: "/mezon.api.Mezon/MultipartUploadAttachmentFileFinish",
             message: req,
-            auth: .bearer(token)
+            auth: .bearer(token),
+            preferHTTPFirst: preferHTTPFirst
         )
     }
 


### PR DESCRIPTION
Chunked multipart upload for large attachment files

## Summary
Adds a **multipart upload** flow for large attachments: a file is split into chunks and uploaded in parallel via MinIO presigned URLs instead of a single PUT. This avoids holding the whole file in memory (no OOM on ~1 GB files), enables parallel uploads, and has a safe fallback to single PUT.

## How it works

### Trigger threshold
| Condition | Flow |
|---|---|
| `fileSize >= 50 MB` | **Multipart** (chunked) |
| `fileSize < 50 MB` | **Single PUT** (streamed from file) |

- `minMultipartFileSize = 10 MB` — decides which flow to use.
- `partSize = 10 MB` — size of each chunk.
- `maxParallelParts = 3` — max number of parts uploaded concurrently.

### Chunking
- `partCount = ceil(fileSize / partSize)`.
  Example: a 64 MB file → `ceil(64 / 10) = 7` parts (first 6 parts are 10 MB, last part is the remainder).
- Each chunk is read **lazily from disk** via `FileHandle.seek(toOffset:)` right before its PUT → the whole file is never loaded into memory.
- Part `k` uses exactly `urls[k]` returned by the server; the last part runs to `fileSize`.

### RPC flow
1. **Start** — `MultipartUploadAttachmentFileStart`
   Sends: `filename, filetype, size, width, height, part_count, parts[part_number]`.
   Returns: `{ filename (object key), urls[] (presigned PUT per part), upload_id }`.
2. **PUT part** — PUT each chunk directly to its MinIO presigned URL (up to 3 in parallel), collecting the `ETag` of each part.
3. **Finish** — `MultipartUploadAttachmentFileFinish`
   Sends: `upload_id, parts[{part_number, e_tag}], filename` → server runs `CompleteMultipartUpload` to assemble the object.

### Safe fallback
- Server returns `urls.count == 1 && upload_id empty` → a single presigned PUT (streamed from file).
- Server returns empty `urls` or empty `upload_id` → throws `MultipartNotApplicable` → single PUT; also sets `skipMultipartForSession` so subsequent files in the session don't call Start uselessly.
- Single PUT uses `MinIOStreamingUploader` (`URLSession.uploadTask(fromFile:)`) → streamed from disk, with byte-level progress.

### Progress & UI performance
- `AttachmentUploadProgressStore` keeps per-file progress; posts a `NotificationCenter` event on each 1% change.
- `ChatViewController` **debounces** the message-list rebuild (coalesced to at most ~1 per 250 ms) to avoid lag/flicker when uploading many large files at once.

### Temp-file durability (document picker)
- A picked file (from iCloud/Files or the tmp `-Inbox` import copy) is **copied to `tmp/mezon-uploads/<uuid>.<ext>`** at pick time (handling security-scoped resources), and uploaded from that copy → avoids iOS tmp cleanup / filename collisions / the file disappearing mid-upload.
- `uploadFiles` checks the file exists before uploading; if missing it logs clearly instead of failing with an obscure error.

## Test plan
- [ ] File < 10 MB → single PUT, uploads OK.
- [ ] File >= 10 MB → multipart: flow runs `Start → PUT 1..N → Finish`, file opens on the CDN.
- [ ] ~200 MB file (document) → uploads OK, no memory spike.
- [ ] Pick the same file twice in a row → no "file doesn't exist" error.
- [ ] Upload many large files at once → message list does not lag/flicker heavily.
- [ ] Server without multipart support → auto-fallback to single PUT, no crash.
- [ ] Video: original uploaded via multipart + thumbnail.
