### PR TITLE
fix: bugs about create thread

### DIFF
--- a/MezonChat/Core/Localization/L10n.swift
+++ b/MezonChat/Core/Localization/L10n.swift
@@ -645,6 +645,8 @@ enum L10n {
     enum ThreadList {
         static let searchPlaceholder = "threadList.searchPlaceholder"
         static let empty = "threadList.empty"
+        static let emptyTitle = "threadList.emptyTitle"
+        static let emptyDescription = "threadList.emptyDescription"
         static let joinedThread = "threadList.joinedThread"
         static let joinedThreads = "threadList.joinedThreads"
         static let otherActiveThread = "threadList.otherActiveThread"
@@ -654,6 +656,7 @@ enum L10n {
         static let searchThread = "threadList.searchThread"
         static let searchThreads = "threadList.searchThreads"
         static let createThreadSoon = "threadList.createThreadSoon"
+        static let createThreadButton = "threadList.createThreadButton"
         static let createThreadTitle = "threadList.createThreadTitle"
         static let createThreadNameLabel = "threadList.createThreadNameLabel"
         static let createThreadNamePlaceholder = "threadList.createThreadNamePlaceholder"
@@ -676,6 +679,8 @@ enum L10n {
     enum ChatSystem {
         static let pinMessageAnchor = "chat.system.pinMessageAnchor"
         static let allThreadsAnchor = "chat.system.allThreadsAnchor"
+        static let startedThread = "chat.system.startedThread"
+        static let seeAllThreads = "chat.system.seeAllThreads"
     }
 
     enum Channel {
@@ -792,6 +797,7 @@ enum L10n {
         static let welcomeToChannel = "chatWelcome.welcomeToChannel"
         static let startOfChannel = "chatWelcome.startOfChannel"
         static let privateChannel = "chatWelcome.privateChannel"
+        static let threadStartedBy = "chatWelcome.threadStartedBy"
         static let beginningOfDM = "chatWelcome.beginningOfDM"
         static let welcomeToGroup = "chatWelcome.welcomeToGroup"
     }
@@ -1567,8 +1573,10 @@ extension L10n {
         "clan.inviteSheet.invited":         "Invited",
         "clan.inviteSheet.unknownClan":     "Unknown Clan",
 
-        "threadList.searchPlaceholder": "Search for Thread Name",
+        "threadList.searchPlaceholder": "Search Threads",
         "threadList.empty": "No threads yet",
+        "threadList.emptyTitle": "There are no threads",
+        "threadList.emptyDescription": "Stay focus on conversation with a thread\n- a temporary text channel.",
         "threadList.joinedThread": "joined thread",
         "threadList.joinedThreads": "joined threads",
         "threadList.otherActiveThread": "other active thread",
@@ -1578,6 +1586,7 @@ extension L10n {
         "threadList.searchThread": "search result",
         "threadList.searchThreads": "search results",
         "threadList.createThreadSoon": "Create thread is not available here yet.",
+        "threadList.createThreadButton": "Create Thread",
         "threadList.createThreadTitle": "New thread",
         "threadList.createThreadNameLabel": "Thread name",
         "threadList.createThreadNamePlaceholder": "New thread",
@@ -1585,7 +1594,7 @@ extension L10n {
         "threadList.createThreadPrivateSubtitle": "Only people you invite can access this thread.",
         "threadList.createThreadSubmit": "Create",
         "threadList.createThreadCancel": "Cancel",
-        "threadList.createThreadNameInvalid": "Enter a name up to 64 characters.",
+        "threadList.createThreadNameInvalid": "Enter a name from 4 to 64 characters.",
         "threadList.createThreadFailed": "Could not create thread.",
         "threadList.createThreadSuccess": "Thread created.",
         "threadList.createThreadInChannel": "In #%@",
@@ -1600,6 +1609,8 @@ extension L10n {
         "channel.thread": "Threads",
         "chat.system.pinMessageAnchor": "a message",
         "chat.system.allThreadsAnchor": "all threads",
+        "chat.system.startedThread": "started a thread:",
+        "chat.system.seeAllThreads": "See",
         "channel.settings": "Channel Settings",
         "channel.threadSettings": "Thread Settings",
         "channel.name":   "Channel Name",
@@ -1789,6 +1800,7 @@ extension L10n {
         "chatWelcome.welcomeToChannel": "Welcome to #%@",
         "chatWelcome.startOfChannel": "This is the start of the #%@ %@ channel",
         "chatWelcome.privateChannel": "private",
+        "chatWelcome.threadStartedBy": "Started by %@",
         "chatWelcome.beginningOfDM": "This is the very beginning of your legendary conversation with %@",
         "chatWelcome.welcomeToGroup": "Welcome to the beginning of the %@ group.",
 
@@ -2555,8 +2567,10 @@ extension L10n {
         "clan.inviteSheet.invited":         "Đã mời",
         "clan.inviteSheet.unknownClan":     "Clan không xác định",
 
-        "threadList.searchPlaceholder": "Tìm theo tên chủ đề",
+        "threadList.searchPlaceholder": "Tìm chủ đề",
         "threadList.empty": "Chưa có chủ đề",
+        "threadList.emptyTitle": "Chưa có chủ đề",
+        "threadList.emptyDescription": "Tập trung vào cuộc trò chuyện bằng một chủ đề\n- một kênh văn bản tạm thời.",
         "threadList.joinedThread": "chủ đề đã tham gia",
         "threadList.joinedThreads": "chủ đề đã tham gia",
         "threadList.otherActiveThread": "chủ đề hoạt động khác",
@@ -2566,6 +2580,7 @@ extension L10n {
         "threadList.searchThread": "kết quả",
         "threadList.searchThreads": "kết quả",
         "threadList.createThreadSoon": "Tạo chủ đề từ đây sẽ có trong bản cập nhật sau.",
+        "threadList.createThreadButton": "Tạo chủ đề",
         "threadList.createThreadTitle": "Chủ đề mới",
         "threadList.createThreadNameLabel": "Tên chủ đề",
         "threadList.createThreadNamePlaceholder": "Chủ đề mới",
@@ -2573,7 +2588,7 @@ extension L10n {
         "threadList.createThreadPrivateSubtitle": "Chỉ những người được mời mới vào được chủ đề này.",
         "threadList.createThreadSubmit": "Tạo",
         "threadList.createThreadCancel": "Hủy",
-        "threadList.createThreadNameInvalid": "Nhập tên không quá 64 ký tự.",
+        "threadList.createThreadNameInvalid": "Nhập tên từ 4 đến 64 ký tự.",
         "threadList.createThreadFailed": "Không tạo được chủ đề.",
         "threadList.createThreadSuccess": "Đã tạo chủ đề.",
         "threadList.createThreadInChannel": "Trong #%@",
@@ -2588,6 +2603,8 @@ extension L10n {
         "channel.thread": "Chủ đề",
         "chat.system.pinMessageAnchor": "một tin nhắn",
         "chat.system.allThreadsAnchor": "tất cả chủ đề",
+        "chat.system.startedThread": "đã tạo một chủ đề:",
+        "chat.system.seeAllThreads": "Xem",
         "channel.settings": "Cài đặt kênh",
         "channel.threadSettings": "Cài đặt chủ đề",
         "channel.name":   "Tên kênh",
@@ -2778,6 +2795,7 @@ extension L10n {
         "chatWelcome.welcomeToChannel": "Chào mừng đến với #%@",
         "chatWelcome.startOfChannel": "Đây là nơi bắt đầu của kênh #%@ %@",
         "chatWelcome.privateChannel": "riêng tư",
+        "chatWelcome.threadStartedBy": "Được tạo bởi %@",
         "chatWelcome.beginningOfDM": "Đây là nơi bắt đầu cuộc trò chuyện của bạn và %@",
         "chatWelcome.welcomeToGroup": "Chào mừng bạn đến với nhóm %@.",
 

--- a/MezonChat/Features/ChannelDetail/CreateThreadFormViewController.swift
+++ b/MezonChat/Features/ChannelDetail/CreateThreadFormViewController.swift
@@ -73,6 +73,9 @@ final class CreateThreadFormViewController: UIViewController {
     private var advancePanelBottomConstraint: NSLayoutConstraint?
     private var advancePanelCollapsedHeight: CGFloat = 0
 
+    private static let minThreadNameLength = 4
+    private static let maxThreadNameLength = 64
+
     private let locationManager = CLLocationManager()
     private var locationCompletion: ((CLLocationCoordinate2D?) -> Void)?
 
@@ -136,13 +139,6 @@ final class CreateThreadFormViewController: UIViewController {
             target: self,
             action: #selector(cancelTapped)
         )
-        navigationItem.rightBarButtonItem = UIBarButtonItem(
-            title: L(L10n.ThreadList.createThreadSubmit),
-            style: .done,
-            target: self,
-            action: #selector(submitTapped)
-        )
-
         contextLabel.text = String(format: L(L10n.ThreadList.createThreadInChannel), parentChannelLabel)
         nameCaptionLabel.text = L(L10n.ThreadList.createThreadNameLabel)
 
@@ -458,14 +454,15 @@ final class CreateThreadFormViewController: UIViewController {
         dismiss(animated: true)
     }
 
-    @objc private func submitTapped() {
-        performCreateThreadSubmission()
+    private func isValidThreadName(_ value: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.count >= Self.minThreadNameLength && trimmed.count <= Self.maxThreadNameLength
     }
 
     private func performCreateThreadSubmission() {
         guard !pendingThreadSubmission else { return }
         let trimmed = (nameField.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.count >= 1, trimmed.count <= 64 else {
+        guard isValidThreadName(trimmed) else {
             let msg = L(L10n.ThreadList.createThreadNameInvalid)
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
@@ -482,7 +479,6 @@ final class CreateThreadFormViewController: UIViewController {
         }
 
         pendingThreadSubmission = true
-        navigationItem.rightBarButtonItem?.isEnabled = false
         navigationItem.leftBarButtonItem?.isEnabled = false
         activityIndicator.startAnimating()
 
@@ -490,7 +486,6 @@ final class CreateThreadFormViewController: UIViewController {
             guard let token = await context.getToken() else {
                 pendingThreadSubmission = false
                 activityIndicator.stopAnimating()
-                navigationItem.rightBarButtonItem?.isEnabled = true
                 navigationItem.leftBarButtonItem?.isEnabled = true
                 Toast.error(L(L10n.ThreadList.createThreadFailed))
                 return
@@ -517,7 +512,6 @@ final class CreateThreadFormViewController: UIViewController {
                         self.sendInputVC.onError = nil
                         self.pendingThreadSubmission = false
                         self.activityIndicator.stopAnimating()
-                        self.navigationItem.rightBarButtonItem?.isEnabled = true
                         self.navigationItem.leftBarButtonItem?.isEnabled = true
                         self.finishCreateSuccess(created: created)
                     }
@@ -527,7 +521,6 @@ final class CreateThreadFormViewController: UIViewController {
                         self.sendInputVC.onError = nil
                         self.pendingThreadSubmission = false
                         self.activityIndicator.stopAnimating()
-                        self.navigationItem.rightBarButtonItem?.isEnabled = true
                         self.navigationItem.leftBarButtonItem?.isEnabled = true
                         let trimmedMsg = message.trimmingCharacters(in: .whitespacesAndNewlines)
                         if !trimmedMsg.isEmpty {
@@ -541,14 +534,12 @@ final class CreateThreadFormViewController: UIViewController {
                 } else {
                     pendingThreadSubmission = false
                     activityIndicator.stopAnimating()
-                    navigationItem.rightBarButtonItem?.isEnabled = true
                     navigationItem.leftBarButtonItem?.isEnabled = true
                     finishCreateSuccess(created: created)
                 }
             } catch {
                 pendingThreadSubmission = false
                 activityIndicator.stopAnimating()
-                navigationItem.rightBarButtonItem?.isEnabled = true
                 navigationItem.leftBarButtonItem?.isEnabled = true
                 Toast.error(L(L10n.ThreadList.createThreadFailed))
             }
@@ -798,6 +789,7 @@ extension CreateThreadFormViewController: UITextFieldDelegate {
     ) -> Bool {
         let next =
             ((textField.text ?? "") as NSString).replacingCharacters(in: range, with: string) as String
-        return next.count <= 64
+        guard next.count <= Self.maxThreadNameLength else { return false }
+        return true
     }
 }

--- a/MezonChat/Features/ChannelDetail/ThreadListViewController.swift
+++ b/MezonChat/Features/ChannelDetail/ThreadListViewController.swift
@@ -73,11 +73,15 @@ final class ThreadListViewController: ViewController {
         tableView.keyboardDismissMode = .onDrag
         tableView.backgroundColor = UIColor.theme.primary
         tableView.separatorStyle = .none
+        tableView.separatorColor = .clear
+        tableView.showsVerticalScrollIndicator = false
+        tableView.showsHorizontalScrollIndicator = false
+        tableView.tableFooterView = UIView(frame: .zero)
         if #available(iOS 15.0, *) { tableView.sectionHeaderTopPadding = 0 }
         tableView.estimatedRowHeight = 76
         tableView.rowHeight = UITableView.automaticDimension
         tableView.register(ThreadListItemCell.self, forCellReuseIdentifier: ThreadListItemCell.reuseId)
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "emptyCell")
+        tableView.register(ThreadListEmptyCell.self, forCellReuseIdentifier: ThreadListEmptyCell.reuseId)
         refreshControl.addTarget(self, action: #selector(pulledToRefresh), for: .valueChanged)
         tableView.refreshControl = refreshControl
         view.addSubview(tableView)
@@ -97,6 +101,9 @@ final class ThreadListViewController: ViewController {
         NotificationCenter.default.addObserver(
             self, selector: #selector(handleThemeChange),
             name: ThemeManager.didChangeNotification, object: nil)
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(handleChannelDescriptionDidUpdate(_:)),
+            name: .mezonChannelDescriptionDidUpdate, object: nil)
 
         applyCachedThreadsIfAny()
         rebuildSections()
@@ -105,7 +112,7 @@ final class ThreadListViewController: ViewController {
     }
 
     deinit {
-        NotificationCenter.default.removeObserver(self, name: ThemeManager.didChangeNotification, object: nil)
+        NotificationCenter.default.removeObserver(self)
     }
 
     @objc private func handleThemeChange() {
@@ -113,6 +120,48 @@ final class ThreadListViewController: ViewController {
         tableView.backgroundColor = UIColor.theme.primary
         applyNavHeaderTheme()
         applySearchBarTheme()
+        tableView.reloadData()
+    }
+
+    private static func int64UserInfo(_ value: Any?) -> Int64? {
+        if let n = value as? Int64 { return n }
+        if let n = value as? Int { return Int64(n) }
+        if let n = value as? NSNumber { return n.int64Value }
+        return nil
+    }
+
+    @objc private func handleChannelDescriptionDidUpdate(_ notification: Notification) {
+        guard let updatedClanId = Self.int64UserInfo(notification.userInfo?["clanId"]),
+              updatedClanId == clanId,
+              let channelId = Self.int64UserInfo(notification.userInfo?["channelId"]),
+              channelId != 0 else {
+            return
+        }
+
+        let candidates = cachedThreadChannelsFromChannelCaches()
+        guard var updated = candidates.first(where: { $0.channelID == channelId })
+                ?? context.account.postbox.resolvedChannelDescription(clanId: clanId, channelId: channelId) else {
+            return
+        }
+
+        let existing = allThreads.first(where: { $0.channelID == channelId })
+        if updated.parentID == 0, let existing {
+            updated.parentID = existing.parentID
+        }
+        guard updated.parentID == parentChannelId || existing != nil else { return }
+
+        allThreads = Self.filterPrivateThreads(Self.mergeThreads([updated], withFallback: allThreads))
+        if !searchText.isEmpty {
+            searchResults = Self.sortedByLastActivity(
+                allThreads.filter {
+                    $0.channelLabel.lowercased().contains(searchText)
+                }
+            )
+        }
+        cachedClanMembersList = nil
+        persistThreadsCache()
+        rebuildSections()
+        tableView.reloadData()
     }
 
     private func setupNavHeader() {
@@ -157,6 +206,7 @@ final class ThreadListViewController: ViewController {
 
     private func applyNavHeaderTheme() {
         let t = UIColor.theme
+        headerBar.backgroundColor = t.primary
         titleLabel.textColor = t.textStrong
         backButton.tintColor = t.textStrong
         addButton.tintColor = t.textStrong
@@ -186,11 +236,11 @@ final class ThreadListViewController: ViewController {
     }
 
     private func configureSearchHeader() {
-        let header = UIView(frame: CGRect(x: 0, y: 0, width: view.bounds.width, height: 66))
+        let header = UIView(frame: CGRect(x: 0, y: 0, width: view.bounds.width, height: 78))
         header.backgroundColor = .clear
 
         searchBarContainer.translatesAutoresizingMaskIntoConstraints = false
-        searchBarContainer.layer.cornerRadius = 8
+        searchBarContainer.layer.cornerRadius = 12
         searchBarContainer.clipsToBounds = true
         header.addSubview(searchBarContainer)
 
@@ -201,7 +251,7 @@ final class ThreadListViewController: ViewController {
         searchField.autocorrectionType = .no
         searchField.autocapitalizationType = .none
         searchField.returnKeyType = .search
-        searchField.font = .systemFont(ofSize: 15)
+        searchField.font = .systemFont(ofSize: 16)
         searchField.delegate = self
         searchField.addTarget(self, action: #selector(searchTextChanged), for: .editingChanged)
         searchBarContainer.addSubview(searchField)
@@ -218,10 +268,10 @@ final class ThreadListViewController: ViewController {
         NSLayoutConstraint.activate([
             searchBarContainer.leadingAnchor.constraint(equalTo: header.leadingAnchor),
             searchBarContainer.trailingAnchor.constraint(equalTo: header.trailingAnchor),
-            searchBarContainer.topAnchor.constraint(equalTo: header.topAnchor, constant: 8),
+            searchBarContainer.topAnchor.constraint(equalTo: header.topAnchor, constant: 18),
             searchBarContainer.heightAnchor.constraint(equalToConstant: 50),
 
-            searchField.leadingAnchor.constraint(equalTo: searchBarContainer.leadingAnchor, constant: 12),
+            searchField.leadingAnchor.constraint(equalTo: searchBarContainer.leadingAnchor, constant: 14),
             searchField.trailingAnchor.constraint(equalTo: searchClearButton.leadingAnchor, constant: -4),
             searchField.topAnchor.constraint(equalTo: searchBarContainer.topAnchor),
             searchField.bottomAnchor.constraint(equalTo: searchBarContainer.bottomAnchor),
@@ -232,7 +282,7 @@ final class ThreadListViewController: ViewController {
             searchClearButton.heightAnchor.constraint(equalToConstant: 32),
         ])
 
-        header.frame.size.height = 66
+        header.frame.size.height = 78
         tableView.tableHeaderView = header
         applySearchBarTheme()
     }
@@ -349,8 +399,8 @@ final class ThreadListViewController: ViewController {
             cachedThreads = decoded.channels
         }
         let merged = Self.mergeThreads(
-            cachedThreads,
-            withFallback: cachedThreadChannelsFromChannelCaches()
+            cachedThreadChannelsFromChannelCaches(),
+            withFallback: cachedThreads
         )
         if !merged.isEmpty {
             allThreads = Self.filterPrivateThreads(merged)
@@ -701,6 +751,143 @@ private enum ThreadCardPosition {
     }
 }
 
+private final class ThreadListEmptyCell: UITableViewCell {
+
+    static let reuseId = "ThreadListEmptyCell"
+
+    private let stackView = UIStackView()
+    private let iconCircleView = UIView()
+    private let iconImageView = UIImageView()
+    private let iconSlashOne = UIView()
+    private let iconSlashTwo = UIView()
+    private let titleLabel = UILabel()
+    private let descriptionLabel = UILabel()
+    private let createButton = UIButton(type: .system)
+
+    var onCreateThread: (() -> Void)?
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        backgroundColor = .clear
+        contentView.backgroundColor = .clear
+        separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: .greatestFiniteMagnitude)
+        layoutMargins = .zero
+        preservesSuperviewLayoutMargins = false
+        selectionStyle = .none
+
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(stackView)
+
+        iconCircleView.translatesAutoresizingMaskIntoConstraints = false
+        iconCircleView.layer.cornerRadius = 28
+        iconCircleView.clipsToBounds = true
+
+        iconImageView.translatesAutoresizingMaskIntoConstraints = false
+        iconImageView.contentMode = .scaleAspectFit
+        iconCircleView.addSubview(iconImageView)
+
+        [iconSlashOne, iconSlashTwo].forEach { slash in
+            slash.translatesAutoresizingMaskIntoConstraints = false
+            slash.layer.cornerRadius = 1.5
+            slash.transform = CGAffineTransform(rotationAngle: -.pi / 7)
+            iconCircleView.addSubview(slash)
+        }
+
+        titleLabel.textAlignment = .center
+        titleLabel.numberOfLines = 0
+        titleLabel.adjustsFontForContentSizeCategory = true
+
+        descriptionLabel.textAlignment = .center
+        descriptionLabel.numberOfLines = 0
+        descriptionLabel.adjustsFontForContentSizeCategory = true
+
+        createButton.translatesAutoresizingMaskIntoConstraints = false
+        createButton.layer.cornerRadius = 26
+        createButton.clipsToBounds = true
+        createButton.titleLabel?.font = .systemFont(ofSize: 16, weight: .bold)
+        createButton.addTarget(self, action: #selector(createTapped), for: .touchUpInside)
+
+        stackView.addArrangedSubview(iconCircleView)
+        stackView.setCustomSpacing(22, after: iconCircleView)
+        stackView.addArrangedSubview(titleLabel)
+        stackView.setCustomSpacing(10, after: titleLabel)
+        stackView.addArrangedSubview(descriptionLabel)
+        stackView.setCustomSpacing(32, after: descriptionLabel)
+        stackView.addArrangedSubview(createButton)
+
+        let top = stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 126)
+        top.priority = .defaultHigh
+
+        NSLayoutConstraint.activate([
+            stackView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            stackView.leadingAnchor.constraint(greaterThanOrEqualTo: contentView.leadingAnchor, constant: 24),
+            stackView.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -24),
+            stackView.topAnchor.constraint(greaterThanOrEqualTo: contentView.topAnchor, constant: 32),
+            stackView.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -32),
+            top,
+
+            iconCircleView.widthAnchor.constraint(equalToConstant: 56),
+            iconCircleView.heightAnchor.constraint(equalToConstant: 56),
+
+            iconImageView.centerXAnchor.constraint(equalTo: iconCircleView.centerXAnchor),
+            iconImageView.centerYAnchor.constraint(equalTo: iconCircleView.centerYAnchor),
+            iconImageView.widthAnchor.constraint(equalToConstant: 28),
+            iconImageView.heightAnchor.constraint(equalToConstant: 28),
+
+            iconSlashOne.centerXAnchor.constraint(equalTo: iconCircleView.centerXAnchor, constant: -4),
+            iconSlashOne.centerYAnchor.constraint(equalTo: iconCircleView.centerYAnchor, constant: -1),
+            iconSlashOne.widthAnchor.constraint(equalToConstant: 3.5),
+            iconSlashOne.heightAnchor.constraint(equalToConstant: 15),
+
+            iconSlashTwo.centerXAnchor.constraint(equalTo: iconCircleView.centerXAnchor, constant: 5),
+            iconSlashTwo.centerYAnchor.constraint(equalTo: iconCircleView.centerYAnchor, constant: -1),
+            iconSlashTwo.widthAnchor.constraint(equalToConstant: 3.5),
+            iconSlashTwo.heightAnchor.constraint(equalToConstant: 15),
+
+            descriptionLabel.widthAnchor.constraint(lessThanOrEqualToConstant: 330),
+
+            createButton.widthAnchor.constraint(equalToConstant: 156),
+            createButton.heightAnchor.constraint(equalToConstant: 52),
+        ])
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        onCreateThread = nil
+    }
+
+    func configure() {
+        let t = UIColor.theme
+        iconCircleView.backgroundColor = t.iconPrimary.withAlphaComponent(0.14)
+        iconImageView.image = UIImage(systemName: "bubble.left.fill")?.withConfiguration(
+            UIImage.SymbolConfiguration(pointSize: 24, weight: .regular)
+        )
+        iconImageView.tintColor = t.textDisabled
+        iconSlashOne.backgroundColor = .white
+        iconSlashTwo.backgroundColor = .white
+
+        titleLabel.text = L(L10n.ThreadList.emptyTitle)
+        titleLabel.font = .systemFont(ofSize: 18, weight: .bold)
+        titleLabel.textColor = t.textStrong
+
+        descriptionLabel.text = L(L10n.ThreadList.emptyDescription)
+        descriptionLabel.font = .systemFont(ofSize: 15, weight: .regular)
+        descriptionLabel.textColor = t.textDisabled
+
+        createButton.setTitle(L(L10n.ThreadList.createThreadButton), for: .normal)
+        createButton.backgroundColor = t.iconPrimary
+        createButton.setTitleColor(.white, for: .normal)
+    }
+
+    @objc private func createTapped() {
+        onCreateThread?()
+    }
+}
+
 private final class ThreadListItemCell: UITableViewCell {
 
     static let reuseId = "ThreadListItemCell"
@@ -895,6 +1082,12 @@ extension ThreadListViewController: UITableViewDataSource, UITableViewDelegate {
         40
     }
 
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        guard displaySections.isEmpty else { return UITableView.automaticDimension }
+        let headerHeight = tableView.tableHeaderView?.bounds.height ?? 0
+        return max(420, tableView.bounds.height - headerHeight)
+    }
+
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         guard !displaySections.isEmpty else { return nil }
         let v = UIView()
@@ -903,18 +1096,21 @@ extension ThreadListViewController: UITableViewDataSource, UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        displaySections.isEmpty ? 0.01 : 10
+        displaySections.isEmpty ? 0 : 10
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard !displaySections.isEmpty, indexPath.section < displaySections.count else {
-            let cell = tableView.dequeueReusableCell(withIdentifier: "emptyCell", for: indexPath)
-            cell.backgroundColor = .clear
-            cell.textLabel?.text = L(L10n.ThreadList.empty)
-            cell.textLabel?.textColor = UIColor.theme.textDisabled
-            cell.textLabel?.textAlignment = .center
-            cell.textLabel?.font = .systemFont(ofSize: 15, weight: .medium)
-            cell.selectionStyle = .none
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: ThreadListEmptyCell.reuseId,
+                for: indexPath
+            ) as? ThreadListEmptyCell else {
+                return UITableViewCell()
+            }
+            cell.configure()
+            cell.onCreateThread = { [weak self] in
+                self?.createThreadTapped()
+            }
             return cell
         }
 

--- a/MezonChat/Features/ChannelList/ChannelListViewController.swift
+++ b/MezonChat/Features/ChannelList/ChannelListViewController.swift
@@ -304,6 +304,7 @@ final class ChannelListViewController: ViewController {
     private let fetchDisposable = MetaDisposable()
     private let dataDisposable = MetaDisposable()
     private var processedBadgeKeys = Set<String>()
+    private var pendingMentionUnreadFloorByClanId: [Int64: [Int64: Int32]] = [:]
 
     private func indexOfChannelInAllChannels(_ channelId: Int64) -> Int? {
         allChannels.firstIndex { $0.channelID == channelId }
@@ -343,6 +344,74 @@ final class ChannelListViewController: ViewController {
         return false
     }
 
+    private func pendingMentionUnreadFloor(clanId: Int64, channelId: Int64) -> Int32 {
+        pendingMentionUnreadFloorByClanId[clanId]?[channelId] ?? 0
+    }
+
+    private func setPendingMentionUnreadFloor(clanId: Int64, channelId: Int64, count: Int32) {
+        guard clanId != 0, channelId != 0, count > 0 else { return }
+        var floors = pendingMentionUnreadFloorByClanId[clanId] ?? [:]
+        floors[channelId] = max(floors[channelId] ?? 0, count)
+        pendingMentionUnreadFloorByClanId[clanId] = floors
+    }
+
+    private func clearPendingMentionUnreadFloor(clanId: Int64, channelId: Int64) {
+        guard clanId != 0, channelId != 0 else { return }
+        pendingMentionUnreadFloorByClanId[clanId]?[channelId] = nil
+        if pendingMentionUnreadFloorByClanId[clanId]?.isEmpty == true {
+            pendingMentionUnreadFloorByClanId[clanId] = nil
+        }
+    }
+
+    @discardableResult
+    private func bumpMentionUnread(clanId: Int64, channelId: Int64) -> Bool {
+        guard clanId != 0, channelId != 0 else { return false }
+        if let index = indexOfChannelInAllChannels(channelId) {
+            allChannels[index].countMessUnread += 1
+            setPendingMentionUnreadFloor(
+                clanId: clanId,
+                channelId: channelId,
+                count: allChannels[index].countMessUnread
+            )
+            return true
+        }
+        let currentFloor = pendingMentionUnreadFloor(clanId: clanId, channelId: channelId)
+        let nextFloor = currentFloor == Int32.max ? currentFloor : currentFloor + 1
+        setPendingMentionUnreadFloor(clanId: clanId, channelId: channelId, count: nextFloor)
+        return false
+    }
+
+    private func preservePendingMentionUnread(
+        in channels: [Mezon_Api_ChannelDescription],
+        clanId: Int64
+    ) -> [Mezon_Api_ChannelDescription] {
+        guard clanId != 0,
+              let floors = pendingMentionUnreadFloorByClanId[clanId],
+              !floors.isEmpty else {
+            return channels
+        }
+
+        var result = channels
+        var existingById: [Int64: Mezon_Api_ChannelDescription] = [:]
+        for channel in allChannels where channel.clanID == 0 || channel.clanID == clanId {
+            existingById[channel.channelID] = channel
+        }
+        for index in result.indices {
+            let channelId = result[index].channelID
+            guard let floor = floors[channelId], floor > 0 else { continue }
+            if result[index].countMessUnread < floor {
+                result[index].countMessUnread = floor
+            }
+            if let existing = existingById[channelId],
+               existing.hasLastSentMessage,
+               (!result[index].hasLastSentMessage
+                || existing.lastSentMessage.timestampSeconds > result[index].lastSentMessage.timestampSeconds) {
+                result[index].lastSentMessage = existing.lastSentMessage
+            }
+        }
+        return result
+    }
+
     @discardableResult
     private func applyMentionEventUnreadIfNeeded(
         clanId: Int64,
@@ -352,24 +421,28 @@ final class ChannelListViewController: ViewController {
         ts: UInt32? = nil
     ) -> Bool {
         guard clanId != 0, messageId != 0, parentChannelId != 0 else { return false }
-        let ekey = "m:\(clanId)_\(messageId)"
-        if processedBadgeKeys.contains(ekey) { return false }
-        processedBadgeKeys.insert(ekey)
+        let targetChannelIds = [parentChannelId, threadChannelId ?? 0]
+            .filter { $0 != 0 }
+            .reduce(into: [Int64]()) { result, channelId in
+                if !result.contains(channelId) {
+                    result.append(channelId)
+                }
+            }
         recordTimestampSentinelForMention(
             clanId: clanId,
-            channelIds: [parentChannelId, threadChannelId ?? 0],
+            channelIds: targetChannelIds,
             ts: ts
         )
-        if processedBadgeKeys.count > 1500 { processedBadgeKeys.removeAll() }
         var didChange = false
-        if let ip = indexOfChannelInAllChannels(parentChannelId) {
-            allChannels[ip].countMessUnread += 1
-            didChange = true
+        for channelId in targetChannelIds {
+            let ekey = "m:\(clanId)_\(messageId)_\(channelId)"
+            if processedBadgeKeys.contains(ekey) { continue }
+            processedBadgeKeys.insert(ekey)
+            if bumpMentionUnread(clanId: clanId, channelId: channelId) {
+                didChange = true
+            }
         }
-        if let t = threadChannelId, t != 0, t != parentChannelId, let it = indexOfChannelInAllChannels(t) {
-            allChannels[it].countMessUnread += 1
-            didChange = true
-        }
+        if processedBadgeKeys.count > 1500 { processedBadgeKeys.removeAll() }
         return didChange
     }
 
@@ -620,20 +693,20 @@ final class ChannelListViewController: ViewController {
             let rows = await inflight.value
             guard isCurrentSessionAlive else { return base }
             guard clanId == self.clanId else { return base }
-            guard !rows.isEmpty else { return base }
+            guard !rows.isEmpty else { return preservePendingMentionUnread(in: base, clanId: clanId) }
             var merged = base
             ChannelUnreadBadgeSync.mergeSocketBadgeRows(into: &merged, badgeRows: rows)
-            return merged
+            return preservePendingMentionUnread(in: merged, clanId: clanId)
         }
 
         if let last = lastBadgeCountFetchAtByClanId[clanId],
            Date().timeIntervalSince(last) < badgeCountFetchCooldown {
-            return base
+            return preservePendingMentionUnread(in: base, clanId: clanId)
         }
 
         let token = await context.getTokenPreferringCachedSkipSessionReadyWait()
         guard clanId == self.clanId else { return base }
-        guard let token else { return base }
+        guard let token else { return preservePendingMentionUnread(in: base, clanId: clanId) }
 
         let task: Task<[Mezon_Api_ChannelDescription], Never> = Task.detached(priority: .utility) {
             do {
@@ -649,10 +722,10 @@ final class ChannelListViewController: ViewController {
 
         guard isCurrentSessionAlive else { return base }
         guard clanId == self.clanId else { return base }
-        guard !rows.isEmpty else { return base }
+        guard !rows.isEmpty else { return preservePendingMentionUnread(in: base, clanId: clanId) }
         var merged = base
         ChannelUnreadBadgeSync.mergeSocketBadgeRows(into: &merged, badgeRows: rows)
-        return merged
+        return preservePendingMentionUnread(in: merged, clanId: clanId)
     }
 
     @MainActor
@@ -1040,6 +1113,7 @@ final class ChannelListViewController: ViewController {
     }
 
     private func removeChannelLocally(channelId: Int64) {
+        clearPendingMentionUnreadFloor(clanId: clanId, channelId: channelId)
         allChannels.removeAll { $0.channelID == channelId }
         
         let built = buildChannelCategories(
@@ -1210,7 +1284,7 @@ final class ChannelListViewController: ViewController {
         guard let channelId = Self.int64UserInfo(notification.userInfo?["channelId"]),
               let clanId = Self.int64UserInfo(notification.userInfo?["clanId"]) else { return }
         guard clanId == self.clanId, clanId != 0 else { return }
-        if notification.userInfo?["isParentOfTopic"] as? Bool == true { return }
+        let isParentOfTopic = notification.userInfo?["isParentOfTopic"] as? Bool == true
         let messageId = notification.userInfo?["messageId"] as? String ?? ""
         let ts = notification.userInfo?["timestampSeconds"]
         let tsU32: UInt32? = {
@@ -1220,13 +1294,12 @@ final class ChannelListViewController: ViewController {
             return nil
         }()
         if !messageId.isEmpty, messageId != "0", let mid = Int64(messageId), mid != 0 {
-            if processedBadgeKeys.contains("m:\(clanId)_\(mid)") { return }
             var updated = false
             let topicFromNoti = Self.int64UserInfo(notification.userInfo?["topicId"]) ?? 0
             if topicFromNoti != 0 {
-                let parentId = parentChannelIdForThreadBadge(
-                    topicId: topicFromNoti, messageChannelId: channelId
-                )
+                let parentId = isParentOfTopic
+                    ? channelId
+                    : parentChannelIdForThreadBadge(topicId: topicFromNoti, messageChannelId: channelId)
                 if applyMentionEventUnreadIfNeeded(
                     clanId: clanId, messageId: mid, parentChannelId: parentId, threadChannelId: topicFromNoti, ts: tsU32
                 ) { updated = true }
@@ -1248,8 +1321,7 @@ final class ChannelListViewController: ViewController {
         guard !processedBadgeKeys.contains(dedupKey) else { return }
         processedBadgeKeys.insert(dedupKey)
         if processedBadgeKeys.count > 1500 { processedBadgeKeys.removeAll() }
-        if let i = indexOfChannelInAllChannels(channelId) {
-            allChannels[i].countMessUnread += 1
+        if bumpMentionUnread(clanId: clanId, channelId: channelId) {
             rebuildAndReload()
         }
     }
@@ -1297,7 +1369,10 @@ final class ChannelListViewController: ViewController {
     }
 
     @objc private func handleChannelMarkedAsRead(_ notification: Notification) {
-        guard let channelId = notification.userInfo?["channelId"] as? Int64 else { return }
+        guard let channelId = Self.int64UserInfo(notification.userInfo?["channelId"]) else { return }
+        let notificationClanId = Self.int64UserInfo(notification.userInfo?["clanId"]) ?? clanId
+        guard notificationClanId == 0 || notificationClanId == clanId else { return }
+        clearPendingMentionUnreadFloor(clanId: notificationClanId == 0 ? clanId : notificationClanId, channelId: channelId)
         let now = UInt32(Date().timeIntervalSince1970)
         for i in 0..<allChannels.count {
             if allChannels[i].channelID == channelId {
@@ -1365,7 +1440,8 @@ final class ChannelListViewController: ViewController {
             clanId != 0 ? readChannelCachePayloadIfAvailable(clanId: clanId) : nil
 
         if clanId != 0, let cache = pendingCache {
-            allChannels = cache.channels
+            let cachedChannels = preservePendingMentionUnread(in: cache.channels, clanId: clanId)
+            allChannels = cachedChannels
             if let meta = cache.meta {
                 channelListCategoryDescs = meta.categoryDescs
                 channelListFavoriteIds = meta.favoriteIds
@@ -1375,8 +1451,8 @@ final class ChannelListViewController: ViewController {
             }
             if let blob = context.account.postbox.getPreferenceData(key: PreferencesKeys.channelListCategories(clanId: clanId)),
                let snap = decodeCategoriesSnapshot(blob),
-               categoriesSnapshotConsistentWithChannels(snap, authoritative: cache.channels) {
-                categories = mergeChannelProtosIntoCategoriesSnapshot(snap, authoritative: cache.channels)
+               categoriesSnapshotConsistentWithChannels(snap, authoritative: cachedChannels) {
+                categories = mergeChannelProtosIntoCategoriesSnapshot(snap, authoritative: cachedChannels)
                 channelsLoadedPromise.set(true)
                 categoriesPipe.putNext(categories)
                 syncSelectedChannelFromStoredPreferences()
@@ -1384,7 +1460,7 @@ final class ChannelListViewController: ViewController {
             } else {
                 let storedCollapsed = loadCollapsedCategoryIds()
                 let built = buildChannelCategories(
-                    cache.channels,
+                    cachedChannels,
                     categoryDescs: channelListCategoryDescs,
                     favoriteChannelIds: channelListFavoriteIds,
                     collapsedIds: storedCollapsed
@@ -1882,10 +1958,11 @@ final class ChannelListViewController: ViewController {
         } else {
             resolvedChannels = channels
         }
-        allChannels = resolvedChannels
+        let visibleChannels = preservePendingMentionUnread(in: resolvedChannels, clanId: clanId)
+        allChannels = visibleChannels
         let storedCollapsed = loadCollapsedCategoryIds()
         let built = buildChannelCategories(
-            resolvedChannels,
+            visibleChannels,
             categoryDescs: channelListCategoryDescs,
             favoriteChannelIds: channelListFavoriteIds,
             collapsedIds: storedCollapsed
@@ -2276,7 +2353,8 @@ final class ChannelListViewController: ViewController {
     }
 
     private func applyChannelCachePayload(channels: [Mezon_Api_ChannelDescription], meta: ChannelListCachedMeta?) {
-        allChannels = channels
+        let resolvedChannels = preservePendingMentionUnread(in: channels, clanId: clanId)
+        allChannels = resolvedChannels
         if let meta {
             channelListCategoryDescs = meta.categoryDescs
             channelListFavoriteIds = meta.favoriteIds
@@ -2286,7 +2364,7 @@ final class ChannelListViewController: ViewController {
         }
         let storedCollapsed = loadCollapsedCategoryIds()
         let built = buildChannelCategories(
-            channels,
+            resolvedChannels,
             categoryDescs: channelListCategoryDescs,
             favoriteChannelIds: channelListFavoriteIds,
             collapsedIds: storedCollapsed

--- a/MezonChat/Features/Chat/Cells/ChatWelcomeItem.swift
+++ b/MezonChat/Features/Chat/Cells/ChatWelcomeItem.swift
@@ -12,6 +12,7 @@ final class ChatWelcomeItem: ListViewItem {
     let dmPeerDisplayName: String
     let dmAvatarURL: String
     let dmGroupAvatarURL: String
+    let threadCreatorName: String
 
     var selectable: Bool { false }
     var approximateHeight: CGFloat { 128 }
@@ -25,7 +26,8 @@ final class ChatWelcomeItem: ListViewItem {
         dmPeerUsername: String,
         dmPeerDisplayName: String,
         dmAvatarURL: String,
-        dmGroupAvatarURL: String
+        dmGroupAvatarURL: String,
+        threadCreatorName: String
     ) {
         self.channelLabel = channelLabel
         self.channelType = channelType
@@ -36,6 +38,7 @@ final class ChatWelcomeItem: ListViewItem {
         self.dmPeerDisplayName = dmPeerDisplayName
         self.dmAvatarURL = dmAvatarURL
         self.dmGroupAvatarURL = dmGroupAvatarURL
+        self.threadCreatorName = threadCreatorName
     }
 
     func nodeConfiguredForParams(async: @escaping (@escaping () -> Void) -> Void, params: ListViewItemLayoutParams, synchronousLoads: Bool, previousItem: ListViewItem?, nextItem: ListViewItem?, completion: @escaping (ListViewItemNode, @escaping () -> (Signal<Void, NoError>?, (ListViewItemApply) -> Void)) -> Void) {
@@ -101,7 +104,8 @@ final class ChatWelcomeItemNode: ListViewItemNode {
                 dmPeerUsername: item.dmPeerUsername,
                 dmPeerDisplayName: item.dmPeerDisplayName,
                 dmAvatarURL: item.dmAvatarURL,
-                dmGroupAvatarURL: item.dmGroupAvatarURL
+                dmGroupAvatarURL: item.dmGroupAvatarURL,
+                threadCreatorName: item.threadCreatorName
             )
 
             let measuredSize = node.measureSize(width: width)

--- a/MezonChat/Features/Chat/Cells/MessageSystemNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageSystemNode.swift
@@ -10,6 +10,7 @@ final class MessageSystemNode: ASDisplayNode {
     private var cachedTextSize: CGSize = .zero
     private var cachedTimeSize: CGSize = .zero
     private var cachedTotalSize: CGSize = .zero
+    private var inlineTimeInText = false
 
     private static let iconSize: CGFloat = 20
     private static let welcomeIconSize: CGFloat = 24
@@ -32,6 +33,25 @@ final class MessageSystemNode: ASDisplayNode {
 
         let parsed = display.parsedContent
         let messageText = parsed.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let messageCode = MezonConstants.MessageCode(rawValue: display.messageCode)
+        let timeText = Self.formatDate(display.message.createdAt)
+
+        let style = RichTextBuilder.Style(
+            bodyFont: .systemFont(ofSize: 13.sf),
+            bodyColor: t.text,
+            mentionFont: .systemFont(ofSize: 13.sf, weight: .semibold),
+            mentionColor: t.textLink,
+            mentionBgColor: t.midnightBlue,
+            roleMentionColor: t.textRoleLink,
+            roleMentionBgColor: t.darkMossGreen,
+            linkColor: t.textLink,
+            codeBgColor: t.tertiary,
+            codeFont: UIFont(name: "Menlo", size: 12.sf) ?? .monospacedSystemFont(ofSize: 12.sf, weight: .regular),
+            boldFont: .systemFont(ofSize: 13.sf, weight: .bold),
+            headingFonts: [],
+            emojiSize: 16.sf,
+            emojiImgproxyFitSide: 40
+        )
 
         if messageText.isEmpty {
             let fallback = systemDefaultText(code: display.messageCode)
@@ -42,23 +62,16 @@ final class MessageSystemNode: ASDisplayNode {
                     .foregroundColor: t.text,
                 ]
             )
+        } else if messageCode == .createThread,
+                  let threadText = Self.createThreadSystemText(
+                    display: display,
+                    style: style,
+                    theme: t,
+                    timeText: timeText
+                  ) {
+            textNode.attributedText = threadText
+            inlineTimeInText = true
         } else {
-            let style = RichTextBuilder.Style(
-                bodyFont: .systemFont(ofSize: 13.sf),
-                bodyColor: t.text,
-                mentionFont: .systemFont(ofSize: 13.sf, weight: .semibold),
-                mentionColor: t.textLink,
-                mentionBgColor: t.midnightBlue,
-                roleMentionColor: t.textRoleLink,
-                roleMentionBgColor: t.darkMossGreen,
-                linkColor: t.textLink,
-                codeBgColor: t.tertiary,
-                codeFont: UIFont(name: "Menlo", size: 12.sf) ?? .monospacedSystemFont(ofSize: 12.sf, weight: .regular),
-                boldFont: .systemFont(ofSize: 13.sf, weight: .bold),
-                headingFonts: [],
-                emojiSize: 16.sf,
-                emojiImgproxyFitSide: 40
-            )
             let built = RichTextBuilder.build(from: parsed, style: style)
             let decorated = Self.decoratedSystemTapText(
                 display: display,
@@ -71,14 +84,18 @@ final class MessageSystemNode: ASDisplayNode {
         textNode.maximumNumberOfLines = 0
         textNode.isUserInteractionEnabled = false
 
-        let timeText = Self.formatDate(display.message.createdAt)
-        timeNode.attributedText = NSAttributedString(
-            string: timeText,
-            attributes: [
-                .font: UIFont.systemFont(ofSize: 11.sf),
-                .foregroundColor: t.textDisabled,
-            ]
-        )
+        if inlineTimeInText {
+            timeNode.attributedText = nil
+            timeNode.isHidden = true
+        } else {
+            timeNode.attributedText = NSAttributedString(
+                string: timeText,
+                attributes: [
+                    .font: UIFont.systemFont(ofSize: 11.sf),
+                    .foregroundColor: t.textDisabled,
+                ]
+            )
+        }
         timeNode.maximumNumberOfLines = 1
 
         addSubnode(iconNode)
@@ -152,9 +169,11 @@ final class MessageSystemNode: ASDisplayNode {
         let iconW = iconColumnWidth()
         let contentW = width - Self.hPadding * 2 - iconW - Self.iconTextGap
         cachedTextSize = textNode.measure(CGSize(width: contentW, height: .greatestFiniteMagnitude))
-        cachedTimeSize = timeNode.measure(CGSize(width: contentW, height: 20))
+        cachedTimeSize = inlineTimeInText ? .zero : timeNode.measure(CGSize(width: contentW, height: 20))
 
-        let textBlockH = cachedTextSize.height + Self.timeGap + cachedTimeSize.height
+        let textBlockH = inlineTimeInText
+            ? cachedTextSize.height
+            : cachedTextSize.height + Self.timeGap + cachedTimeSize.height
         let minH = max(textBlockH, iconW)
         let totalH = Self.vPadding + minH + Self.vPadding
         cachedTotalSize = CGSize(width: width, height: totalH)
@@ -176,7 +195,11 @@ final class MessageSystemNode: ASDisplayNode {
 
         let textContentW = bounds.width - textX - Self.hPadding
         textNode.frame = CGRect(x: textX, y: topY, width: textContentW, height: cachedTextSize.height)
-        timeNode.frame = CGRect(x: textX, y: topY + cachedTextSize.height + Self.timeGap, width: cachedTimeSize.width, height: cachedTimeSize.height)
+        if inlineTimeInText {
+            timeNode.frame = .zero
+        } else {
+            timeNode.frame = CGRect(x: textX, y: topY + cachedTextSize.height + Self.timeGap, width: cachedTimeSize.width, height: cachedTimeSize.height)
+        }
     }
 
     private func configureIcon(code: Int32, theme: ThemeAttributes) {
@@ -192,7 +215,8 @@ final class MessageSystemNode: ASDisplayNode {
                 ?? UIImage(systemName: "arrow.forward", withConfiguration: UIImage.SymbolConfiguration(pointSize: 16, weight: .semibold))
             iconColor = theme.textSuccess
         case .createThread:
-            iconImage = UIImage(systemName: "number", withConfiguration: config)
+            iconImage = UIImage(named: "Channel/channelThread")
+                ?? UIImage(systemName: "text.bubble.fill", withConfiguration: config)
             iconColor = theme.text
         case .createPin:
             iconImage = UIImage(systemName: "pin.fill", withConfiguration: config)
@@ -292,6 +316,119 @@ final class MessageSystemNode: ASDisplayNode {
         return base
     }
 
+    private static func createThreadSystemText(
+        display: ChatMessageDisplay,
+        style: RichTextBuilder.Style,
+        theme: ThemeAttributes,
+        timeText: String
+    ) -> NSAttributedString? {
+        let source = display.parsedContent.text
+        guard let threadInfo = parseThreadParenLabelId(source), !threadInfo.label.isEmpty else {
+            return nil
+        }
+
+        let result = NSMutableAttributedString()
+
+        if let mention = firstMention(in: display.parsedContent, before: threadInfo.matchRange) {
+            result.append(NSAttributedString(string: mention.text, attributes: mentionAttributes(mention: mention, style: style)))
+            result.append(NSAttributedString(string: " ", attributes: bodyAttributes(style: style)))
+        }
+
+        result.append(NSAttributedString(
+            string: L(L10n.ChatSystem.startedThread) + " ",
+            attributes: bodyAttributes(style: style)
+        ))
+
+        let threadRangeStart = result.length
+        result.append(NSAttributedString(
+            string: threadInfo.label,
+            attributes: [
+                .font: style.mentionFont,
+                .foregroundColor: theme.textLink,
+                .mezonSystemAction: ("thread:" + threadInfo.id) as NSString,
+            ]
+        ))
+
+        if !threadInfo.content.isEmpty {
+            result.append(NSAttributedString(string: threadInfo.content, attributes: bodyAttributes(style: style)))
+        }
+
+        result.append(NSAttributedString(
+            string: ". " + L(L10n.ChatSystem.seeAllThreads) + " ",
+            attributes: bodyAttributes(style: style)
+        ))
+
+        result.append(NSAttributedString(
+            string: L(L10n.ChatSystem.allThreadsAnchor),
+            attributes: [
+                .font: style.mentionFont,
+                .foregroundColor: theme.textLink,
+                .mezonSystemAction: "threads" as NSString,
+            ]
+        ))
+        result.append(NSAttributedString(string: ".", attributes: bodyAttributes(style: style)))
+        result.append(NSAttributedString(
+            string: "   " + timeText,
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 11.sf),
+                .foregroundColor: theme.textDisabled,
+            ]
+        ))
+
+        if threadRangeStart >= result.length {
+            return nil
+        }
+        return result
+    }
+
+    private static func bodyAttributes(style: RichTextBuilder.Style) -> [NSAttributedString.Key: Any] {
+        [
+            .font: style.bodyFont,
+            .foregroundColor: style.bodyColor,
+        ]
+    }
+
+    private static func mentionAttributes(
+        mention: (text: String, userId: String?, roleId: String?),
+        style: RichTextBuilder.Style
+    ) -> [NSAttributedString.Key: Any] {
+        let isRoleMention = mention.roleId != nil && mention.userId == nil
+        var attrs: [NSAttributedString.Key: Any] = [
+            .font: style.mentionFont,
+            .foregroundColor: isRoleMention ? style.roleMentionColor : style.mentionColor,
+            .backgroundColor: isRoleMention ? style.roleMentionBgColor : style.mentionBgColor,
+        ]
+        if isRoleMention, let roleId = mention.roleId, !roleId.isEmpty {
+            attrs[.mezonRoleMention] = roleId as NSString
+        } else if let userId = mention.userId, !userId.isEmpty {
+            attrs[.mezonMention] = userId as NSString
+        }
+        return attrs
+    }
+
+    private static func firstMention(
+        in parsed: ParsedContent,
+        before threadRange: NSRange
+    ) -> (text: String, userId: String?, roleId: String?)? {
+        for token in parsed.tokens.sorted(by: { $0.start < $1.start }) {
+            guard case .mention(let userId, let roleId, _) = token.kind else { continue }
+            guard token.start < threadRange.location else { continue }
+            let raw = parsed.text.mezon_utf16Substring(from: token.start, to: token.end)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !raw.isEmpty else { continue }
+            return (raw, userId, roleId)
+        }
+        let prefix = (parsed.text as NSString).substring(to: min(threadRange.location, (parsed.text as NSString).length))
+        if let regex = try? NSRegularExpression(pattern: "@[^\\s()]+"),
+           let match = regex.firstMatch(in: prefix, range: NSRange(location: 0, length: (prefix as NSString).length)) {
+            let raw = (prefix as NSString).substring(with: match.range)
+            if !raw.isEmpty {
+                return (raw, nil, nil)
+            }
+        }
+        return nil
+    }
+
     private static func threadNavigationTitle(display: ChatMessageDisplay, threadChannelId: Int64) -> String? {
         let target = "\(threadChannelId)"
         let haystack = display.parsedContent.text
@@ -310,14 +447,18 @@ final class MessageSystemNode: ASDisplayNode {
         return nil
     }
 
-    private static func parseThreadParenLabelId(_ content: String) -> (label: String, id: String)? {
+    private static func parseThreadParenLabelId(_ content: String) -> (label: String, id: String, content: String, matchRange: NSRange)? {
         guard let regex = try? NSRegularExpression(pattern: "\\(([^,]+),\\s*([^)]+)\\)"),
               let m = regex.firstMatch(in: content, range: NSRange(location: 0, length: (content as NSString).length)),
               m.numberOfRanges >= 3 else { return nil }
         let ns = content as NSString
         let label = ns.substring(with: m.range(at: 1)).trimmingCharacters(in: .whitespacesAndNewlines)
         let id = ns.substring(with: m.range(at: 2)).trimmingCharacters(in: .whitespacesAndNewlines)
-        return (label, id)
+        let suffixStart = NSMaxRange(m.range)
+        let suffix = suffixStart < ns.length
+            ? ns.substring(from: suffixStart).trimmingCharacters(in: .whitespacesAndNewlines)
+            : ""
+        return (label, id, suffix, m.range)
     }
 
     private static func nsRanges(of needle: String, in haystack: String, caseInsensitive: Bool) -> [NSRange] {

--- a/MezonChat/Features/Chat/Cells/WelcomeCellNode.swift
+++ b/MezonChat/Features/Chat/Cells/WelcomeCellNode.swift
@@ -4,7 +4,7 @@ import UIKit
 final class WelcomeCellNode: ASDisplayNode {
 
     private enum Mode {
-        case clan(channelType: Int32, isPrivate: Bool, isAgeRestricted: Bool, isMediaChannel: Bool)
+        case clan(channelType: Int32, isPrivate: Bool, isAgeRestricted: Bool, isMediaChannel: Bool, threadCreatorName: String)
         case dmOneToOne(label: String, username: String, priorityName: String, avatarURL: String, placeholderLetter: String)
         case dmGroup(label: String, groupAvatarURL: String?)
     }
@@ -48,7 +48,8 @@ final class WelcomeCellNode: ASDisplayNode {
         dmPeerUsername: String,
         dmPeerDisplayName: String,
         dmAvatarURL: String,
-        dmGroupAvatarURL: String
+        dmGroupAvatarURL: String,
+        threadCreatorName: String
     ) {
         let isGroupDM = channelType == MezonConstants.ChannelType.group.rawValue
         let isMediaChannel: Bool = {
@@ -86,7 +87,8 @@ final class WelcomeCellNode: ASDisplayNode {
                 channelType: channelType,
                 isPrivate: isPrivate,
                 isAgeRestricted: isAgeRestricted,
-                isMediaChannel: isMediaChannel
+                isMediaChannel: isMediaChannel,
+                threadCreatorName: threadCreatorName.trimmingCharacters(in: .whitespacesAndNewlines)
             )
             showsUsernameRow = false
         }
@@ -101,7 +103,7 @@ final class WelcomeCellNode: ASDisplayNode {
         let name = channelLabel
 
         switch resolvedMode {
-        case let .clan(channelType, isPrivate, isAgeRestricted, isMediaChannel):
+        case let .clan(channelType, isPrivate, isAgeRestricted, isMediaChannel, threadCreatorName):
             iconContainerNode.backgroundColor = t.secondaryLight
             iconContainerNode.cornerRadius = Self.clanIconSize / 2
             iconContainerNode.clipsToBounds = true
@@ -129,6 +131,7 @@ final class WelcomeCellNode: ASDisplayNode {
                 }
             default: iconName = "Channel/channel"
             }
+            let isThread = channelType == MezonConstants.ChannelType.thread.rawValue
             let image = UIImage(named: iconName) ?? UIImage(systemName: iconName)
             iconImageNode.image = image?.withRenderingMode(.alwaysTemplate)
             iconImageNode.tintColor = t.textStrong
@@ -137,14 +140,22 @@ final class WelcomeCellNode: ASDisplayNode {
 
             let privateWord = (isPrivate && !isMediaChannel) ? L(L10n.ChatWelcome.privateChannel) : ""
             titleNode.attributedText = NSAttributedString(
-                string: String(format: L(L10n.ChatWelcome.welcomeToChannel), name),
+                string: isThread ? name : String(format: L(L10n.ChatWelcome.welcomeToChannel), name),
                 attributes: [
                     .font: UIFont.systemFont(ofSize: 22.sf, weight: .semibold),
                     .foregroundColor: t.textStrong,
                 ]
             )
+            let subtitle: String = {
+                if isThread {
+                    return threadCreatorName.isEmpty
+                        ? ""
+                        : String(format: L(L10n.ChatWelcome.threadStartedBy), threadCreatorName)
+                }
+                return String(format: L(L10n.ChatWelcome.startOfChannel), name, privateWord)
+            }()
             subtitleNode.attributedText = NSAttributedString(
-                string: String(format: L(L10n.ChatWelcome.startOfChannel), name, privateWord),
+                string: subtitle,
                 attributes: [
                     .font: UIFont.systemFont(ofSize: 12.sf),
                     .foregroundColor: t.text,

--- a/MezonChat/Features/Chat/ChatContainerNode.swift
+++ b/MezonChat/Features/Chat/ChatContainerNode.swift
@@ -354,7 +354,8 @@ final class ChatContainerNode: ASDisplayNode {
                         dmPeerUsername: state.dmPeerUsername,
                         dmPeerDisplayName: state.dmPeerDisplayName,
                         dmAvatarURL: state.dmAvatarURL,
-                        dmGroupAvatarURL: state.dmGroupAvatarURL
+                        dmGroupAvatarURL: state.dmGroupAvatarURL,
+                        threadCreatorName: state.threadCreatorName
                     ))
                     didInsertWelcomeHero = true
                 } else {
@@ -608,6 +609,7 @@ final class ChatContainerNode: ASDisplayNode {
             state.dmPeerDisplayName,
             state.dmAvatarURL,
             state.dmGroupAvatarURL,
+            state.threadCreatorName,
         ].joined(separator: "|")
     }
 

--- a/MezonChat/Features/Chat/ChatViewController.swift
+++ b/MezonChat/Features/Chat/ChatViewController.swift
@@ -299,6 +299,7 @@ struct ChatState {
     var dmPeerDisplayName: String
     var dmAvatarURL: String
     var dmGroupAvatarURL: String
+    var threadCreatorName: String
     var hasMoreOlder: Bool
     var hasMoreNewer: Bool
     var isLoadingMore: Bool
@@ -313,6 +314,7 @@ struct ChatState {
     static let empty = ChatState(
         messages: [], channelLabel: "", channelType: 0, isPrivate: false, isAgeRestricted: false,
         isDM: false, isPeerBlocked: false, dmPeerUsername: "", dmPeerDisplayName: "", dmAvatarURL: "", dmGroupAvatarURL: "",
+        threadCreatorName: "",
         hasMoreOlder: false, hasMoreNewer: false, isLoadingMore: false, isLoadingNewer: false,
         isLoadingMessageContext: false,
         isLoading: false, errorMessage: nil, lastSeenMessageId: nil, currentUserId: nil,
@@ -1587,6 +1589,7 @@ final class ChatViewController: ViewController {
     private func setErrorMessage(_ v: String?) { errorMessage = v; metadataOnlyPipe.putNext(()) }
 
     private var hasCompletedInitialFetch = false
+    private var didApplyBadgeLastSeen = false
     private static let initialEmptyMessageRetryDelaysNanoseconds: [UInt64] = [
         600_000_000,
         1_200_000_000
@@ -1665,6 +1668,8 @@ final class ChatViewController: ViewController {
         )
         ensureParentChannelMetaSubscription()
 
+        startBadgeCountLastSeenRefresh()
+
         let shouldSkipInitialRemoteFetchForEmptyTopic = skipInitialRemoteFetchForEmptyTopic
         Task { @MainActor [weak self] in
             guard let self else { return }
@@ -1714,6 +1719,59 @@ final class ChatViewController: ViewController {
             self.fetchChannelMembers(token: token)
             self.checkBanStatus(token: token)
             self.resolveChannelLabelFromNetwork(token: token)
+        }
+    }
+
+    private func startBadgeCountLastSeenRefresh() {
+        guard channel.channelID != 0, !didApplyBadgeLastSeen else { return }
+
+        if let cached = context.account.postbox.resolvedChannelDescription(clanId: clanId, channelId: channel.channelID),
+           cached.hasLastSeenMessage, cached.lastSeenMessage.id != 0 {
+            didApplyBadgeLastSeen = true
+            applyLastSeen(from: cached)
+            return
+        }
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            var token: String? = {
+                if let t = self.context.session?.token, !t.isEmpty { return t }
+                if let t = SessionStore.load()?.token, !t.isEmpty { return t }
+                return nil
+            }()
+            if token == nil {
+                token = await self.context.getTokenPreferringCachedSkipSessionReadyWait()
+            }
+            guard let token else { return }
+            await self.applyLastSeenFromBadgeCountNetwork(token: token)
+        }
+    }
+
+    @MainActor
+    private func applyLastSeenFromBadgeCountNetwork(token: String) async {
+        guard !didApplyBadgeLastSeen else { return }
+        guard channel.channelID != 0 else { return }
+        do {
+            let response = try await context.account.network.listChannelBadgeCount(clanId: clanId, token: token)
+            guard let desc = response.channeldesc.first(where: { $0.channelID == channel.channelID }) else {
+                return
+            }
+            didApplyBadgeLastSeen = true
+            applyLastSeen(from: desc)
+        } catch {
+        }
+    }
+
+    @MainActor
+    private func applyLastSeen(from desc: Mezon_Api_ChannelDescription) {
+        guard desc.hasLastSeenMessage, desc.lastSeenMessage.id != 0 else { return }
+        let newSeenId = "\(desc.lastSeenMessage.id)"
+        guard newSeenId != self.lastSeenMessageId else { return }
+        self.lastSeenMessageId = newSeenId
+        if self.hasPerformedInitialUnreadScroll {
+            self.scrollToUnreadLine(lastSeenId: newSeenId)
+        } else {
+            self.shouldScrollToBottom = false
         }
     }
 
@@ -2243,22 +2301,8 @@ final class ChatViewController: ViewController {
     }
 
     private func fetchChannelPermissions(token: String? = nil) {
-        let channelId = channel.channelID
-        Task { @MainActor in
-            let resolvedToken: String
-            if let token { resolvedToken = token } else if let t = await self.context.getTokenPreferringCachedSkipSessionReadyWait() { resolvedToken = t } else { return }
-            let token = resolvedToken
-            do {
-                let response = try await self.context.account.network.listUserPermissionInChannel(clanId: clanId, channelId: channelId, token: token)
-                let permissions = response.permissions.permissions
-                let records = permissions.map { PermissionRecord(from: $0) }
-                self.context.account.postbox.write { tx in
-                    tx.updateChannelPermissions(records, channelId: channelId)
-                }
-                self.context.rolePermissions.applyChannelPermissions(channelId: channelId, permissions: permissions)
-            } catch {
-            }
-        }
+        guard clanId != 0 else { return }
+        context.rolePermissions.ensureChannelPermissions(clanId: clanId, channelId: channel.channelID)
     }
 
     private func fetchChannelMembers(token: String? = nil) {
@@ -2382,6 +2426,38 @@ final class ChatViewController: ViewController {
         return context.engine.friendsData.blockedUserIds().contains(peerId)
     }
 
+    private func resolvedThreadCreatorName() -> String {
+        guard channel.type == MezonConstants.ChannelType.thread.rawValue else { return "" }
+        let creatorId = channel.creatorID
+        if creatorId != 0 {
+            let userId = String(creatorId)
+            if let member = context.account.postbox.read({ tx in
+                tx.getClanMembers(clanId: clanId).first(where: { $0.userId == creatorId })
+            }) {
+                let clanNick = member.clanNick.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !clanNick.isEmpty { return clanNick }
+                let displayName = member.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !displayName.isEmpty { return displayName }
+                let username = member.username.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !username.isEmpty { return username }
+            }
+            if let currentUser = context.currentUser, currentUser.id == userId {
+                let displayName = currentUser.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !displayName.isEmpty { return displayName }
+                let username = currentUser.username.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !username.isEmpty { return username }
+            }
+            if let profile = context.account.postbox.read({ $0.getProfile(userId: userId) }) {
+                if let displayName = profile.displayName?.trimmingCharacters(in: .whitespacesAndNewlines), !displayName.isEmpty {
+                    return displayName
+                }
+                let username = profile.username.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !username.isEmpty { return username }
+            }
+        }
+        return channel.creatorName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     var currentState: ChatState {
         let labelFromMeta = parentChannelMeta?.label
         let resolvedParentName =
@@ -2399,6 +2475,7 @@ final class ChatViewController: ViewController {
             dmPeerDisplayName: channel.displayNames.first ?? "",
             dmAvatarURL: channel.avatars.first ?? "",
             dmGroupAvatarURL: channel.channelAvatar,
+            threadCreatorName: resolvedThreadCreatorName(),
             hasMoreOlder: hasMoreOlder,
             hasMoreNewer: hasMoreNewer,
             isLoadingMore: isLoadingMore,

--- a/MezonChat/Features/DirectMessages/DirectMessagesViewController.swift
+++ b/MezonChat/Features/DirectMessages/DirectMessagesViewController.swift
@@ -776,9 +776,12 @@ final class DirectMessagesViewController: ViewController {
     private let fetchDirectMessagesCooldown: TimeInterval = 2.0
 
     private func listDirectAndGroupMessageChannels(token: String) async throws -> [Mezon_Api_ChannelDescription] {
-        var channels = try await context.account.network.listDirectMessageChannels(token: token)
+        async let directChannelsTask = context.account.network.listDirectMessageChannels(token: token)
+        async let groupChannelsTask = context.account.network.listGroupMessageChannels(token: token)
+
+        var channels = try await directChannelsTask
         do {
-            let groupChannels = try await context.account.network.listGroupMessageChannels(token: token)
+            let groupChannels = try await groupChannelsTask
             var existingIds = Set(channels.map(\.channelID))
             for channel in groupChannels where !existingIds.contains(channel.channelID) {
                 channels.append(channel)

--- a/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
+++ b/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
@@ -894,7 +894,8 @@ final class SendMessageInputViewController: UIViewController {
                 })
         )
         refreshSendPermissionAvailability()
-        if channelStreamMode == MezonConstants.ChannelStreamMode.dm.rawValue {
+        if channelStreamMode == MezonConstants.ChannelStreamMode.dm.rawValue,
+           context.engine.friendsData.allFriends().isEmpty {
             Task { [weak self] in
                 guard let self, let token = await self.context.getToken() else { return }
                 await self.context.engine.friendsData.refreshFromNetwork(token: token)


### PR DESCRIPTION
## 1. Root Cause

- Thread list empty state, spacing, scroll indicator, and subtitle sizing did not match the expected mobile UI.
- Thread creation allowed invalid short names and still showed a redundant top-right `Create` action while sending the first message already creates the thread.
- Create-thread system message rendered from raw content instead of the expected inline format.
- Mention badge for newly created threads was updated by socket but could be overwritten by stale cache/fetch data, causing the badge to flash then disappear.
- Thread welcome header reused channel welcome copy instead of showing thread name and creator.
- After editing a thread name, ThreadList kept its local snapshot/cache and did not react to channel description updates until manual refresh.

## 2. Solution

- Added a custom empty ThreadList UI and tuned search spacing, footer/separator behavior, scroll indicators, button/title/subtitle sizing.
- Added thread name validation from 4 to 64 characters and removed the redundant top-right `Create` button.
- Updated create-thread system message rendering to match the expected format: `@user started a thread: ThreadName. See all threads.`
- Preserved local mention unread state in ChannelList and deduped mention events per target channel so parent/thread badges do not overwrite each other.
- Updated thread welcome header to show:
  - Thread name
  - `Started by <creator>`
  - Creator name priority: `clanNick -> displayName -> username`
- Made ThreadList observe `.mezonChannelDescriptionDidUpdate`, merge updated thread metadata locally, persist cache, and reload immediately after editing thread name.

## 3. Selftest

- Ran `git diff --check` on affected files.
- Ran `xcrun swiftc -parse` on updated Swift files.
- Verified lightweight parsing/checks passed for ThreadList, Chat welcome/system message, ChannelList badge logic, and thread creation form changes.