### PR TITLE
feat: config deeplink

### DIFF
--- a/MezonChat/Application/AppDelegate.swift
+++ b/MezonChat/Application/AppDelegate.swift
@@ -166,6 +166,15 @@ final class AppDelegate: UIResponder, UIApplicationDelegate, UIWindowSceneDelega
             }
             Self.navigateToChannel(channelId: channelId, clanId: clanId, isDM: isDM)
         }
+
+        for urlContext in connectionOptions.urlContexts {
+            if !DeepLinkRouter.handle(urlContext.url) {
+                handleShareURL(urlContext.url)
+            }
+        }
+        for activity in connectionOptions.userActivities {
+            if DeepLinkRouter.handle(userActivity: activity) { break }
+        }
     }
 
     private func startAuthFlow(context: AccountContext) {
@@ -308,8 +317,13 @@ final class AppDelegate: UIResponder, UIApplicationDelegate, UIWindowSceneDelega
     }
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         for context in URLContexts {
+            if DeepLinkRouter.handle(context.url) { continue }
             handleShareURL(context.url)
         }
+    }
+
+    func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        DeepLinkRouter.handle(userActivity: userActivity)
     }
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {

--- a/MezonChat/Features/ChannelDetail/ChannelDetailViewController.swift
+++ b/MezonChat/Features/ChannelDetail/ChannelDetailViewController.swift
@@ -218,32 +218,29 @@ final class ChannelDetailViewController: ViewController {
         context.currentUser.flatMap { Int64($0.id) }
     }
 
-    private func estimatedGroupMemberCount() -> Int {
-        if channel.memberCount > 0 {
-            return Int(channel.memberCount)
-        }
-        var ids = Set(channel.userIds)
-        if let myId = currentUserNumericId {
-            ids.insert(myId)
-        }
-        return max(ids.count, 1)
+    private var isCurrentGroupCreator: Bool {
+        guard isGroupDirectMessage,
+              channel.creatorID != 0,
+              let myId = currentUserNumericId else { return false }
+        return myId == channel.creatorID
     }
 
     private func showGroupDMOptions() {
         guard isGroupDirectMessage else { return }
 
-        let deleteByEstimate = estimatedGroupMemberCount() <= 1
-        let leaveTitle = deleteByEstimate ? L(L10n.ChannelDetail.deleteGroup) : L(L10n.ChannelDetail.leaveGroup)
         let sheet = GroupDMOptionsSheetViewController(
             customizeTitle: L(L10n.ChannelDetail.customizeGroup),
-            leaveTitle: leaveTitle,
-            isDeleteAction: deleteByEstimate,
+            leaveTitle: L(L10n.ChannelDetail.leaveGroup),
+            deleteTitle: isCurrentGroupCreator ? L(L10n.ChannelDetail.deleteGroup) : nil,
             onCustomize: { [weak self] in
                 self?.presentCustomizeGroup()
             },
-            onLeaveOrDelete: { [weak self] in
-                self?.confirmLeaveOrDeleteGroup()
-            }
+            onLeave: { [weak self] in
+                self?.confirmLeaveGroup()
+            },
+            onDelete: isCurrentGroupCreator ? { [weak self] in
+                self?.confirmDeleteGroup()
+            } : nil
         )
         sheet.modalPresentationStyle = .overFullScreen
         sheet.modalTransitionStyle = .crossDissolve
@@ -273,40 +270,39 @@ final class ChannelDetailViewController: ViewController {
         )
     }
 
-    private func confirmLeaveOrDeleteGroup() {
-        let deleteByEstimate = estimatedGroupMemberCount() <= 1
-        let title = deleteByEstimate
-            ? L(L10n.ChannelDetail.deleteGroupConfirmTitle)
-            : L(L10n.ChannelDetail.leaveGroupConfirmTitle)
-        let message = deleteByEstimate
-            ? L(L10n.ChannelDetail.deleteGroupConfirmBody)
-            : L(L10n.ChannelDetail.leaveGroupConfirmBody)
-        let actionTitle = deleteByEstimate ? L(L10n.ChannelDetail.deleteGroup) : L(L10n.ChannelDetail.leaveGroup)
+    private func confirmLeaveGroup() {
+        presentLeaveOrDeleteConfirmation(
+            title: L(L10n.ChannelDetail.leaveGroupConfirmTitle),
+            message: L(L10n.ChannelDetail.leaveGroupConfirmBody),
+            actionTitle: L(L10n.ChannelDetail.leaveGroup),
+            userConfirmedDelete: false
+        )
+    }
 
+    private func confirmDeleteGroup() {
+        presentLeaveOrDeleteConfirmation(
+            title: L(L10n.ChannelDetail.deleteGroupConfirmTitle),
+            message: L(L10n.ChannelDetail.deleteGroupConfirmBody),
+            actionTitle: L(L10n.ChannelDetail.deleteGroup),
+            userConfirmedDelete: true
+        )
+    }
+
+    private func presentLeaveOrDeleteConfirmation(
+        title: String,
+        message: String,
+        actionTitle: String,
+        userConfirmedDelete: Bool
+    ) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: L(L10n.Common.cancel), style: .cancel))
         alert.addAction(UIAlertAction(title: actionTitle, style: .destructive) { [weak self] _ in
-            self?.performLeaveOrDeleteGroup()
+            self?.performLeaveOrDeleteGroup(userConfirmedDelete: userConfirmedDelete)
         })
         present(alert, animated: true)
     }
 
-    private func shouldDeleteGroup(token: String) async -> Bool {
-        do {
-            let response = try await context.account.network.listChannelUsersUC(
-                channelId: channel.channelID,
-                limit: 500,
-                token: token
-            )
-            if !response.userIds.isEmpty {
-                return Set(response.userIds).count <= 1
-            }
-        } catch {
-        }
-        return estimatedGroupMemberCount() <= 1
-    }
-
-    private func performLeaveOrDeleteGroup() {
+    private func performLeaveOrDeleteGroup(userConfirmedDelete: Bool) {
         Task { @MainActor [weak self] in
             guard let self else { return }
             guard let token = await self.context.getToken() else {
@@ -318,8 +314,9 @@ final class ChannelDetailViewController: ViewController {
                 return
             }
 
+            let deleteGroup = userConfirmedDelete && self.isCurrentGroupCreator
+
             do {
-                let deleteGroup = await self.shouldDeleteGroup(token: token)
                 if deleteGroup {
                     try await self.context.account.network.deleteChannelDesc(
                         channelId: self.channel.channelID,
@@ -380,9 +377,10 @@ private final class GroupDMOptionsSheetViewController: UIViewController {
 
     private let customizeTitle: String
     private let leaveTitle: String
-    private let isDeleteAction: Bool
+    private let deleteTitle: String?
     private let onCustomize: () -> Void
-    private let onLeaveOrDelete: () -> Void
+    private let onLeave: () -> Void
+    private let onDelete: (() -> Void)?
 
     private let dimView = UIView()
     private let containerView = UIView()
@@ -391,15 +389,17 @@ private final class GroupDMOptionsSheetViewController: UIViewController {
     init(
         customizeTitle: String,
         leaveTitle: String,
-        isDeleteAction: Bool,
+        deleteTitle: String?,
         onCustomize: @escaping () -> Void,
-        onLeaveOrDelete: @escaping () -> Void
+        onLeave: @escaping () -> Void,
+        onDelete: (() -> Void)?
     ) {
         self.customizeTitle = customizeTitle
         self.leaveTitle = leaveTitle
-        self.isDeleteAction = isDeleteAction
+        self.deleteTitle = deleteTitle
         self.onCustomize = onCustomize
-        self.onLeaveOrDelete = onLeaveOrDelete
+        self.onLeave = onLeave
+        self.onDelete = onDelete
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -432,19 +432,29 @@ private final class GroupDMOptionsSheetViewController: UIViewController {
 
         let customizeButton = makeActionButton(
             title: customizeTitle,
-            symbolName: "pencil",
             titleColor: UIColor.theme.textStrong
         )
         customizeButton.addTarget(self, action: #selector(customizePressed), for: .touchUpInside)
 
         let leaveButton = makeActionButton(
             title: leaveTitle,
-            symbolName: isDeleteAction ? "trash.fill" : "rectangle.and.arrow.right",
             titleColor: UIColor.systemRed
         )
         leaveButton.addTarget(self, action: #selector(leavePressed), for: .touchUpInside)
 
-        let stack = UIStackView(arrangedSubviews: [customizeButton, leaveButton])
+        var arrangedSubviews: [UIView] = [customizeButton, leaveButton]
+        var deleteButton: UIButton?
+        if let deleteTitle, onDelete != nil {
+            let button = makeActionButton(
+                title: deleteTitle,
+                titleColor: UIColor.systemRed
+            )
+            button.addTarget(self, action: #selector(deletePressed), for: .touchUpInside)
+            deleteButton = button
+            arrangedSubviews.append(button)
+        }
+
+        let stack = UIStackView(arrangedSubviews: arrangedSubviews)
         stack.translatesAutoresizingMaskIntoConstraints = false
         stack.axis = .vertical
         stack.alignment = .fill
@@ -472,9 +482,12 @@ private final class GroupDMOptionsSheetViewController: UIViewController {
             customizeButton.heightAnchor.constraint(equalToConstant: 52.sh),
             leaveButton.heightAnchor.constraint(equalToConstant: 52.sh)
         ])
+        if let deleteButton {
+            deleteButton.heightAnchor.constraint(equalToConstant: 52.sh).isActive = true
+        }
     }
 
-    private func makeActionButton(title: String, symbolName: String, titleColor: UIColor) -> UIButton {
+    private func makeActionButton(title: String, titleColor: UIColor) -> UIButton {
         let button = UIButton(type: .system)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.backgroundColor = UIColor.theme.secondary
@@ -482,12 +495,8 @@ private final class GroupDMOptionsSheetViewController: UIViewController {
         button.setTitle(title, for: .normal)
         button.setTitleColor(titleColor, for: .normal)
         button.titleLabel?.font = .systemFont(ofSize: 16.sf, weight: .semibold)
-        button.contentHorizontalAlignment = .leading
+        button.contentHorizontalAlignment = .center
         button.contentEdgeInsets = UIEdgeInsets(top: 0, left: 18.sw, bottom: 0, right: 18.sw)
-        button.imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 10.sw)
-        button.titleEdgeInsets = UIEdgeInsets(top: 0, left: 10.sw, bottom: 0, right: -10.sw)
-        button.tintColor = titleColor
-        button.setImage(UIImage(systemName: symbolName), for: .normal)
         return button
     }
 
@@ -518,7 +527,11 @@ private final class GroupDMOptionsSheetViewController: UIViewController {
     }
 
     @objc private func leavePressed() {
-        dismissSheet(completion: onLeaveOrDelete)
+        dismissSheet(completion: onLeave)
+    }
+
+    @objc private func deletePressed() {
+        dismissSheet(completion: onDelete)
     }
 }
 

--- a/MezonChat/Features/ChannelList/ChannelItemCellNode.swift
+++ b/MezonChat/Features/ChannelList/ChannelItemCellNode.swift
@@ -222,62 +222,108 @@ struct VoiceMemberDisplay {
     let avatarURL: String?
 }
 
-private func makeVoiceAvatarNodes(member m: VoiceMemberDisplay, size s: CGFloat) -> (wrapper: ASDisplayNode, img: ASNetworkImageNode, initLabel: ASTextNode2) {
-    let imgNode = ASNetworkImageNode()
-    imgNode.style.preferredSize = CGSize(width: s, height: s)
-    imgNode.cornerRadius = s / 2
-    imgNode.clipsToBounds = true
-    imgNode.contentMode = .scaleAspectFill
+final class VoiceAvatarNode: ASDisplayNode, ASNetworkImageNodeDelegate {
 
-    let initNode = ASTextNode2()
-    initNode.maximumNumberOfLines = 1
+    private let imgNode = ASNetworkImageNode()
+    private let initNode = ASTextNode2()
+    private let proxiedURL: URL?
 
-    let wrapper = ASDisplayNode()
-    wrapper.automaticallyManagesSubnodes = true
-    wrapper.style.preferredSize = CGSize(width: s, height: s)
-    wrapper.cornerRadius = s / 2
-    wrapper.clipsToBounds = true
+    private var didLoadImage = false
+    private var retryCount = 0
+    private static let maxRetries = 4
 
-    if let av = m.avatarURL, !av.isEmpty {
-        wrapper.backgroundColor = .clear
-        let proxy = ImgproxyURL.create(from: av, width: 150, height: 150)
-        imgNode.url = URL(string: proxy)
-        initNode.isHidden = true
-    } else {
-        wrapper.backgroundColor = UIColor.avatarColor(for: m.username)
-        imgNode.isHidden = true
+    init(member m: VoiceMemberDisplay, size s: CGFloat) {
+        if let av = m.avatarURL, !av.isEmpty {
+            proxiedURL = URL(string: ImgproxyURL.create(from: av, width: 20, height: 20))
+        } else {
+            proxiedURL = nil
+        }
+        super.init()
+        automaticallyManagesSubnodes = true
+        style.preferredSize = CGSize(width: s, height: s)
+        cornerRadius = s / 2
+        clipsToBounds = true
+        backgroundColor = UIColor.avatarColor(for: m.username)
+
         let initial = String(m.username.prefix(1)).uppercased()
         let fontSize: CGFloat = s < 22 ? 9 : 11
+        initNode.maximumNumberOfLines = 1
         initNode.attributedText = NSAttributedString(
             string: initial,
             attributes: [
                 .font: UIFont.systemFont(ofSize: fontSize, weight: .bold),
                 .foregroundColor: UIColor.white,
             ])
+
+        imgNode.style.preferredSize = CGSize(width: s, height: s)
+        imgNode.cornerRadius = s / 2
+        imgNode.clipsToBounds = true
+        imgNode.contentMode = .scaleAspectFill
+        imgNode.delegate = self
+
+        if let proxiedURL {
+            imgNode.url = proxiedURL
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(handleNetworkStatusChanged(_:)),
+                name: NetworkMonitor.statusDidChangeNotification,
+                object: nil
+            )
+        } else {
+            imgNode.isHidden = true
+        }
     }
 
-    wrapper.layoutSpecBlock = { _, _ in
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
         let center = ASCenterLayoutSpec(centeringOptions: .XY, sizingOptions: [], child: initNode)
         return ASOverlayLayoutSpec(child: center, overlay: imgNode)
     }
 
-    return (wrapper, imgNode, initNode)
+    private func reloadAvatar() {
+        guard let proxiedURL, !didLoadImage else { return }
+        imgNode.url = nil
+        imgNode.url = proxiedURL
+    }
+
+    @objc private func handleNetworkStatusChanged(_ notification: Notification) {
+        let connected = (notification.userInfo?["isConnected"] as? Bool) ?? NetworkMonitor.shared.isConnected
+        guard connected, !didLoadImage else { return }
+        retryCount = 0
+        DispatchQueue.main.async { [weak self] in
+            self?.reloadAvatar()
+        }
+    }
+
+    @objc func imageNode(_ imageNode: ASNetworkImageNode, didLoad image: UIImage) {
+        guard imageNode === imgNode else { return }
+        if image.size.width >= 0.5, image.size.height >= 0.5 {
+            didLoadImage = true
+        }
+    }
+
+    @objc func imageNode(_ imageNode: ASNetworkImageNode, didFailWithError error: Error) {
+        guard imageNode === imgNode, !didLoadImage, retryCount < Self.maxRetries else { return }
+        retryCount += 1
+        let delay = Double(retryCount) * 1.5
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+            self?.reloadAvatar()
+        }
+    }
 }
 
 final class VoiceMemberExpandedCellNode: ASCellNode {
 
     private static let avatarSize: CGFloat = 22
 
-    private let avatarWrapper: ASDisplayNode
-    private let avatarImg: ASNetworkImageNode
-    private let avatarInit: ASTextNode2
+    private let avatarNode: VoiceAvatarNode
     private let nameNode = ASTextNode2()
 
     init(member: VoiceMemberDisplay) {
-        let nodes = makeVoiceAvatarNodes(member: member, size: Self.avatarSize)
-        avatarWrapper = nodes.wrapper
-        avatarImg = nodes.img
-        avatarInit = nodes.initLabel
+        avatarNode = VoiceAvatarNode(member: member, size: Self.avatarSize)
         super.init()
         automaticallyManagesSubnodes = true
         selectionStyle = .none
@@ -304,7 +350,7 @@ final class VoiceMemberExpandedCellNode: ASCellNode {
             spacing: 10,
             justifyContent: .start,
             alignItems: .center,
-            children: [avatarWrapper, nameNode]
+            children: [avatarNode, nameNode]
         )
         return ASInsetLayoutSpec(
             insets: UIEdgeInsets(top: 2, left: 40, bottom: 2, right: 12),
@@ -330,8 +376,7 @@ final class VoiceChannelMembersCollapsedCellNode: ASCellNode {
 
         let visible = Array(members.prefix(Self.maxVisible))
         for m in visible {
-            let nodes = makeVoiceAvatarNodes(member: m, size: Self.avatarSize)
-            avatarNodes.append(nodes.wrapper)
+            avatarNodes.append(VoiceAvatarNode(member: m, size: Self.avatarSize))
         }
 
         if totalCount > Self.maxVisible {

--- a/MezonChat/Features/Chat/Cells/MessageBubbleNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageBubbleNode.swift
@@ -425,6 +425,7 @@ final class MessageBubbleNode: ASDisplayNode {
 
         if hasMedia {
             let mcn = MessageMediaContentNode()
+            mcn.isUserInteractionEnabled = true
             mcn.configure(media: mediaAttachments)
             mcn.onImageTapped = { [weak self] index in
                 self?.handleImageTap(index: index, media: mediaAttachments, interaction: interaction)

--- a/MezonChat/Features/Chat/Cells/MessageMediaContentNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageMediaContentNode.swift
@@ -64,8 +64,11 @@ final class MessageMediaContentNode: ASDisplayNode {
     private var isMultiple = false
     private var lastRemoteProxyURLByIndex: [Int: String] = [:]
 
+    private var mediaTapGesture: UITapGestureRecognizer?
+
     override init() {
         super.init()
+        isUserInteractionEnabled = true
     }
 
     private static func mosaicItemSize(for att: ParsedAttachment) -> CGSize {
@@ -195,10 +198,10 @@ final class MessageMediaContentNode: ASDisplayNode {
         isSingleImage = false
         isMultiple = false
         guard !media.isEmpty else { return }
-        let isAnimatedType = media.count == 1 && Self.isAnimatedImageAttachment(media[0])
-        if media.count == 1, media[0].isSticker || isAnimatedType {
+        let isGifType = media.count == 1 && Self.isGifImageAttachment(media[0])
+        if media.count == 1, media[0].isSticker || isGifType {
             isSticker = true
-            isAnimatedStandaloneImage = isAnimatedType && !media[0].isSticker
+            isAnimatedStandaloneImage = isGifType && !media[0].isSticker
         } else if media.count == 1 {
             isSingleImage = true
         } else {
@@ -207,7 +210,6 @@ final class MessageMediaContentNode: ASDisplayNode {
     }
 
     func configure(media: [ParsedAttachment]) {
-
         imageNodes.forEach { $0.removeFromSupernode(); $0.reset() }
         imageNodes.removeAll()
         videoOverlayNodes.forEach { $0.removeFromSupernode() }
@@ -226,10 +228,10 @@ final class MessageMediaContentNode: ASDisplayNode {
         guard !media.isEmpty else { return }
 
 
-        let isAnimatedType = media.count == 1 && Self.isAnimatedImageAttachment(media[0])
-        if media.count == 1, media[0].isSticker || isAnimatedType {
+        let isGifType = media.count == 1 && Self.isGifImageAttachment(media[0])
+        if media.count == 1, media[0].isSticker || isGifType {
             isSticker = true
-            isAnimatedStandaloneImage = isAnimatedType && !media[0].isSticker
+            isAnimatedStandaloneImage = isGifType && !media[0].isSticker
             isSingleImage = false
             isMultiple = false
             let node = ASDisplayNode()
@@ -247,9 +249,11 @@ final class MessageMediaContentNode: ASDisplayNode {
             isSingleImage = true
             isMultiple = false
             let shimmer = ShimmerPlaceholderNode()
+            shimmer.isUserInteractionEnabled = false
             shimmerNodes.append(shimmer)
             addSubnode(shimmer)
             let node = TransformImageNode()
+            node.isUserInteractionEnabled = false
             node.contentAnimations = [.firstUpdate]
             node.imageUpdated = { [weak shimmer] _ in
                 shimmer?.removeFromSupernode()
@@ -280,9 +284,11 @@ final class MessageMediaContentNode: ASDisplayNode {
             let items = media
             for (i, att) in items.enumerated() {
                 let shimmer = ShimmerPlaceholderNode()
+                shimmer.isUserInteractionEnabled = false
                 shimmerNodes.append(shimmer)
                 addSubnode(shimmer)
                 let node = TransformImageNode()
+                node.isUserInteractionEnabled = false
                 node.contentAnimations = [.firstUpdate]
                 node.imageUpdated = { [weak shimmer] _ in
                     shimmer?.removeFromSupernode()
@@ -309,6 +315,10 @@ final class MessageMediaContentNode: ASDisplayNode {
                     videoOverlayNodes.append(placeholder)
                 }
             }
+        }
+
+        if isNodeLoaded {
+            attachMediaTapGesture()
         }
     }
 
@@ -457,17 +467,31 @@ final class MessageMediaContentNode: ASDisplayNode {
     }
 
 
-    private static func isAnimatedImageAttachment(_ attachment: ParsedAttachment) -> Bool {
+    private static func isGifImageAttachment(_ attachment: ParsedAttachment) -> Bool {
         let filetype = attachment.filetype
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
         let mime = filetype.split(separator: ";", maxSplits: 1).first
             .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) } ?? filetype
-        if mime == "image/gif" || mime == "image/webp" || mime == "gif" || mime == "webp" {
+        if mime == "image/gif" || mime == "gif" {
             return true
         }
-        return ["gif", "webp"].contains(pathExtension(from: attachment.filename))
-            || ["gif", "webp"].contains(pathExtension(from: attachment.url))
+        return ["gif"].contains(pathExtension(from: attachment.filename))
+            || ["gif"].contains(pathExtension(from: attachment.url))
+    }
+
+    private static func isAnimatedImageAttachment(_ attachment: ParsedAttachment) -> Bool {
+        if isGifImageAttachment(attachment) { return true }
+        let filetype = attachment.filetype
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let mime = filetype.split(separator: ";", maxSplits: 1).first
+            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) } ?? filetype
+        if mime == "image/webp" || mime == "webp" {
+            return true
+        }
+        return ["webp"].contains(pathExtension(from: attachment.filename))
+            || ["webp"].contains(pathExtension(from: attachment.url))
     }
 
     private static func pathExtension(from value: String) -> String {
@@ -530,6 +554,7 @@ final class MessageMediaContentNode: ASDisplayNode {
         } else {
             sourceURL = media.url
         }
+        guard !sourceURL.isEmpty else { return }
         guard index < imageNodes.count else { return }
         let node = imageNodes[index]
         let w = 400
@@ -568,19 +593,32 @@ final class MessageMediaContentNode: ASDisplayNode {
         }
     }
 
-    override func didLoad() {
-        super.didLoad()
-        for (i, node) in imageNodes.enumerated() {
-            node.view.isUserInteractionEnabled = true
-            node.view.tag = i
-            let tap = UITapGestureRecognizer(target: self, action: #selector(handleImageTap(_:)))
-            node.view.addGestureRecognizer(tap)
-        }
+    private func attachMediaTapGesture() {
+        guard isNodeLoaded else { return }
+        isUserInteractionEnabled = true
+        view.isUserInteractionEnabled = true
+        guard mediaTapGesture == nil else { return }
+        let tap = UITapGestureRecognizer(target: self, action: #selector(handleMediaTap(_:)))
+        view.addGestureRecognizer(tap)
+        mediaTapGesture = tap
     }
 
-    @objc private func handleImageTap(_ gesture: UITapGestureRecognizer) {
-        guard let view = gesture.view else { return }
-        onImageTapped?(view.tag)
+    override func didLoad() {
+        super.didLoad()
+        attachMediaTapGesture()
+    }
+
+    @objc private func handleMediaTap(_ gesture: UITapGestureRecognizer) {
+        let point = gesture.location(in: view)
+        let index: Int?
+        if isSticker {
+            let bounds = CGRect(origin: .zero, size: cachedTotalSize)
+            index = bounds.contains(point) ? 0 : nil
+        } else {
+            index = cachedImageFrames.enumerated().first(where: { $1.contains(point) })?.offset
+        }
+        guard let index else { return }
+        onImageTapped?(index)
     }
 
     func currentImage(at index: Int) -> UIImage? {

--- a/MezonChat/Features/Clans/InstallClanViewController.swift
+++ b/MezonChat/Features/Clans/InstallClanViewController.swift
@@ -1,0 +1,264 @@
+import UIKit
+
+final class InstallClanViewController: UIViewController {
+    private let context: AccountContext
+    private let appId: Int64
+    private let clans: [Mezon_Api_ClanDesc]
+
+    private var selectedClan: Mezon_Api_ClanDesc?
+    private var appName: String = ""
+    private var appLogo: String = ""
+
+    private let scrollView = UIScrollView()
+    private let contentView = UIView()
+    private let avatarView = UIImageView()
+    private let avatarPlaceholder = UILabel()
+    private let titleLabel = UILabel()
+    private let descriptionLabel = UILabel()
+    private let addToClanLabel = UILabel()
+    private let clanPickerButton = UIButton(type: .system)
+    private let installButton = UIButton(type: .system)
+    private let backButton = UIButton(type: .system)
+    private var avatarTask: URLSessionDataTask?
+
+    init(context: AccountContext, appId: Int64, clans: [Mezon_Api_ClanDesc]) {
+        self.context = context
+        self.appId = appId
+        self.clans = clans
+        super.init(nibName: nil, bundle: nil)
+        modalPresentationStyle = .fullScreen
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = UIColor.theme.primary
+        setupUI()
+        updateInstallButtonState()
+        fetchAppDetail()
+    }
+
+    private func setupUI() {
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentView)
+
+        avatarView.translatesAutoresizingMaskIntoConstraints = false
+        avatarView.contentMode = .scaleAspectFill
+        avatarView.clipsToBounds = true
+        avatarView.layer.cornerRadius = 50
+        avatarView.backgroundColor = UIColor.theme.secondary
+
+        avatarPlaceholder.translatesAutoresizingMaskIntoConstraints = false
+        avatarPlaceholder.textAlignment = .center
+        avatarPlaceholder.font = .systemFont(ofSize: 40, weight: .semibold)
+        avatarPlaceholder.textColor = UIColor.theme.textStrong
+
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.font = .systemFont(ofSize: 22, weight: .bold)
+        titleLabel.textColor = UIColor.theme.textStrong
+        titleLabel.textAlignment = .center
+        titleLabel.numberOfLines = 2
+
+        descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
+        descriptionLabel.font = .systemFont(ofSize: 14, weight: .regular)
+        descriptionLabel.textColor = UIColor.theme.text
+        descriptionLabel.textAlignment = .center
+        descriptionLabel.numberOfLines = 0
+        descriptionLabel.text = "This app would be able to access information in the clan you choose."
+
+        addToClanLabel.translatesAutoresizingMaskIntoConstraints = false
+        addToClanLabel.font = .systemFont(ofSize: 13, weight: .semibold)
+        addToClanLabel.textColor = UIColor.theme.textDisabled
+        addToClanLabel.text = "ADD TO CLAN"
+
+        clanPickerButton.translatesAutoresizingMaskIntoConstraints = false
+        clanPickerButton.contentHorizontalAlignment = .left
+        clanPickerButton.contentEdgeInsets = UIEdgeInsets(top: 14, left: 14, bottom: 14, right: 40)
+        clanPickerButton.backgroundColor = UIColor.theme.secondary
+        clanPickerButton.layer.cornerRadius = 8
+        clanPickerButton.setTitleColor(UIColor.theme.text, for: .normal)
+        clanPickerButton.titleLabel?.font = .systemFont(ofSize: 15, weight: .regular)
+        clanPickerButton.titleLabel?.lineBreakMode = .byTruncatingTail
+        clanPickerButton.setTitle("Select a clan", for: .normal)
+        clanPickerButton.addTarget(self, action: #selector(handleSelectClan), for: .touchUpInside)
+
+        let chevron = UIImageView(image: UIImage(systemName: "chevron.down"))
+        chevron.translatesAutoresizingMaskIntoConstraints = false
+        chevron.tintColor = UIColor.theme.textDisabled
+        chevron.contentMode = .scaleAspectFit
+        clanPickerButton.addSubview(chevron)
+        NSLayoutConstraint.activate([
+            chevron.trailingAnchor.constraint(equalTo: clanPickerButton.trailingAnchor, constant: -14),
+            chevron.centerYAnchor.constraint(equalTo: clanPickerButton.centerYAnchor),
+            chevron.widthAnchor.constraint(equalToConstant: 16),
+            chevron.heightAnchor.constraint(equalToConstant: 16),
+        ])
+
+        installButton.translatesAutoresizingMaskIntoConstraints = false
+        installButton.backgroundColor = UIColor.mezonPrimary
+        installButton.layer.cornerRadius = 8
+        installButton.setTitleColor(.white, for: .normal)
+        installButton.titleLabel?.font = .systemFont(ofSize: 16, weight: .semibold)
+        installButton.setTitle("Add", for: .normal)
+        installButton.addTarget(self, action: #selector(handleInstall), for: .touchUpInside)
+
+        backButton.translatesAutoresizingMaskIntoConstraints = false
+        backButton.backgroundColor = UIColor.theme.secondary
+        backButton.layer.cornerRadius = 8
+        backButton.setTitleColor(UIColor.theme.text, for: .normal)
+        backButton.titleLabel?.font = .systemFont(ofSize: 16, weight: .semibold)
+        backButton.setTitle("Back", for: .normal)
+        backButton.addTarget(self, action: #selector(handleBack), for: .touchUpInside)
+
+        [avatarView, avatarPlaceholder, titleLabel, descriptionLabel, addToClanLabel, clanPickerButton, installButton, backButton].forEach { contentView.addSubview($0) }
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+
+            contentView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            contentView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            contentView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            contentView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+
+            avatarView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 40),
+            avatarView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            avatarView.widthAnchor.constraint(equalToConstant: 100),
+            avatarView.heightAnchor.constraint(equalToConstant: 100),
+
+            avatarPlaceholder.centerXAnchor.constraint(equalTo: avatarView.centerXAnchor),
+            avatarPlaceholder.centerYAnchor.constraint(equalTo: avatarView.centerYAnchor),
+
+            titleLabel.topAnchor.constraint(equalTo: avatarView.bottomAnchor, constant: 16),
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 24),
+            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -24),
+
+            descriptionLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 12),
+            descriptionLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 24),
+            descriptionLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -24),
+
+            addToClanLabel.topAnchor.constraint(equalTo: descriptionLabel.bottomAnchor, constant: 32),
+            addToClanLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 24),
+            addToClanLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -24),
+
+            clanPickerButton.topAnchor.constraint(equalTo: addToClanLabel.bottomAnchor, constant: 10),
+            clanPickerButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 24),
+            clanPickerButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -24),
+            clanPickerButton.heightAnchor.constraint(equalToConstant: 50),
+
+            installButton.topAnchor.constraint(equalTo: clanPickerButton.bottomAnchor, constant: 28),
+            installButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 24),
+            installButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -24),
+            installButton.heightAnchor.constraint(equalToConstant: 50),
+
+            backButton.topAnchor.constraint(equalTo: installButton.bottomAnchor, constant: 12),
+            backButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 24),
+            backButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -24),
+            backButton.heightAnchor.constraint(equalToConstant: 50),
+            backButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -24),
+        ])
+    }
+
+    private func fetchAppDetail() {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard let token = await self.context.getToken() else { return }
+            do {
+                let app = try await self.context.account.network.getApp(appId: self.appId, token: token)
+                self.appName = app.appname
+                self.appLogo = app.applogo
+                self.applyAppDetail()
+            } catch {
+                Toast.error(error.localizedDescription)
+            }
+        }
+    }
+
+    private func applyAppDetail() {
+        let name = appName.trimmingCharacters(in: .whitespacesAndNewlines)
+        titleLabel.text = name.isEmpty ? "App" : name
+        avatarPlaceholder.text = String(name.prefix(1)).uppercased()
+        loadAvatar(from: appLogo)
+    }
+
+    private func loadAvatar(from urlString: String) {
+        let trimmed = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            avatarPlaceholder.isHidden = false
+            return
+        }
+        avatarPlaceholder.isHidden = false
+        if let cached = ImageCache.shared.memoryImage(forKey: trimmed) {
+            avatarView.image = cached
+            avatarPlaceholder.isHidden = true
+            return
+        }
+        avatarTask?.cancel()
+        avatarTask = ImageCache.shared.loadImage(urlString: trimmed) { [weak self] image in
+            guard let image else { return }
+            DispatchQueue.main.async {
+                self?.avatarView.image = image
+                self?.avatarPlaceholder.isHidden = true
+            }
+        }
+    }
+
+    private func updateInstallButtonState() {
+        let enabled = selectedClan != nil
+        installButton.isEnabled = enabled
+        installButton.alpha = 1.0
+        installButton.backgroundColor = enabled ? UIColor.mezonPrimary : UIColor.theme.secondary
+        installButton.setTitleColor(enabled ? .white : UIColor.theme.textDisabled, for: .normal)
+    }
+
+    @objc private func handleSelectClan() {
+        guard !clans.isEmpty else {
+            Toast.error("You are not a member of any clan")
+            return
+        }
+        let picker = ClanPickerSheetViewController(
+            clans: clans,
+            selectedClanId: selectedClan?.clanID,
+            title: "Select a clan"
+        ) { [weak self] clan in
+            guard let self else { return }
+            self.selectedClan = clan
+            self.clanPickerButton.setTitle(clan.clanName, for: .normal)
+            self.clanPickerButton.setTitleColor(UIColor.theme.textStrong, for: .normal)
+            self.updateInstallButtonState()
+        }
+        present(picker, animated: true)
+    }
+
+    @objc private func handleInstall() {
+        guard let clan = selectedClan else { return }
+        installButton.isEnabled = false
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard let token = await self.context.getToken() else {
+                self.updateInstallButtonState()
+                return
+            }
+            do {
+                try await self.context.account.network.addAppToClan(appId: self.appId, clanId: clan.clanID, token: token)
+                Toast.success("App installed successfully")
+                self.dismiss(animated: true)
+            } catch {
+                Toast.error(error.localizedDescription)
+                self.updateInstallButtonState()
+            }
+        }
+    }
+
+    @objc private func handleBack() {
+        dismiss(animated: true)
+    }
+
+    deinit { avatarTask?.cancel() }
+}

--- a/MezonChat/Features/DeepLink/DeepLinkNodeOverlayController.swift
+++ b/MezonChat/Features/DeepLink/DeepLinkNodeOverlayController.swift
@@ -1,0 +1,30 @@
+import AsyncDisplayKit
+import UIKit
+
+final class DeepLinkNodeOverlayController: UIViewController {
+    private let contentNode: ASDisplayNode
+
+    init(node: ASDisplayNode) {
+        self.contentNode = node
+        super.init(nibName: nil, bundle: nil)
+        modalPresentationStyle = .overFullScreen
+        modalTransitionStyle = .crossDissolve
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = UIColor.theme.primary
+        view.addSubnode(contentNode)
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        contentNode.frame = view.bounds
+    }
+
+    func dismissOverlay(completion: (() -> Void)? = nil) {
+        dismiss(animated: true, completion: completion)
+    }
+}

--- a/MezonChat/Features/DeepLink/DeepLinkRouter.swift
+++ b/MezonChat/Features/DeepLink/DeepLinkRouter.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+enum DeepLinkRoute: Equatable {
+    case channelApp(channelId: String, clanId: String?, code: String?, subpath: String?)
+    case invite(code: String)
+    case chat(username: String, data: String?)
+    case botInstall(appId: String)
+}
+
+enum DeepLinkRouter {
+    static let supportedPrefixes = ["https://mezon.ai", "http://mezon.ai", "mezon.ai://", "mezon://"]
+
+    private(set) static var pending: DeepLinkRoute?
+
+    static func isDeepLink(_ url: URL) -> Bool {
+        if let scheme = url.scheme?.lowercased() {
+            if scheme == "mezon" || scheme == "mezon.ai" { return true }
+            if scheme == "http" || scheme == "https" {
+                return url.host?.lowercased() == "mezon.ai"
+            }
+        }
+        let lowered = url.absoluteString.lowercased()
+        return supportedPrefixes.contains(where: { lowered.hasPrefix($0) })
+    }
+
+    @discardableResult
+    static func handle(_ url: URL) -> Bool {
+        guard isDeepLink(url), let route = route(from: url) else { return false }
+        pending = route
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: .mezonHandleDeepLink, object: nil)
+        }
+        return true
+    }
+
+    @discardableResult
+    static func handle(userActivity: NSUserActivity) -> Bool {
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+              let url = userActivity.webpageURL else { return false }
+        return handle(url)
+    }
+
+    static func consumePending() -> DeepLinkRoute? {
+        defer { pending = nil }
+        return pending
+    }
+
+    static func route(from url: URL) -> DeepLinkRoute? {
+        let raw = url.absoluteString
+        let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        func query(_ name: String) -> String? {
+            queryItems.first(where: { $0.name == name })?.value
+        }
+
+        if raw.contains("channel-app/") {
+            if let m = firstMatch(in: raw, pattern: "channel-app/([0-9]+)/([0-9]+)") {
+                return .channelApp(channelId: m[1], clanId: m[2], code: query("code"), subpath: query("subpath"))
+            }
+            if let m = firstMatch(in: raw, pattern: "channel-app/([0-9]+)") {
+                return .channelApp(channelId: m[1], clanId: nil, code: query("code"), subpath: query("subpath"))
+            }
+        }
+
+        if raw.contains("invite/") {
+            if let m = firstMatch(in: raw, pattern: "invite/(?:chat/)?([0-9]+)") {
+                return .invite(code: m[1])
+            }
+        }
+
+        if raw.contains("chat/") {
+            if let m = firstMatch(in: raw, pattern: "(?:^|/)chat/([^/?#]+)") {
+                return .chat(username: m[1], data: query("data"))
+            }
+        }
+
+        if raw.contains("app/install/") || raw.contains("bot/install/") {
+            if let m = firstMatch(in: raw, pattern: "(?:bot|app)/install/([0-9]+)") {
+                return .botInstall(appId: m[1])
+            }
+        }
+
+        return nil
+    }
+
+    static func decodeProfileData(_ dataParam: String) -> QRUserProfileData? {
+        let s = dataParam.trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "\n", with: "")
+        guard !s.isEmpty else { return nil }
+        if let raw = Data(base64Encoded: s, options: .ignoreUnknownCharacters),
+           let p = try? JSONDecoder().decode(QRUserProfileData.self, from: raw) {
+            return p
+        }
+        if let raw = Data(base64Encoded: s, options: .ignoreUnknownCharacters),
+           let str = String(data: raw, encoding: .utf8),
+           let json = str.removingPercentEncoding,
+           let j = json.data(using: .utf8),
+           let p = try? JSONDecoder().decode(QRUserProfileData.self, from: j) {
+            return p
+        }
+        return nil
+    }
+
+    private static func firstMatch(in string: String, pattern: String) -> [String]? {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let range = NSRange(string.startIndex..., in: string)
+        guard let match = regex.firstMatch(in: string, range: range) else { return nil }
+        var groups: [String] = []
+        for index in 0..<match.numberOfRanges {
+            if let r = Range(match.range(at: index), in: string) {
+                groups.append(String(string[r]))
+            } else {
+                groups.append("")
+            }
+        }
+        return groups
+    }
+}
+
+extension Notification.Name {
+    static let mezonHandleDeepLink = Notification.Name("MezonHandleDeepLink")
+}

--- a/MezonChat/Features/DirectMessages/DirectMessagesContainerNode.swift
+++ b/MezonChat/Features/DirectMessages/DirectMessagesContainerNode.swift
@@ -30,6 +30,7 @@ final class DirectMessagesContainerNode: ASDisplayNode {
 
     private let refreshControl = UIRefreshControl()
     private var validLayout: (size: CGSize, safeTop: CGFloat, bottomInset: CGFloat)?
+    private var appliedActivityHeaderSize: CGSize?
 
     init(signal: Signal<DirectMessagesState, NoError>, interaction: DirectMessagesInteraction) {
         tableView = UITableView(frame: .zero, style: .plain)
@@ -68,15 +69,10 @@ final class DirectMessagesContainerNode: ASDisplayNode {
                 
                 if directMessagesChanged || avatarURLCacheChanged {
                     self.prefetchAvatarImages(for: Array(newState.directMessages.prefix(16)))
-                    if self.tableView.frame.width > 0 {
-                        if Self.channelIdOrder(previousState.directMessages) == Self.channelIdOrder(newState.directMessages) {
-                            self.reconfigureVisibleCells()
-                        } else {
-                            self.tableView.reloadData()
-                        }
-                    } else {
-                        self.needsReloadOnLayout = true
-                    }
+                    self.applyDirectMessageUpdates(
+                        previous: previousState.directMessages,
+                        new: newState.directMessages
+                    )
                 }
             })
         )
@@ -260,16 +256,24 @@ final class DirectMessagesContainerNode: ASDisplayNode {
     private func syncActivityTableHeader(width: CGFloat) {
         let stripH: CGFloat = state.messageActivityRows.isEmpty ? 0 : (50.sh + 8.sh)
         guard stripH > 0.5, width > 0.5 else {
-            tableView.tableHeaderView = nil
+            if tableView.tableHeaderView != nil {
+                tableView.tableHeaderView = nil
+            }
+            appliedActivityHeaderSize = nil
             return
         }
         if activityStrip.superview !== activityTableHeaderWrapper {
             activityTableHeaderWrapper.addSubview(activityStrip)
         }
+        let targetSize = CGSize(width: width, height: stripH)
+        if appliedActivityHeaderSize == targetSize,
+           tableView.tableHeaderView === activityTableHeaderWrapper {
+            return
+        }
         activityTableHeaderWrapper.frame = CGRect(x: 0, y: 0, width: width, height: stripH)
         activityStrip.frame = activityTableHeaderWrapper.bounds
         tableView.tableHeaderView = activityTableHeaderWrapper
-        tableView.tableHeaderView = activityTableHeaderWrapper
+        appliedActivityHeaderSize = targetSize
     }
 
     func applyTheme() {
@@ -352,6 +356,48 @@ final class DirectMessagesContainerNode: ASDisplayNode {
 
     private static func channelIdOrder(_ channels: [Mezon_Api_ChannelDescription]) -> [Int64] {
         channels.map(\.channelID)
+    }
+
+    private func applyDirectMessageUpdates(
+        previous: [Mezon_Api_ChannelDescription],
+        new: [Mezon_Api_ChannelDescription]
+    ) {
+        guard tableView.frame.width > 0 else {
+            needsReloadOnLayout = true
+            return
+        }
+
+        let oldOrder = Self.channelIdOrder(previous)
+        let newOrder = Self.channelIdOrder(new)
+
+        if oldOrder == newOrder {
+            reconfigureVisibleCells()
+            return
+        }
+
+        if oldOrder.count == newOrder.count, Set(oldOrder) == Set(newOrder) {
+            var oldIndexById: [Int64: Int] = [:]
+            oldIndexById.reserveCapacity(oldOrder.count)
+            for (index, id) in oldOrder.enumerated() {
+                oldIndexById[id] = index
+            }
+            UIView.performWithoutAnimation {
+                tableView.performBatchUpdates({
+                    for (newIndex, id) in newOrder.enumerated() {
+                        guard let oldIndex = oldIndexById[id], oldIndex != newIndex else { continue }
+                        tableView.moveRow(
+                            at: IndexPath(row: oldIndex, section: 0),
+                            to: IndexPath(row: newIndex, section: 0)
+                        )
+                    }
+                }, completion: { [weak self] _ in
+                    self?.reconfigureVisibleCells()
+                })
+            }
+            return
+        }
+
+        tableView.reloadData()
     }
 
     private func reconfigureVisibleCells() {

--- a/MezonChat/Features/DirectMessages/DirectMessagesViewController.swift
+++ b/MezonChat/Features/DirectMessages/DirectMessagesViewController.swift
@@ -376,39 +376,60 @@ final class DirectMessagesViewController: ViewController {
         return max(layout.safeInsets.top, layout.statusBarHeight ?? 0, viewSafeTop)
     }
 
+    private var stateUpdateDepth = 0
+    private var pendingReloadNotification = false
+
+    private func notifyStateChanged() {
+        if stateUpdateDepth > 0 {
+            pendingReloadNotification = true
+        } else {
+            needsReloadPipe.putNext(())
+        }
+    }
+
+    private func performBatchStateUpdate(_ body: () -> Void) {
+        stateUpdateDepth += 1
+        body()
+        stateUpdateDepth -= 1
+        if stateUpdateDepth == 0, pendingReloadNotification {
+            pendingReloadNotification = false
+            needsReloadPipe.putNext(())
+        }
+    }
+
     private func setDirectMessages(_ v: [Mezon_Api_ChannelDescription]) {
         guard directMessages != v else { return }
         directMessages = v
         directMessagesPipe.putNext(v)
-        needsReloadPipe.putNext(())
+        notifyStateChanged()
     }
 
     private func setIsEmpty(_ v: Bool) {
         guard isEmpty != v else { return }
         isEmpty = v
         isEmptyPipe.putNext(v)
-        needsReloadPipe.putNext(())
+        notifyStateChanged()
     }
 
     private func setIsLoading(_ v: Bool) {
         guard isLoading != v else { return }
         isLoading = v
         isLoadingPipe.putNext(v)
-        needsReloadPipe.putNext(())
+        notifyStateChanged()
     }
 
     private func setErrorMessage(_ v: String?) {
         guard errorMessage != v else { return }
         errorMessage = v
         errorMessagePipe.putNext(v)
-        needsReloadPipe.putNext(())
+        notifyStateChanged()
     }
 
     private func setIncomingFriendRequestCount(_ v: Int) {
         let changed = incomingFriendRequestCount != v
         incomingFriendRequestCount = v
         if changed {
-            needsReloadPipe.putNext(())
+            notifyStateChanged()
         }
     }
 
@@ -431,8 +452,10 @@ final class DirectMessagesViewController: ViewController {
             next.insert(channel, at: 0)
         }
         let sorted = Self.sortDmChannels(next)
-        setDirectMessages(sorted)
-        setIsEmpty(sorted.isEmpty)
+        performBatchStateUpdate {
+            setDirectMessages(sorted)
+            setIsEmpty(sorted.isEmpty)
+        }
         persistDmChannelListToPostbox()
     }
 
@@ -766,9 +789,11 @@ final class DirectMessagesViewController: ViewController {
         let cached = context.account.postbox.getCachedDMChannelList()
         guard !cached.isEmpty else { return }
         let sorted = Self.sortDmChannels(cached)
-        setDirectMessages(sorted)
-        setIsEmpty(sorted.isEmpty)
-        setErrorMessage(nil)
+        performBatchStateUpdate {
+            setDirectMessages(sorted)
+            setIsEmpty(sorted.isEmpty)
+            setErrorMessage(nil)
+        }
     }
 
     private var fetchDirectMessagesTask: Task<Void, Never>?
@@ -813,11 +838,13 @@ final class DirectMessagesViewController: ViewController {
         let task = Task<Void, Never> { @MainActor [weak self] in
             guard let self else { return }
             defer {
-                self.setIsLoading(false)
                 self.fetchDirectMessagesTask = nil
                 self.lastFetchDirectMessagesAt = Date()
             }
-            guard let token = await self.context.getTokenPreferringCachedSkipSessionReadyWait() else { return }
+            guard let token = await self.context.getTokenPreferringCachedSkipSessionReadyWait() else {
+                self.setIsLoading(false)
+                return
+            }
             await self.fetchUserActivities(token: token)
             do {
                 let cachedRows = self.directMessages
@@ -832,14 +859,20 @@ final class DirectMessagesViewController: ViewController {
                 } catch {
                 }
                 let sorted = Self.sortDmChannels(channels)
-                self.setDirectMessages(sorted)
-                self.setIsEmpty(sorted.isEmpty)
+                self.performBatchStateUpdate {
+                    self.setIsLoading(false)
+                    self.setDirectMessages(sorted)
+                    self.setIsEmpty(sorted.isEmpty)
+                    self.setErrorMessage(nil)
+                }
                 self.persistDmChannelListToPostbox()
-                self.setErrorMessage(nil)
             } catch {
-                self.applyDmListFromCache()
-                if self.directMessages.isEmpty {
-                    self.setErrorMessage(error.localizedDescription)
+                self.performBatchStateUpdate {
+                    self.setIsLoading(false)
+                    self.applyDmListFromCache()
+                    if self.directMessages.isEmpty {
+                        self.setErrorMessage(error.localizedDescription)
+                    }
                 }
             }
         }
@@ -867,8 +900,10 @@ final class DirectMessagesViewController: ViewController {
                 } catch {
                 }
                 let sorted = Self.sortDmChannels(channels)
-                self.setDirectMessages(sorted)
-                self.setIsEmpty(sorted.isEmpty)
+                self.performBatchStateUpdate {
+                    self.setDirectMessages(sorted)
+                    self.setIsEmpty(sorted.isEmpty)
+                }
                 self.persistDmChannelListToPostbox()
             } catch {
                 self.applyDmListFromCache()

--- a/MezonChat/Features/Main/MezonRootController.swift
+++ b/MezonChat/Features/Main/MezonRootController.swift
@@ -104,6 +104,7 @@ final class MezonRootController: NavigationController {
         NotificationCenter.default.addObserver(self, selector: #selector(handleQRSelectClanRoot(_:)), name: .mezonQRSelectClan, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleQRNavigateToDM(_:)), name: .mezonQRNavigateToDM, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleSharedContent(_:)), name: .mezonDidReceiveSharedContent, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleDeepLink), name: .mezonHandleDeepLink, object: nil)
 
         NotificationCenter.default.addObserver(self, selector: #selector(handleIncomingPeerCall(_:)), name: .mezonIncomingPeerCall, object: nil)
 
@@ -111,6 +112,7 @@ final class MezonRootController: NavigationController {
 
         bootstrapGlobalFriendState()
         processPendingNavigation()
+        processPendingDeepLink()
         checkPendingSharedContentOnLaunch()
 
         DispatchQueue.main.async { [weak self] in
@@ -682,6 +684,182 @@ final class MezonRootController: NavigationController {
             }
             topVC.present(sharingVC, animated: true)
         }
+    }
+
+    // MARK: - Deep links
+
+    private func processPendingDeepLink() {
+        guard let route = DeepLinkRouter.consumePending() else { return }
+        scheduleDeepLink(route)
+    }
+
+    @objc private func handleDeepLink() {
+        guard let route = DeepLinkRouter.consumePending() else { return }
+        scheduleDeepLink(route)
+    }
+
+    private func scheduleDeepLink(_ route: DeepLinkRoute) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            await withTaskGroup(of: Void.self) { group in
+                group.addTask { @MainActor in
+                    await self.context.waitForSessionReady()
+                }
+                group.addTask {
+                    try? await Task.sleep(nanoseconds: 5_000_000_000)
+                }
+                _ = await group.next()
+                group.cancelAll()
+            }
+            self.performDeepLink(route)
+        }
+    }
+
+    private func performDeepLink(_ route: DeepLinkRoute) {
+        switch route {
+        case let .channelApp(channelId, clanId, _, _):
+            handleDeepLinkChannelApp(channelId: channelId, clanId: clanId)
+        case let .invite(code):
+            handleDeepLinkInvite(code: code)
+        case let .chat(username, data):
+            handleDeepLinkChat(username: username, data: data)
+        case let .botInstall(appId):
+            handleDeepLinkBotInstall(appId: appId)
+        }
+    }
+
+    private func handleDeepLinkBotInstall(appId: String) {
+        guard let appIdInt = Int64(appId) else { return }
+        let clans = homeController?.clanListVC.clans ?? []
+        let vc = InstallClanViewController(context: context, appId: appIdInt, clans: clans)
+        presentDeepLinkOverlay(vc)
+    }
+
+    private func presentDeepLinkOverlay(_ controller: UIViewController) {
+        let presenter: UIViewController
+        if let root = view.window?.rootViewController {
+            var top = root
+            while let presented = top.presentedViewController {
+                top = presented
+            }
+            presenter = top
+        } else {
+            presenter = self
+        }
+        guard presenter.presentedViewController == nil,
+              !presenter.isBeingPresented,
+              !presenter.isBeingDismissed else { return }
+        if presenter is InstallClanViewController || presenter is DeepLinkNodeOverlayController { return }
+        presenter.present(controller, animated: true)
+    }
+
+    private func handleDeepLinkChannelApp(channelId: String, clanId: String?) {
+        guard let channelIdInt = Int64(channelId) else { return }
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard let token = await self.context.getToken() else {
+                Toast.error("Session unavailable")
+                return
+            }
+            let clanIdInt = clanId.flatMap { Int64($0) } ?? self.context.currentClanId
+            guard clanIdInt != 0 else {
+                Toast.error("App unavailable")
+                return
+            }
+            do {
+                let apps = try await self.context.account.network.listChannelApps(clanId: clanIdInt, token: token)
+                guard let app = apps.first(where: { $0.channelID == channelIdInt }) else {
+                    Toast.error("App unavailable")
+                    return
+                }
+                let webAppData = try await self.context.account.network.generateChannelAppHash(appId: app.appID, token: token)
+                guard !webAppData.isEmpty, let url = app.channelAppWebPageURL(webAppData: webAppData) else {
+                    Toast.error("App unavailable")
+                    return
+                }
+                let title = app.appName.trimmingCharacters(in: .whitespacesAndNewlines)
+                let vc = ChannelAppWebViewController(pageURL: url, appTitle: title.isEmpty ? "App" : title)
+                self.presentOverlay(controller: vc, inGlobal: true)
+                DispatchQueue.main.async { [weak self] in
+                    self?.requestLayout(transition: .immediate)
+                }
+            } catch {
+                Toast.error(error.localizedDescription)
+            }
+        }
+    }
+
+    private func handleDeepLinkInvite(code: String) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            var token = self.context.session?.token ?? ""
+            if token.isEmpty {
+                token = await self.context.getToken() ?? ""
+            }
+            do {
+                let inviteInfo = try await self.context.engine.clanData.getInviteInfo(code: code, token: token)
+                let theme = self.context.sharedContext.currentPresentationTheme.attributes
+                let node = QRClanInviteNode(theme: theme, inviteInfo: inviteInfo)
+                let overlay = DeepLinkNodeOverlayController(node: node)
+                node.onCancel = { [weak overlay] in
+                    overlay?.dismissOverlay()
+                }
+                node.onJoin = { [weak self, weak overlay] in
+                    guard let self else { return }
+                    Task { @MainActor in
+                        do {
+                            let response = try await self.context.engine.clanData.joinClanWithInvite(code: code, token: token)
+                            overlay?.dismissOverlay {
+                                self.rootTabController?.selectedIndex = 0
+                                self.popToTabBarController()
+                                NotificationCenter.default.post(
+                                    name: .mezonQRSelectClan,
+                                    object: nil,
+                                    userInfo: ["clanId": "\(response.clanID)"]
+                                )
+                            }
+                        } catch {
+                            Toast.error(error.localizedDescription)
+                        }
+                    }
+                }
+                self.presentDeepLinkOverlay(overlay)
+            } catch {
+                Toast.error(error.localizedDescription)
+            }
+        }
+    }
+
+    private func handleDeepLinkChat(username: String, data: String?) {
+        guard let data, let profile = DeepLinkRouter.decodeProfileData(data) else {
+            return
+        }
+        let theme = context.sharedContext.currentPresentationTheme.attributes
+        let node = QRUserProfileNode(profile: profile, theme: theme)
+        let overlay = DeepLinkNodeOverlayController(node: node)
+        node.onClose = { [weak overlay] in
+            overlay?.dismissOverlay()
+        }
+        node.onMessage = { [weak self, weak overlay] in
+            guard let self else { return }
+            Task { @MainActor in
+                do {
+                    guard let userId = Int64(profile.id) else { return }
+                    let token = await self.context.getToken() ?? ""
+                    let channel = try await self.context.account.network.createDirectMessage(userId: userId, token: token)
+                    overlay?.dismissOverlay {
+                        NotificationCenter.default.post(
+                            name: .mezonQRNavigateToDM,
+                            object: nil,
+                            userInfo: ["channelId": "\(channel.channelID)", "title": profile.name]
+                        )
+                    }
+                } catch {
+                    Toast.error(error.localizedDescription)
+                }
+            }
+        }
+        presentDeepLinkOverlay(overlay)
     }
 
     deinit {

--- a/MezonChat/MezonChat.entitlements
+++ b/MezonChat/MezonChat.entitlements
@@ -4,6 +4,11 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:mezon.ai</string>
+		<string>applinks:www.mezon.ai</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.mezon.mobile</string>

--- a/MezonChat/Networking/MezonHTTPClient.swift
+++ b/MezonChat/Networking/MezonHTTPClient.swift
@@ -1609,6 +1609,27 @@ final class MezonHTTPClient {
         return response.channelApps
     }
 
+    func getApp(appId: Int64, token: String) async throws -> Mezon_Api_App {
+        var req = Mezon_Api_App()
+        req.id = appId
+        return try await postProto(
+            path: "/mezon.api.Mezon/GetApp",
+            message: req,
+            auth: .bearer(token)
+        )
+    }
+
+    func addAppToClan(appId: Int64, clanId: Int64, token: String) async throws {
+        var req = Mezon_Api_AppClan()
+        req.appID = appId
+        req.clanID = clanId
+        try await postProtoIgnoringBody(
+            path: "/mezon.api.Mezon/AddAppToClan",
+            message: req,
+            auth: .bearer(token)
+        )
+    }
+
     func generateChannelAppHash(appId: Int64, token: String) async throws -> String {
         var req = Mezon_Api_GenerateHashChannelAppsRequest()
         req.appID = appId

--- a/MezonChat/Resources/Info.plist
+++ b/MezonChat/Resources/Info.plist
@@ -28,6 +28,15 @@
 				<string>mezon.mobile.sharing</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>ai.mezon.deeplink</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>mezon</string>
+				<string>mezon.ai</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>

--- a/project.yml
+++ b/project.yml
@@ -160,6 +160,10 @@ targets:
           - CFBundleURLSchemes:
               - "mezon.mobile.sharing"
             CFBundleURLName: "mezon.mobile.sharing"
+          - CFBundleURLSchemes:
+              - "mezon"
+              - "mezon.ai"
+            CFBundleURLName: "ai.mezon.deeplink"
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait
           - UIInterfaceOrientationLandscapeLeft


### PR DESCRIPTION
ticket: https://github.com/mezonai/mezon/issues/12936
# feat: Deep Linking (Universal Links + Custom URL Scheme)

Brings the iOS app to parity with Android/React Native for opening `mezon.ai`
links directly inside the app (join clan, install bot, channel app, user profile).

---

## 1. Root Cause / Context

The iOS app had **no deep link handling**:

- Tapping a `https://mezon.ai/...` link always opened the **website** (or did
  nothing), even when the app was installed.
- Custom scheme links (`mezon://...`) were not registered, so they failed
  silently.
- Android/React Native already supported these routes
  (`RootNavigator.tsx` linking config + `AuthenticationLoader.onNavigationDeeplink`),
  so iOS was behind on a shared product flow (invites, bot installs, shared
  profiles).

Result: invite / install / profile links shared from web or other clients could
not drive in-app navigation on iOS.

---

## 2. Solution

Native deep link layer that mirrors the RN routing logic, reusing existing iOS
screens/flows wherever possible.

### Supported routes

| Link path | Action | Reused iOS flow |
|---|---|---|
| `invite/:code` | Show clan invite → join | `getInviteInfo` / `joinClanWithInvite` + `QRClanInviteNode` |
| `channel-app/:channelId/:clanId` | Open channel app web view | `listChannelApps` / `generateChannelAppHash` + `ChannelAppWebViewController` |
| `chat/:username?data=` | Show user profile → DM | `QRUserProfileNode` + `createDirectMessage` |
| `(bot\|app)/install/:appId` | Install bot/app into a clan | `getApp` / `addAppToClan` + `InstallClanViewController` (new) |

Accepted prefixes (same as RN): `https://mezon.ai`, `http://mezon.ai`,
`mezon.ai://`, `mezon://`.

### Architecture

```
URL  ──▶  AppDelegate (scene openURL / continue userActivity / cold-start)
          └─▶ DeepLinkRouter.handle(url)
                 ├─ parse → DeepLinkRoute
                 ├─ store as `pending`
                 └─ post .mezonHandleDeepLink
                         └─▶ MezonRootController
                                 └─ scheduleDeepLink → waitForSessionReady → route
```

- **`DeepLinkRouter`** – pure parser (regex, mirrors RN), pending storage for
  cold start, single notification entry point.
- **`MezonRootController`** – owns navigation; gates every route behind
  `waitForSessionReady()` (cold + warm), then presents the matching screen. This
  reuses the existing `.mezonNavigateToChannel` / notification pattern already in
  the controller.
- **`InstallClanViewController`** (new) – native install screen mirroring RN
  `InstallClanScreen`: app detail (`getApp`), clan picker
  (`ClanPickerSheetViewController`), `addAppToClan`.

---

## 3. Self-test

### Prerequisites
- App built & installed on a **logged-in** session (routes need an authenticated
  session + loaded clans).
- For **Universal Links** (`https://`) to open the app instead of Safari, the
  server must host
  `https://mezon.ai/.well-known/apple-app-site-association` (see Follow-ups). On
  simulator without AASA, test routing with the **custom scheme** equivalents
  below.

### Test links

| Case | Universal Link | Custom scheme (sim) | Expected |
|---|---|---|---|
| Join clan | `https://mezon.ai/invite/2033727298921828352` | `mezon://invite/2033727298921828352` | Invite sheet with clan info → **Join** switches to that clan |
| Add bot | `https://mezon.ai/developers/bot/install/2053745607465504768` | `mezon://developers/bot/install/2053745607465504768` | Install screen (app logo/name) → pick clan → **Add** (enabled only after pick) → success toast |
| Chat profile |  
<img width="531" height="470" alt="image" src="https://github.com/user-attachments/assets/f0fd4d1f-809d-47ad-bd32-222661ffb8e7" />
 | Profile card → **Message** opens DM |
