### PR TITLE
260609-IOS-Improve emoji empty UI

### DIFF
--- a/MezonChat/Core/Localization/L10n.swift
+++ b/MezonChat/Core/Localization/L10n.swift
@@ -389,6 +389,7 @@ enum L10n {
         static let settings       = "clan.settings"
         static let duplicateName  = "clan.duplicateName"
         static let invalidName    = "clan.invalidName"
+        static let creationLimitReached = "clan.creationLimitReached"
     }
 
     enum Discover {
@@ -468,6 +469,7 @@ enum L10n {
             static let previewUpload = "clan.setting.emojis.previewUpload"
             static let previewLengthError = "clan.setting.emojis.previewLengthError"
             static let previewTypeEmoji = "clan.setting.emojis.previewTypeEmoji"
+            static let empty = "clan.setting.emojis.empty"
         }
 
         enum Stickers {
@@ -1351,6 +1353,7 @@ extension L10n {
         "clan.settings":    "Clan Settings",
         "clan.duplicateName": "The clan name already exists. Please enter another name.",
         "clan.invalidName": "Please enter a valid clan name (max 64 characters, only words, numbers, _ or -).",
+        "clan.creationLimitReached": "You have reached the clan creation limit.",
 
         "discover.communityOnMezon": "Community on Mezon",
         "discover.exploreCommunities": "Explore communities",
@@ -1443,6 +1446,7 @@ extension L10n {
         "clan.setting.emojis.previewUpload": "Upload",
         "clan.setting.emojis.previewLengthError": "%@ name must be between %d and %d characters, only letters, numbers, _ and - are allowed.",
         "clan.setting.emojis.previewTypeEmoji": "Emoji",
+        "clan.setting.emojis.empty": "No emojis found",
 
         "clanRoles.title":                  "Roles",
         "clanRoles.roleDescription":        "Use roles to group your clan members and assign permissions.",
@@ -2345,6 +2349,7 @@ extension L10n {
         "clan.settings":    "Cài đặt Clan",
         "clan.duplicateName": "Tên Clan đã tồn tại. Vui lòng nhập tên khác.",
         "clan.invalidName": "Vui lòng nhập tên clan hợp lệ (tối đa 64 ký tự, chỉ từ, số, _ hoặc -).",
+        "clan.creationLimitReached": "Bạn đã đạt giới hạn tạo clan.",
 
         "discover.communityOnMezon": "Cộng đồng trên Mezon",
         "discover.exploreCommunities": "Khám phá cộng đồng",
@@ -2437,6 +2442,7 @@ extension L10n {
         "clan.setting.emojis.previewUpload": "Tải lên",
         "clan.setting.emojis.previewLengthError": "Tên %@ phải từ %d đến %d ký tự, chỉ chữ, số, _ và -.",
         "clan.setting.emojis.previewTypeEmoji": "biểu cảm",
+        "clan.setting.emojis.empty": "Không tìm thấy biểu cảm nào",
 
         "clanRoles.title":                  "Vai trò",
         "clanRoles.roleDescription":        "Dùng vai trò để nhóm thành viên và phân quyền trong clan.",

--- a/MezonChat/Features/Chat/ChatViewController.swift
+++ b/MezonChat/Features/Chat/ChatViewController.swift
@@ -656,6 +656,7 @@ final class ChatViewController: ViewController {
                     )
                     return
                 }
+                if ClanCreationLimit.showLimitToastIfNeeded(context: self.context) { return }
                 Task {
                     do {
                         let response = try await self.context.engine.clanData.joinClanWithInvite(code: code, token: token)

--- a/MezonChat/Features/ClanSettings/ClanEmojisViewController.swift
+++ b/MezonChat/Features/ClanSettings/ClanEmojisViewController.swift
@@ -230,7 +230,7 @@ final class ClanEmojisViewController: BaseViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        reloadData()
+        loadEmojiData()
         fetchClanMembersIfNeeded()
     }
 
@@ -269,18 +269,17 @@ final class ClanEmojisViewController: BaseViewController {
         }
         tableHeaderContainer.backgroundColor = UIColor.theme.primary
         applyEmojiListChrome()
-        tableView.reloadData()
+        refreshEmojiTable()
     }
 
     private func applyEmojiListChrome() {
-        let hasEmojis = !emojis.isEmpty
-        tableView.isHidden = !hasEmojis
-        if hasEmojis {
+        tableView.isHidden = false
+        if emojis.isEmpty {
+            tableView.backgroundColor = UIColor.theme.primary
+            tableView.layer.cornerRadius = 0
+        } else {
             tableView.backgroundColor = UIColor.theme.secondary
             tableView.layer.cornerRadius = 12.swh
-        } else {
-            tableView.backgroundColor = .clear
-            tableView.layer.cornerRadius = 0
         }
     }
 
@@ -304,20 +303,32 @@ final class ClanEmojisViewController: BaseViewController {
             height: tableHeaderHeight
         )
         let listTop = safeTop + headerH + tableHeaderHeight
-        let hasEmojis = !emojis.isEmpty
         applyEmojiListChrome()
         tableView.tableHeaderView = nil
         tableView.frame = CGRect(
             x: inset,
             y: listTop,
             width: contentWidth,
-            height: hasEmojis ? layout.size.height - listTop : 0
+            height: layout.size.height - listTop
         )
-        if abs(lastTableHeaderWidth - layout.size.width) > 0.5 {
+        if emojis.isEmpty {
+            UIView.performWithoutAnimation {
+                tableView.reloadData()
+            }
+        } else if abs(lastTableHeaderWidth - layout.size.width) > 0.5 {
             lastTableHeaderWidth = layout.size.width
             tableView.beginUpdates()
             tableView.endUpdates()
         }
+    }
+
+    private func emptyRowHeight(for tableView: UITableView) -> CGFloat {
+        let boundsHeight = tableView.bounds.height
+        if boundsHeight > 0 { return boundsHeight }
+        guard let layout = currentlyAppliedLayout else { return 0 }
+        let safeTop = resolvedSafeTop(for: layout)
+        let listTop = safeTop + headerBarHeight + tableHeaderHeight
+        return max(0, layout.size.height - listTop)
     }
 
     private var currentUserId: Int64 {
@@ -382,7 +393,7 @@ final class ClanEmojisViewController: BaseViewController {
         present(picker, animated: true)
     }
 
-    private func reloadData() {
+    private func loadEmojiData() {
         emojis = repository.emojis(clanId: clanId)
         let members = context.engine.account.postbox.read { $0.getClanMembers(clanId: self.clanId) }
         clanMembers = Dictionary(uniqueKeysWithValues: members.map { ($0.userId, $0) })
@@ -390,11 +401,20 @@ final class ClanEmojisViewController: BaseViewController {
         let atLimit = repository.isAtUploadLimit(clanId: clanId)
         uploadButton.isEnabled = true
         uploadButton.alpha = atLimit ? 0.5 : 1.0
-        tableView.reloadData()
         applyEmojiListChrome()
+    }
+
+    private func refreshEmojiTable() {
+        if emojis.isEmpty, currentlyAppliedLayout == nil { return }
+        tableView.reloadData()
         if let layout = currentlyAppliedLayout {
             applyChromeLayout(layout)
         }
+    }
+
+    private func reloadData() {
+        loadEmojiData()
+        refreshEmojiTable()
     }
 
     private func fetchClanMembersIfNeeded() {
@@ -498,11 +518,21 @@ final class ClanEmojisViewController: BaseViewController {
 
 extension ClanEmojisViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        emojis.count
+        emojis.isEmpty ? 1 : emojis.count
+    }
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        guard emojis.isEmpty else { return UITableView.automaticDimension }
+        let height = emptyRowHeight(for: tableView)
+        return height > 0 ? height : UITableView.automaticDimension
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: EmojiItemCell.reuseId, for: indexPath) as! EmojiItemCell
+        if emojis.isEmpty {
+            cell.configureEmpty(text: L(L10n.ClanSetting.Emojis.empty))
+            return cell
+        }
         let rowCount = emojis.count
         let isLast = indexPath.row == rowCount - 1
         let emoji = emojis[indexPath.row]

--- a/MezonChat/Features/ClanSettings/EmojiItemCell.swift
+++ b/MezonChat/Features/ClanSettings/EmojiItemCell.swift
@@ -33,6 +33,7 @@ final class EmojiItemCell: UITableViewCell {
     private let creatorTextAvatar = TextAvatarView(username: "", size: creatorAvatarSize, fontSize: 12.sf)
     private let creatorAvatarImageView = UIImageView()
     private let creatorNameLabel = UILabel()
+    private let emptyStateLabel = UILabel()
     private let separatorView = UIView()
 
     private var iconTask: URLSessionDataTask?
@@ -135,11 +136,17 @@ final class EmojiItemCell: UITableViewCell {
         creatorNameLabel.textColor = UIColor.theme.textStrong
         creatorNameLabel.lineBreakMode = .byTruncatingTail
 
+        emptyStateLabel.font = .systemFont(ofSize: 15.sf, weight: .medium)
+        emptyStateLabel.textColor = UIColor.theme.textDisabled
+        emptyStateLabel.textAlignment = .center
+        emptyStateLabel.numberOfLines = 0
+        emptyStateLabel.isHidden = true
+
         [deleteActionView, mainContentView, separatorView].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             contentView.addSubview($0)
         }
-        [deleteButton, iconContainerView, iconView, forSaleBadgeHost, forSaleBadgeView, nameFieldStack, creatorTextAvatar, creatorNameLabel].forEach {
+        [deleteButton, iconContainerView, iconView, forSaleBadgeHost, forSaleBadgeView, nameFieldStack, emptyStateLabel, creatorTextAvatar, creatorNameLabel].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
         deleteActionView.addSubview(deleteButton)
@@ -150,7 +157,7 @@ final class EmojiItemCell: UITableViewCell {
         nameFieldStack.addArrangedSubview(colonPrefixLabel)
         nameFieldStack.addArrangedSubview(nameTextField)
         nameFieldStack.addArrangedSubview(colonSuffixLabel)
-        [iconContainerView, forSaleBadgeHost, nameFieldStack, creatorTextAvatar, creatorNameLabel].forEach {
+        [iconContainerView, forSaleBadgeHost, nameFieldStack, emptyStateLabel, creatorTextAvatar, creatorNameLabel].forEach {
             mainContentView.addSubview($0)
         }
         contentView.addGestureRecognizer(panGesture)
@@ -215,6 +222,11 @@ final class EmojiItemCell: UITableViewCell {
             ),
             nameFieldStack.trailingAnchor.constraint(lessThanOrEqualTo: creatorNameLabel.leadingAnchor, constant: -10.sw),
 
+            emptyStateLabel.centerXAnchor.constraint(equalTo: mainContentView.centerXAnchor),
+            emptyStateLabel.centerYAnchor.constraint(equalTo: mainContentView.centerYAnchor),
+            emptyStateLabel.leadingAnchor.constraint(greaterThanOrEqualTo: mainContentView.leadingAnchor, constant: Self.horizontalInset),
+            emptyStateLabel.trailingAnchor.constraint(lessThanOrEqualTo: mainContentView.trailingAnchor, constant: -Self.horizontalInset),
+
             creatorTextAvatar.trailingAnchor.constraint(equalTo: mainContentView.trailingAnchor, constant: -Self.horizontalInset),
             creatorTextAvatar.centerYAnchor.constraint(equalTo: mainContentView.centerYAnchor),
             creatorTextAvatar.widthAnchor.constraint(equalToConstant: Self.creatorAvatarSize),
@@ -254,15 +266,17 @@ final class EmojiItemCell: UITableViewCell {
         mainContentView.transform = CGAffineTransform(translationX: currentSwipeOffset, y: 0)
     }
 
-    private func updateAppearance() {
-        mainContentView.backgroundColor = UIColor.theme.secondary
+    private func updateAppearance(isEmpty: Bool = false) {
+        let contentBackground = isEmpty ? UIColor.theme.primary : UIColor.theme.secondary
+        mainContentView.backgroundColor = contentBackground
         forSaleBadgeHost.backgroundColor = UIColor.theme.secondary
         separatorView.backgroundColor = UIColor.theme.border
         nameTextField.textColor = .mezonTextPrimary
         colonPrefixLabel.textColor = .mezonTextPrimary
         colonSuffixLabel.textColor = .mezonTextPrimary
+        emptyStateLabel.textColor = UIColor.theme.textDisabled
         creatorNameLabel.textColor = UIColor.theme.textStrong
-        selectedBackgroundView?.backgroundColor = UIColor.theme.secondary.withAlphaComponent(0.6)
+        selectedBackgroundView?.backgroundColor = contentBackground.withAlphaComponent(isEmpty ? 0 : 0.6)
         applySwipeOffset(currentSwipeOffset, animated: false)
     }
 
@@ -310,7 +324,10 @@ final class EmojiItemCell: UITableViewCell {
         closeSwipe(animated: false)
         isSwipeDeletable = isEditable
         syncDeleteActionVisibility()
-        updateAppearance()
+        updateAppearance(isEmpty: false)
+        iconContainerView.isHidden = false
+        nameFieldStack.isHidden = false
+        emptyStateLabel.isHidden = true
         originalInnerName = CachedClanEmojiRecord.innerName(from: emoji.shortname)
         nameTextField.text = originalInnerName
         nameTextField.textColor = .mezonTextPrimary
@@ -333,18 +350,20 @@ final class EmojiItemCell: UITableViewCell {
     func configureEmpty(text: String, isLast: Bool = true) {
         closeSwipe(animated: false)
         isSwipeDeletable = false
-        updateAppearance()
+        updateAppearance(isEmpty: true)
         iconTask?.cancel()
         iconView.image = nil
         creatorAvatarImageView.image = nil
+        iconContainerView.isHidden = true
         iconView.isHidden = true
         forSaleBadgeHost.isHidden = true
         creatorTextAvatar.isHidden = true
         creatorNameLabel.isHidden = true
+        nameFieldStack.isHidden = true
+        emptyStateLabel.isHidden = false
+        emptyStateLabel.text = text
         deleteActionView.isHidden = true
-        nameTextField.text = text
-        nameTextField.textColor = UIColor.theme.textDisabled
-        nameTextField.textAlignment = .left
+        nameTextField.text = nil
         nameTextField.isUserInteractionEnabled = false
         isUserInteractionEnabled = false
         applyRowSeparator(isLast: isLast)
@@ -377,6 +396,10 @@ final class EmojiItemCell: UITableViewCell {
         loadingIconURL = nil
         iconView.image = nil
         forSaleBadgeHost.isHidden = true
+        iconContainerView.isHidden = false
+        nameFieldStack.isHidden = false
+        emptyStateLabel.isHidden = true
+        emptyStateLabel.text = nil
         creatorAvatarImageView.image = nil
         creatorTextAvatar.showImageMode()
         onShortnameCommit = nil

--- a/MezonChat/Features/ClanSettings/EmojisRepository.swift
+++ b/MezonChat/Features/ClanSettings/EmojisRepository.swift
@@ -39,11 +39,7 @@ final class EmojisRepository {
         let updated = try await context.account.network.updateClanEmoji(request: req, token: token)
         mutateEmojiCache { emojis in
             guard let idx = emojis.firstIndex(where: { $0.id == id }) else { return }
-            emojis[idx] = Self.mergeEmojiRecord(
-                existing: emojis[idx],
-                updated: updated.toCachedRecord(),
-                fallbackShortname: shortname
-            )
+            emojis[idx].shortname = updated.shortname.isEmpty ? shortname : updated.shortname
         }
     }
 
@@ -136,7 +132,7 @@ final class EmojisRepository {
         if updated.clanID != 0 { merged.clanID = updated.clanID }
         if !updated.logo.isEmpty { merged.logo = updated.logo }
         if !updated.clanName.isEmpty { merged.clanName = updated.clanName }
-        merged.isForSale = updated.isForSale
+        merged.isForSale = updated.isForSale || existing.isForSale
         return merged
     }
 

--- a/MezonChat/Features/Clans/ClanCreationModels.swift
+++ b/MezonChat/Features/Clans/ClanCreationModels.swift
@@ -97,6 +97,26 @@ enum ClanCreationTemplate: Int, CaseIterable {
     }
 }
 
+@MainActor
+enum ClanCreationLimit {
+    static let maxClans = 50
+
+    static func currentClanCount(context: AccountContext) -> Int {
+        context.account.postbox.read { tx in tx.getClans().count }
+    }
+
+    static func isAtLimit(context: AccountContext) -> Bool {
+        currentClanCount(context: context) >= maxClans
+    }
+
+    @discardableResult
+    static func showLimitToastIfNeeded(context: AccountContext) -> Bool {
+        guard isAtLimit(context: context) else { return false }
+        Toast.error(L(L10n.Clan.creationLimitReached))
+        return true
+    }
+}
+
 enum ClanCreationNameRules {
     static let maxLength = 64
 

--- a/MezonChat/Features/Clans/CreateClanViewController.swift
+++ b/MezonChat/Features/Clans/CreateClanViewController.swift
@@ -394,6 +394,7 @@ final class CreateClanViewController: BaseViewController, UIImagePickerControlle
 
     @objc private func createTapped() {
         guard !isSubmitting, uploadCount == 0 else { return }
+        if ClanCreationLimit.showLimitToastIfNeeded(context: context) { return }
         let name = (nameField.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         guard !name.isEmpty else {
             Toast.error(L(L10n.Clan.nameRequired))


### PR DESCRIPTION
issue: https://github.com/mezonai/mezon/issues/13200
result: 
<img width="358" height="758" alt="image" src="https://github.com/user-attachments/assets/8987df23-90d2-4762-ab3b-15586457a9d7" />

root cause: 
Bug 1 — Empty emoji list ClanEmojisViewController hid the table when the list was empty, so no empty-state text was shown.
Bug 2 — For-sale badge disappears after rename updateEmoji merged the full API response into cache; UpdateClanEmojiById omits is_for_sale, so isForSale was overwritten to false locally until a full sync on app restart.

test cases:
ug 1 — Empty state
Open a clan with no custom emojis and verify "No emojis found" is shown.
Confirm the empty text has no leading or trailing colons.
Confirm the empty text is centered in the list area below the upload section.
Confirm the empty list background matches the screen background (no secondary rounded card).
Upload an emoji and confirm the list switches to the normal secondary rounded list.
Delete the last emoji and confirm "No emojis found" appears again.
Bug 2 — For-sale badge after edit
Open a clan emoji that has the for-sale badge and note it is visible.
Edit the emoji name, save, and confirm the for-sale badge stays visible immediately.
Without restarting the app, pull to refresh or leave and re-enter the screen and confirm the badge is still visible.
Confirm only the name changed and the emoji image is unchanged.
Edit a non-for-sale emoji name and confirm no for-sale badge appears.
Kill and reopen the app, then confirm the for-sale badge is still correct after rename.

solution:
Bug 1 — Empty emoji list
Solution: Show a dedicated empty state instead of hiding the table.

ClanEmojisViewController: render 1 row when the list is empty, give it full list height, and use primary background (no rounded secondary card).
EmojiItemCell: add emptyStateLabel for centered text; hide nameFieldStack (:name:) in empty mode.
L10n: add clan.setting.emojis.empty → "No emojis found".
Bug 2 — For-sale badge lost after rename
Solution: On rename, update only shortname in local cache — do not merge the full API response.

EmojisRepository.updateEmoji: set emojis[idx].shortname only, because UpdateClanEmojiById returns a partial record without is_for_sale.
mergeEmojiRecord: keep isForSale = updated.isForSale || existing.isForSale for the create/add flow as a safeguard.
