### PR TITLE
fix: preserve attachments when presign_finish update has no attachment payload

### DIFF
--- a/MezonChat/Core/Postbox/Messages/MessageRecord.swift
+++ b/MezonChat/Core/Postbox/Messages/MessageRecord.swift
@@ -142,7 +142,7 @@ extension MessageRecord {
                 senderDisplayName: fresh.senderDisplayName,
                 senderAvatarURL: fresh.senderAvatarURL,
                 sendingState: fresh.sendingState,
-                attachmentsJSON: fresh.attachmentsJSON,
+                attachmentsJSON: mergedAttachmentsJSON(fresh: fresh, previous: prev),
                 reactionsJSON: fresh.reactionsJSON,
                 referencesData: fresh.referencesData,
                 mentionsJSON: fresh.mentionsJSON
@@ -178,7 +178,7 @@ extension MessageRecord {
                 senderDisplayName: mergedDisplayName,
                 senderAvatarURL: mergedAvatarURL,
                 sendingState: fresh.sendingState,
-                attachmentsJSON: fresh.attachmentsJSON,
+                attachmentsJSON: mergedAttachmentsJSON(fresh: fresh, previous: prev),
                 reactionsJSON: mergedReactionsJSON(fresh: fresh, previous: prev),
                 referencesData: fresh.referencesData,
                 mentionsJSON: fresh.mentionsJSON
@@ -226,7 +226,7 @@ extension MessageRecord {
             senderDisplayName: finalDisplayName,
             senderAvatarURL: fresh.senderAvatarURL ?? prev.senderAvatarURL,
             sendingState: fresh.sendingState,
-            attachmentsJSON: fresh.attachmentsJSON,
+            attachmentsJSON: mergedAttachmentsJSON(fresh: fresh, previous: prev),
             reactionsJSON: mergedReactionsJSON(fresh: fresh, previous: prev),
             referencesData: fresh.referencesData,
             mentionsJSON: fresh.mentionsJSON
@@ -257,9 +257,44 @@ extension MessageRecord {
         fresh.reactionsJSON.isEmpty ? previous.reactionsJSON : fresh.reactionsJSON
     }
 
+    private static func mergedAttachmentsJSON(incoming: Data, previous: Data) -> Data {
+        incoming.isEmpty ? previous : incoming
+    }
+
+    private static func mergedAttachmentsJSON(fresh: MessageRecord, previous: MessageRecord) -> Data {
+        mergedAttachmentsJSON(incoming: fresh.attachmentsJSON, previous: previous.attachmentsJSON)
+    }
+
+    static func mergingIncomingPreservingEmptyAttachments(
+        incoming: MessageRecord,
+        previous: MessageRecord
+    ) -> MessageRecord {
+        let attachmentsJSON = mergedAttachmentsJSON(incoming: incoming.attachmentsJSON, previous: previous.attachmentsJSON)
+        guard attachmentsJSON != incoming.attachmentsJSON else { return incoming }
+        return MessageRecord(
+            id: incoming.id,
+            channelId: incoming.channelId,
+            clanId: incoming.clanId,
+            senderId: incoming.senderId,
+            content: incoming.content,
+            createdAt: incoming.createdAt,
+            editedAt: incoming.editedAt,
+            isDeleted: incoming.isDeleted,
+            code: incoming.code,
+            senderDisplayName: incoming.senderDisplayName,
+            senderAvatarURL: incoming.senderAvatarURL,
+            sendingState: incoming.sendingState,
+            attachmentsJSON: attachmentsJSON,
+            reactionsJSON: incoming.reactionsJSON,
+            referencesData: incoming.referencesData,
+            mentionsJSON: incoming.mentionsJSON
+        )
+    }
+
     private static func recordByMergingReactions(fresh: MessageRecord, previous: MessageRecord) -> MessageRecord {
         let reactionsJSON = mergedReactionsJSON(fresh: fresh, previous: previous)
-        guard reactionsJSON != fresh.reactionsJSON else { return fresh }
+        let attachmentsJSON = mergedAttachmentsJSON(fresh: fresh, previous: previous)
+        guard reactionsJSON != fresh.reactionsJSON || attachmentsJSON != fresh.attachmentsJSON else { return fresh }
         return MessageRecord(
             id: fresh.id,
             channelId: fresh.channelId,
@@ -273,7 +308,7 @@ extension MessageRecord {
             senderDisplayName: fresh.senderDisplayName,
             senderAvatarURL: fresh.senderAvatarURL,
             sendingState: fresh.sendingState,
-            attachmentsJSON: fresh.attachmentsJSON,
+            attachmentsJSON: attachmentsJSON,
             reactionsJSON: reactionsJSON,
             referencesData: fresh.referencesData,
             mentionsJSON: fresh.mentionsJSON

--- a/MezonChat/Core/Postbox/Messages/MessageTable.swift
+++ b/MezonChat/Core/Postbox/Messages/MessageTable.swift
@@ -280,7 +280,10 @@ final class MessageTable: Table {
                     current[pidx] = Self.mergePendingIdentityIntoServerEcho(pending: pending, server: msg)
                     pendingDeletes.insert(pid)
                 } else if let idx = current.firstIndex(where: { $0.id == msg.id }) {
-                    current[idx] = msg
+                    current[idx] = MessageRecord.mergingIncomingPreservingEmptyAttachments(
+                        incoming: msg,
+                        previous: current[idx]
+                    )
                 } else {
                     current.append(msg)
                 }

--- a/MezonChat/Networking/MezonSocket.swift
+++ b/MezonChat/Networking/MezonSocket.swift
@@ -542,6 +542,8 @@ final class MezonSocket: NSObject {
     ) -> Data? {
         guard let msg = envelope.message else { return nil }
         switch msg {
+        case .channelMessageAck(let ack):
+            return try? ack.serializedData()
         case .listDataSocket(let wrapper):
             switch apiName {
             case "ListChannelBadgeCount":


### PR DESCRIPTION
## Summary

- Fix message attachments disappearing after `UpdateChannelMessage` syncs only `presign_finish` content (no attachment payload in server echo / socket update).
- Preserve existing `attachmentsJSON` when an incoming message update has empty attachments, matching the pattern already used for reactions.
- Decode `channelMessageAck` from socket RPC envelope responses so `UpdateChannelMessage` over WebSocket returns a proper ack instead of empty bytes.

## Problem

When sending images/files with incremental upload:

1. `SendChannelMessage` stores attachments in postbox.
2. `UpdateChannelMessage` pushes batched `presign_finish` keys with content like `{"presign_finish":["key1","key2"]}` only.
3. Server echo / `channel_message_update` often returns **no attachments**.
4. Client merge logic overwrote `attachmentsJSON` with empty data → attachments vanished from chat UI.

## Solution

| Area | Change |
|------|--------|
| `MessageRecord.fromApi` | Add `mergedAttachmentsJSON` — use incoming attachments only when non-empty; otherwise keep previous |
| `MessageTable.addMessages` | When replacing a message by id, merge via `mergingIncomingPreservingEmptyAttachments` |
| `MezonSocket` | Extract `channelMessageAck` in `serializedPayloadForCompletedApiRequest` for socket RPC responses |

## Test plan

- [ ] Send a message with 2+ images in a channel
- [ ] Confirm images stay visible while upload progresses (skeleton → real image per `presign_finish` key)
- [ ] After final `UpdateChannelMessage` (`isFinal=true`), attachments still visible; no blank media bubble
- [ ] Edit message text only — attachments unchanged
- [ ] Second device in same channel receives `channel_message_update` with empty attachments — attachments still visible on viewer
- [ ] `UpdateChannelMessage` over socket returns non-empty ack when server sends `channelMessageAck` in envelope