### PR TITLE
260610-IOS-Implement invite clan setting

### DIFF
--- a/MezonChat/Features/ClanSettings/ClanSettingsContainerNode.swift
+++ b/MezonChat/Features/ClanSettings/ClanSettingsContainerNode.swift
@@ -8,6 +8,7 @@ final class ClanSettingsContainerNode: ASDisplayNode {
     var onSelectIntegrations: (() -> Void)?
     var onSelectStickers: (() -> Void)?
     var onSelectEmojis: (() -> Void)?
+    var onSelectInvites: (() -> Void)?
 
     private let context: AccountContext
     private let clanId: Int64
@@ -113,7 +114,7 @@ final class ClanSettingsContainerNode: ASDisplayNode {
         if canShowRoles {
             userActions.append(.init(title: L(L10n.ClanSetting.roles), icon: "ClanSetting/RolesIcon", navigate: .roles))
         }
-        userActions.append(.init(title: L(L10n.ClanSetting.invites), icon: "ClanSetting/Invite"))
+        userActions.append(.init(title: L(L10n.ClanSetting.invites), icon: "ClanSetting/Invite", navigate: .invites))
         let userGroup = createGroup(actions: userActions)
         stackView.addArrangedSubview(userGroup)
 
@@ -391,6 +392,8 @@ final class ClanSettingsContainerNode: ASDisplayNode {
             onSelectStickers?()
         case .emojis:
             onSelectEmojis?()
+        case .invites:
+            onSelectInvites?()
         }
     }
 
@@ -418,6 +421,7 @@ private enum ClanSettingsNavigateAction: Int {
     case integrations = 2
     case stickers = 3
     case emojis = 4
+    case invites = 5
 }
 
 private struct SettingAction {

--- a/MezonChat/Features/ClanSettings/ClanSettingsViewController.swift
+++ b/MezonChat/Features/ClanSettings/ClanSettingsViewController.swift
@@ -61,6 +61,19 @@ final class ClanSettingsViewController: BaseViewController {
             let vc = ClanEmojisViewController(context: self.context, clanId: self.clanId)
             self.navigationController?.pushViewController(vc, animated: true)
         }
+        node.onSelectInvites = { [weak self] in
+            guard let self else { return }
+            let vc = ClanInviteSheetViewController(context: self.context, clanId: self.clanId)
+            vc.modalPresentationStyle = .pageSheet
+            if #available(iOS 15.0, *) {
+                if let sheet = vc.sheetPresentationController {
+                    sheet.prefersGrabberVisible = true
+                    sheet.detents = [.medium(), .large()]
+                    sheet.selectedDetentIdentifier = .medium
+                }
+            }
+            self.present(vc, animated: true)
+        }
         displayNode = node
     }
 


### PR DESCRIPTION
task https://github.com/mezonai/mezon/issues/13272
result:
<img width="389" height="792" alt="image" src="https://github.com/user-attachments/assets/5a9efe31-ba92-4014-9b7f-00843252f91b" />

test cases:
Tap on the "Invites" option under the User Management section in Clan Settings.
Verify that the Clan Invite bottom sheet appears smoothly from the bottom.
Verify that the bottom sheet initially occupies only half of the screen height.
Verify that dragging the top grabber expands the bottom sheet to full screen.
Verify that swiping down on the bottom sheet dismisses it completely.
solution: add navigation logic to clan invite bottomsheet