### PR TITLE
260630-IOS-Fix bug image blur

### DIFF
--- a/MezonChat/Features/ChannelDetail/Tabs/MediaGalleryNode.swift
+++ b/MezonChat/Features/ChannelDetail/Tabs/MediaGalleryNode.swift
@@ -189,10 +189,11 @@ final class MediaGalleryNode: ASDisplayNode {
 
     private func presentGallery(startingAt index: Int, previewImage: UIImage? = nil) {
         guard index >= 0, index < attachments.count else { return }
+        let proxySide = Int(flowLayout.itemSize.width * UIScreen.main.scale)
         let items: [GalleryItemInfo] = attachments.enumerated().map { (itemIndex, att) in
             let isVideo = Self.isVideo(att)
             let imageThumbURL = ImgproxyURL.attachmentURL(
-                from: att.url, width: 150, height: 150, resizeType: "fit")
+                from: att.url, width: proxySide, height: proxySide, resizeType: "fill")
             let preview = itemIndex == index
                 ? (previewImage
                     ?? ImageCache.shared.memoryImage(forKey: imageThumbURL)
@@ -326,10 +327,11 @@ extension MediaGalleryNode: ASCollectionDataSource, ASCollectionDelegate {
     func collectionNode(_ collectionNode: ASCollectionNode, nodeBlockForItemAt indexPath: IndexPath)
         -> ASCellNodeBlock
     {
-               let attachment = attachments[indexPath.item]
+        let attachment = attachments[indexPath.item]
         let isVideo = Self.isVideo(attachment)
+        let proxySide = Int(flowLayout.itemSize.width * UIScreen.main.scale)
         let imageThumbURL = ImgproxyURL.attachmentURL(
-            from: attachment.url, width: 150, height: 150, resizeType: "fit")
+            from: attachment.url, width: proxySide, height: proxySide, resizeType: "fill")
         let index = indexPath.item
         return { [weak self] in
             var cell: MediaThumbCellNode!

--- a/MezonChat/Features/SendMessageInput/EmojisPanel.swift
+++ b/MezonChat/Features/SendMessageInput/EmojisPanel.swift
@@ -402,10 +402,10 @@ final class EmojisPanel: UIView {
 
     private func displayTitle(for key: String) -> String {
         switch key {
-        case EmojiCategoryOrdering.recent: return "Recent"
-        case EmojiCategoryOrdering.forSale: return "For sale"
-        case EmojiCategoryOrdering.frequently: return "Frequently"
-        default: return key
+        case EmojiCategoryOrdering.recent: return "RECENT"
+        case EmojiCategoryOrdering.forSale: return "FOR SALE"
+        case EmojiCategoryOrdering.frequently: return "FREQUENTLY"
+        default: return key.uppercased()
         }
     }
 


### PR DESCRIPTION
https://github.com/mezonai/mezon/issues/13406
Root Cause:
Missing screen scale factor: The requested thumbnail dimension was hardcoded to 150 points without multiplying by UIScreen.main.scale, causing low-resolution images to stretch on high-density Retina displays.
Incorrect resize type: Using Imgproxy's "fit" instead of "fill" caused non-square images to shrink disproportionately on one edge, which the client-side .fill mode then heavily upscaled (up to 5x), causing severe blurriness.

Solution:
Multiply the requested Imgproxy size by UIScreen.main.scale to fetch the true physical pixel resolution.
Change Imgproxy resizeType from "fit" to "fill" so the server center-crops the thumbnails properly to match the grid cell's square ratio.

Test Cases:
Verify that square images in the Media Gallery load sharply on Retina display devices like iPhone Pro Max.
Verify that non-square images (e.g., wide 16:9 banners) in the Media Gallery are correctly center-cropped and appear crisp without heavy blur.