### PR TITLE
260702-IOS-Handle accept friend

### DIFF
--- a/MezonChat/Core/AccountContext/AccountContextImpl.swift
+++ b/MezonChat/Core/AccountContext/AccountContextImpl.swift
@@ -1379,7 +1379,7 @@ final class AccountContextImpl: AccountContext {
     }
 
     private func handleSocketNotification(_ noti: Mezon_Api_Notification) {
-        if noti.code == -3 { // NOTIFICATION_CODE_FRIEND_ACCEPT
+        if noti.code == -3 { 
             var senderName = ""
             if !noti.content.isEmpty {
                 let firstByte = noti.content.first ?? 0

--- a/MezonChat/Core/AccountContext/AccountContextImpl.swift
+++ b/MezonChat/Core/AccountContext/AccountContextImpl.swift
@@ -1379,6 +1379,30 @@ final class AccountContextImpl: AccountContext {
     }
 
     private func handleSocketNotification(_ noti: Mezon_Api_Notification) {
+        if noti.code == -3 { // NOTIFICATION_CODE_FRIEND_ACCEPT
+            var senderName = ""
+            if !noti.content.isEmpty {
+                let firstByte = noti.content.first ?? 0
+                if firstByte == 123 || firstByte == 91 {
+                    if let obj = try? JSONSerialization.jsonObject(with: noti.content) as? [String: Any] {
+                        let dn = obj["display_name"] as? String ?? ""
+                        senderName = dn.isEmpty ? (obj["username"] as? String ?? "") : dn
+                    }
+                } else {
+                    if let fcm = try? Mezon_Api_DirectFcmProto(serializedBytes: noti.content) {
+                        senderName = fcm.displayName.isEmpty ? fcm.username : fcm.displayName
+                    }
+                }
+            }
+            if senderName.isEmpty {
+                senderName = engine.account.postbox.read { tx in tx.getProfile(userId: String(noti.senderID))?.displayName } ?? "Someone"
+            }
+            let message = String(format: L(L10n.FriendRequest.toastAcceptSuccess), senderName)
+            Toast.success(message)
+            engine.friendsData.scheduleRefreshFromSocket()
+            return
+        }
+
         guard noti.channelID != 0 else { return }
         if currentChannel?.channelID == noti.channelID, noti.clanID != 0 { return }
 

--- a/MezonChat/Core/MezonEngine/MezonEngine+ClanData.swift
+++ b/MezonChat/Core/MezonEngine/MezonEngine+ClanData.swift
@@ -1114,7 +1114,7 @@ extension MezonEngine {
             persistFriends(list)
         }
 
-        private func scheduleRefreshFromSocket() {
+        func scheduleRefreshFromSocket() {
             socketRefreshTask?.cancel()
             socketRefreshTask = Task { [weak self] in
                 guard let self else { return }

--- a/MezonChat/Features/ChannelList/ChannelActionSheet.swift
+++ b/MezonChat/Features/ChannelList/ChannelActionSheet.swift
@@ -41,7 +41,7 @@ enum ChannelAction: CaseIterable {
         case .threads: return "Channel/channelThread"
         case .editChannel: return "Profile/SettingIcon"
         case .deleteChannel: return "ChannelSetting/DeleteIcon"
-        case .leaveThread: return "ChannelSetting/LeaveGroupIcon"
+        case .leaveThread: return "Profile/RemoveFriendIcon"
         }
     }
 


### PR DESCRIPTION
Root Cause:
The app incorrectly relied on the .addFriend socket event to show the toast, which lacked the exact state context (like who accepted the request) and often had an empty payload or mismatched ID.
Solution:
Listened for the specific real-time push notification with code -3 (NOTIFICATION_CODE_FRIEND_ACCEPT), parsed the sender's display name directly from the notification payload or local cache, displayed the success toast, and triggered a background refresh of the friends list.
TC1: Send a friend request to another user and verify a success toast appears immediately when they accept it.
TC2: Verify that the toast displays the correct display name or username of the person who accepted the request.
TC3: Verify that the friends list is automatically refreshed and the new friend appears in the "Friends" tab without manual pulling.