### PR TITLE
260207-IOS-Fix show Just now of old conversation

### DIFF
--- a/MezonChat/Features/DirectMessages/DmListItemCell.swift
+++ b/MezonChat/Features/DirectMessages/DmListItemCell.swift
@@ -328,7 +328,6 @@ final class DmListItemCell: UITableViewCell {
         if !hasHeaderPayload {
             let ts = max(
                 channel.updateTimeSeconds,
-                channel.lastSeenMessage.timestampSeconds,
                 channel.createTimeSeconds
             )
             return ts > 0 ? formatRelativeTime(timestamp: ts) : ""


### PR DESCRIPTION
issue: https://github.com/mezonai/mezon-ios/issues/209
Root Cause:
When navigating back from a chat, the app marks it as read and updates lastSeenMessage.timestampSeconds to the current time (now). For empty or older DMs (where hasHeaderPayload is false), the UI time calculation mistakenly included this updated lastSeenMessage.timestampSeconds in its fallback max() function, causing it to incorrectly display "Just now".

Solution:
Removed channel.lastSeenMessage.timestampSeconds from the fallback max() calculation inside previewTimeString() in DmListItemCell.swift, ensuring empty chats properly display their original updateTimeSeconds or createTimeSeconds.

Test Cases:
Open an old, empty Direct Message conversation from the list, navigate back, and verify its time label does not change to "Just now".
Send a new message in any Direct Message conversation, navigate back to the list, and verify its time label correctly updates to "Just now".