### PR TITLE
260703-IOS-Fix bug poll detail UI

### DIFF
--- a/MezonChat/Features/Chat/ChatViewController.swift
+++ b/MezonChat/Features/Chat/ChatViewController.swift
@@ -841,15 +841,31 @@ final class ChatViewController: ViewController {
                             channelId: Int64(channelId) ?? 0,
                             token: token
                         )
+                        let allClanMembers: [ClanMemberRecord] = self.clanId != 0
+                            ? self.context.account.postbox.read { $0.getClanMembers(clanId: self.clanId) }
+                            : []
+                        let clanMembersMap = Dictionary(allClanMembers.map { ($0.userId, $0) }, uniquingKeysWith: { first, _ in first })
+                        
                         var votersByOption: [Int: [PollVoter]] = [:]
                         for detail in response.voterDetails {
                             let voters = detail.userIds.map { userId in
                                 let profile = self.context.account.postbox.read { $0.getProfile(userId: "\(userId)") }
+                                let clanMember = clanMembersMap[userId]
+                                
+                                let displayName: String
+                                if let clanNick = clanMember?.clanNick, !clanNick.isEmpty {
+                                    displayName = clanNick
+                                } else {
+                                    displayName = profile?.displayName ?? profile?.username ?? "User"
+                                }
+                                
+                                let avatar = clanMember?.resolvedAvatarURL(fallbackProfileAvatar: profile?.avatarUrl) ?? profile?.avatarUrl ?? ""
+                                
                                 return PollVoter(
                                     id: "\(userId)",
-                                    displayName: profile?.displayName ?? profile?.username ?? "User",
-                                    username: profile?.username ?? "",
-                                    avatar: profile?.avatarUrl ?? ""
+                                    displayName: displayName,
+                                    username: profile?.username ?? clanMember?.username ?? "",
+                                    avatar: avatar
                                 )
                             }
                             votersByOption[Int(detail.answerIndex)] = voters


### PR DESCRIPTION
issue: https://github.com/mezonai/mezon/issues/13389
Root Cause: The poll detail view always fetched the default global user profile for voters, completely ignoring the clanNick and clanAvatar data when the poll was located inside a clan.

Solution: Fetched the ClanMemberRecord list from the local database for the current clan, and updated the mapping logic to prioritize displaying clan-specific avatars and nicknames over the default global profiles.

Test Cases:
Verify that viewing a poll inside a clan correctly displays the voters' clan avatars and clan nicknames.
Verify that viewing a poll inside a clan correctly falls back to the global avatar and display name if the voter hasn't set clan-specific ones.
Verify that viewing a poll inside a Direct Message (DM) correctly displays the voters' default global avatar and display name.
