### PR TITLE
260706-IOS-Fix update realtime files

### DIFF
--- a/MezonChat/Core/AccountContext/AccountContextImpl.swift
+++ b/MezonChat/Core/AccountContext/AccountContextImpl.swift
@@ -1016,6 +1016,11 @@ final class AccountContextImpl: AccountContext {
                         )
                     }
                 }
+                NotificationCenter.default.post(
+                    name: Notification.Name("MezonChannelMessageDeleted"),
+                    object: nil,
+                    userInfo: ["channelId": channelId, "clanId": clanId]
+                )
                 return
             }
 
@@ -1172,6 +1177,11 @@ final class AccountContextImpl: AccountContext {
 
         case .messageRemoved(let removed):
             account.postbox.write { tx in tx.deleteMessage(id: "\(removed.messageID)") }
+            NotificationCenter.default.post(
+                name: Notification.Name("MezonChannelMessageDeleted"),
+                object: nil,
+                userInfo: ["channelId": removed.channelID, "clanId": removed.clanID]
+            )
 
         case .lastSeen(let e):
             NotificationCenter.default.post(

--- a/MezonChat/Features/ChannelDetail/Tabs/FileListNode.swift
+++ b/MezonChat/Features/ChannelDetail/Tabs/FileListNode.swift
@@ -55,6 +55,38 @@ final class FileListNode: ASDisplayNode {
         }
 
         loadingNode.style.preferredSize = CGSize(width: 44, height: 44)
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(handleMessageChanged(_:)), name: Notification.Name("MezonNewMessageReceived"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleMessageChanged(_:)), name: Notification.Name("MezonChannelMessageDeleted"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleMessageChanged(_:)), name: Notification.Name("MezonChannelMarkedAsRead"), object: nil)
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    private static func notificationInt64(_ value: Any?) -> Int64? {
+        if let v = value as? Int64 { return v }
+        if let v = value as? Int { return Int64(v) }
+        if let v = value as? NSNumber { return v.int64Value }
+        if let v = value as? String { return Int64(v) }
+        return nil
+    }
+
+    @objc private func handleMessageChanged(_ notification: Notification) {
+        let notiChannelId = Self.notificationInt64(notification.userInfo?["channelId"]) ?? 0
+        let notiTopicId = Self.notificationInt64(notification.userInfo?["topicId"]) ?? 0
+        
+        if notification.name == Notification.Name("MezonChannelMarkedAsRead") {
+            let fromSelf = notification.userInfo?["fromSelf"] as? Bool ?? false
+            if !fromSelf { return }
+        }
+        
+        if notiChannelId == self.channelId || (notiTopicId != 0 && notiTopicId == self.channelId) {
+            DispatchQueue.main.async {
+                self.fetchFiles(showLoading: false)
+            }
+        }
     }
 
     func loadTabDataIfNeeded() {
@@ -140,10 +172,12 @@ final class FileListNode: ASDisplayNode {
         return true
     }
 
-    private func fetchFiles() {
-        isLoading = true
+    private func fetchFiles(showLoading: Bool = true) {
+        if showLoading {
+            isLoading = true
+            setNeedsLayout()
+        }
         loadFailed = false
-        setNeedsLayout()
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
@@ -333,10 +367,10 @@ extension FileListNode: ASTableDataSource, ASTableDelegate {
         var name = ""
         context.account.postbox.read { tx in
             if let p = tx.getProfile(userId: idStr) {
-                if let dn = p.displayName, !dn.isEmpty {
-                    name = dn
-                } else if !p.username.isEmpty {
+                if !p.username.isEmpty {
                     name = p.username
+                } else if let dn = p.displayName, !dn.isEmpty {
+                    name = dn
                 }
             }
         }
@@ -468,6 +502,9 @@ private final class FileDocumentCellNode: ASCellNode {
                 .foregroundColor: t.textDisabled,
             ]
         )
+        
+        sharedNode.style.flexShrink = 1
+        timeNode.style.flexShrink = 0
     }
 
     override func didLoad() {


### PR DESCRIPTION
issue: https://github.com/mezonai/mezon/issues/13398
Bug 1: UI bug with long names and incorrect username display
Root Cause: The resolveUploaderName method incorrectly prioritized displayName over username, and FileDocumentCellNode lacked the proper flexShrink configurations to prevent long text from overflowing.

Solution: Updated resolveUploaderName to prioritize username (matching Web logic), and set .flexShrink = 1 for the sender name node and .flexShrink = 0 for the time node to handle text truncation correctly.

Test Cases:

Verify that the user's username is displayed instead of their clan display name.
Verify that an extremely long username is properly truncated with an ellipsis without pushing the timestamp off the screen.
Bug 2: Files list does not update in real-time
Root Cause: FileListNode only fetched the file list once on load and lacked listeners for socket events (such as new messages or deletions) and local self-sent message events.

Solution: Added NotificationCenter observers in FileListNode for MezonNewMessageReceived, MezonChannelMessageDeleted, and MezonChannelMarkedAsRead (to catch self-sent files), ensuring the silent re-fetch runs safely on the main thread using a robust type-casting helper.

Test Cases:

Verify that when another user sends a file to the channel, the files list updates automatically.
Verify that when a file is deleted from the channel, it disappears from the files list automatically.
Verify that when you upload a file yourself, the files list updates automatically.
