### PR TITLE
260709-IOS-Fix cannot del msg

### DIFF
--- a/MezonChat/Features/Chat/ChatViewController.swift
+++ b/MezonChat/Features/Chat/ChatViewController.swift
@@ -6479,33 +6479,45 @@ final class ChatViewController: ViewController {
 
     private func performDeleteMessage(display: ChatMessageDisplay) {
         let msgId = display.message.id
-        if let msgIdInt = Int64(msgId) {
-            let mode: Int32
-            switch channel.type {
-            case MezonConstants.ChannelType.thread.rawValue:
-                mode = MezonConstants.ChannelStreamMode.thread.rawValue
-            case MezonConstants.ChannelType.dm.rawValue:
-                mode = MezonConstants.ChannelStreamMode.dm.rawValue
-            case MezonConstants.ChannelType.group.rawValue:
+        guard let msgIdInt = Int64(msgId) else { return }
+
+        let mode: Int32
+        switch channel.type {
+        case MezonConstants.ChannelType.thread.rawValue:
+            mode = MezonConstants.ChannelStreamMode.thread.rawValue
+        case MezonConstants.ChannelType.dm.rawValue:
+            mode = MezonConstants.ChannelStreamMode.dm.rawValue
+        case MezonConstants.ChannelType.group.rawValue:
+            mode = MezonConstants.ChannelStreamMode.group.rawValue
+        default:
+            if clanId != 0 {
+                mode = MezonConstants.ChannelStreamMode.channel.rawValue
+            } else {
                 mode = MezonConstants.ChannelStreamMode.group.rawValue
-            default:
-                if clanId != 0 {
-                    mode = MezonConstants.ChannelStreamMode.channel.rawValue
-                } else {
-                    mode = MezonConstants.ChannelStreamMode.group.rawValue
-                }
             }
-            let isPublic = clanId != 0 && channel.parentID == 0 && channel.channelPrivate == 0
-            context.account.socket.removeChannelMessage(
-                clanId: clanId,
-                channelId: channel.channelID,
-                mode: mode,
-                messageId: msgIdInt,
-                isPublic: isPublic,
-                topicId: topicId
-            )
         }
-        context.account.postbox.write { tx in tx.deleteMessage(id: msgId) }
+
+        let isPublic = clanId != 0 && channel.parentID == 0 && channel.channelPrivate == 0
+        Task { @MainActor in
+            guard let token = await self.context.getToken() else {
+                Toast.error(L(L10n.ClanInviteSheet.sessionNotFound))
+                return
+            }
+
+            do {
+                try await self.context.account.network.deleteChannelMessage(
+                    clanId: self.clanId,
+                    channelId: self.channel.channelID,
+                    mode: mode,
+                    isPublic: isPublic,
+                    messageId: msgIdInt,
+                    topicId: self.topicId,
+                    token: token
+                )
+            } catch {
+                Toast.error(error.localizedDescription)
+            }
+        }
     }
 
     private func showPinMessageConfirm(display: ChatMessageDisplay) {

--- a/MezonChat/Networking/MezonHTTPClient.swift
+++ b/MezonChat/Networking/MezonHTTPClient.swift
@@ -1133,6 +1133,30 @@ final class MezonHTTPClient {
         )
     }
 
+    func deleteChannelMessage(
+        clanId: Int64,
+        channelId: Int64,
+        mode: Int32,
+        isPublic: Bool,
+        messageId: Int64,
+        topicId: Int64 = 0,
+        token: String
+    ) async throws {
+        var req = Mezon_Realtime_ChannelMessageRemove()
+        req.clanID = clanId
+        req.channelID = channelId
+        req.mode = mode
+        req.isPublic = isPublic
+        req.messageID = messageId
+        req.topicID = topicId
+
+        try await postProtoIgnoringBody(
+            path: "/mezon.api.Mezon/DeleteChannelMessage",
+            message: req,
+            auth: .bearer(token)
+        )
+    }
+
     func listChannelMessages(
         clanId: Int64,
         channelId: Int64,

--- a/MezonChat/Networking/MezonSocket.swift
+++ b/MezonChat/Networking/MezonSocket.swift
@@ -434,19 +434,6 @@ final class MezonSocket: NSObject {
         send(envelope)
     }
 
-    func removeChannelMessage(clanId: Int64, channelId: Int64, mode: Int32, messageId: Int64, isPublic: Bool, topicId: Int64 = 0) {
-        var remove = Mezon_Realtime_ChannelMessageRemove()
-        remove.clanID = clanId
-        remove.channelID = channelId
-        remove.messageID = messageId
-        remove.mode = mode
-        remove.isPublic = isPublic
-        remove.topicID = topicId
-        var envelope = Mezon_Realtime_Envelope()
-        envelope.channelMessageRemove = remove
-        send(envelope)
-    }
-
     func writeLastSeenMessage(clanId: Int64, channelId: Int64, mode: Int32, messageId: Int64, timestampSeconds: UInt32, badgeCount: Int32) {
         var event = Mezon_Realtime_LastSeenMessageEvent()
         event.clanID = clanId


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-59
Root Cause
Mobile apps were deleting messages through the realtime socket channelMessageRemove path, while web uses the DeleteChannelMessage API/RPC. On iOS, the client also deleted the local message optimistically, so it showed success locally even when the deletion was not propagated to other clients.
Solution
Updated Android and iOS to call DeleteChannelMessage with ChannelMessageRemove payload, and removed the old outgoing socket delete path. iOS no longer deletes the local message optimistically; message removal is synced through the server messageRemoved event.
Test Cases
Delete a message in a DM from Android and verify it disappears on Android, iOS, and web.
Delete a message in a DM from iOS and verify it disappears on Android, iOS, and web.
Delete a message in a public channel and verify all clients receive the removal update.
Delete a message in a private channel or thread and verify the correct message is removed only in that conversation.
Force the delete API to fail and verify the client does not remove the message locally as if it succeeded.