### PR TITLE
260715-IOS-Fix open canvas detail

### DIFF
--- a/MezonChat/Core/Localization/L10n.swift
+++ b/MezonChat/Core/Localization/L10n.swift
@@ -1174,6 +1174,8 @@ enum L10n {
         static let newGroup = "channelDetail.newGroup"
         static let addMembers = "channelDetail.addMembers"
         static let untitledCanvas = "channelDetail.untitledCanvas"
+        static let searchCanvasPlaceholder = "channelDetail.searchCanvasPlaceholder"
+        static let noCanvasFound = "channelDetail.noCanvasFound"
         static let searchFilesPlaceholder = "channelDetail.searchFilesPlaceholder"
         static let fileSharedBy = "channelDetail.fileSharedBy"
         static let noFilesYet = "channelDetail.noFilesYet"
@@ -2437,6 +2439,8 @@ extension L10n {
         "channelDetail.newGroup": "New Group",
         "channelDetail.addMembers": "Add Members",
         "channelDetail.untitledCanvas": "Untitled Canvas",
+        "channelDetail.searchCanvasPlaceholder": "Search Canvas",
+        "channelDetail.noCanvasFound": "No canvas found.",
         "channelDetail.searchFilesPlaceholder": "Search files",
         "channelDetail.fileSharedBy": "Shared by %@",
         "channelDetail.noFilesYet": "No files yet",
@@ -3658,6 +3662,8 @@ extension L10n {
         "channelDetail.newGroup": "Nhóm mới",
         "channelDetail.addMembers": "Thêm thành viên",
         "channelDetail.untitledCanvas": "Bản vẽ chưa đặt tên",
+        "channelDetail.searchCanvasPlaceholder": "Tìm canvas",
+        "channelDetail.noCanvasFound": "Không tìm thấy canvas.",
         "channelDetail.searchFilesPlaceholder": "Tìm tệp",
         "channelDetail.fileSharedBy": "Chia sẻ bởi %@",
         "channelDetail.noFilesYet": "Chưa có tệp",

--- a/MezonChat/Features/ChannelDetail/CanvasWebViewController.swift
+++ b/MezonChat/Features/ChannelDetail/CanvasWebViewController.swift
@@ -5,21 +5,38 @@ import WebKit
 @MainActor
 final class CanvasWebViewController: ViewController, WKNavigationDelegate {
 
+    private static let canvasLoadMaxCheckCount = 75
+    private static let emptyTitleRetryThreshold = 3
+
     private let pageURL: URL
     private weak var accountContext: AccountContext?
     private let canvasTitle: String
+    private let expectsNonEmptyTitle: Bool
+    private var onDismiss: (() -> Void)?
 
     private var webView: WKWebView?
+    private var canvasLoadCheckWorkItem: DispatchWorkItem?
+    private var canvasLoadCheckAttemptCount = 0
+    private var emptyTitleObservationCount = 0
+    private var didRetryCanvasLoad = false
 
     private let headerBar = UIView()
     private let backButton = UIButton(type: .system)
     private let titleLabel = UILabel()
     private let headerSeparator = UIView()
 
-    init(pageURL: URL, canvasTitle: String, accountContext: AccountContext) {
+    init(
+        pageURL: URL,
+        canvasTitle: String,
+        expectsNonEmptyTitle: Bool,
+        accountContext: AccountContext,
+        onDismiss: @escaping () -> Void
+    ) {
         self.pageURL = pageURL
         self.canvasTitle = canvasTitle
+        self.expectsNonEmptyTitle = expectsNonEmptyTitle
         self.accountContext = accountContext
+        self.onDismiss = onDismiss
         super.init(navigationBarPresentationData: nil)
     }
 
@@ -45,7 +62,14 @@ final class CanvasWebViewController: ViewController, WKNavigationDelegate {
     }
 
     deinit {
+        canvasLoadCheckWorkItem?.cancel()
         NotificationCenter.default.removeObserver(self, name: ThemeManager.didChangeNotification, object: nil)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        guard navigationController?.viewControllers.contains(where: { $0 === self }) == false else { return }
+        notifyDismiss()
     }
 
     private func setupNavHeader() {
@@ -103,7 +127,7 @@ final class CanvasWebViewController: ViewController, WKNavigationDelegate {
 
     private func applyNavHeaderTheme() {
         let t = UIColor.theme
-        headerBar.backgroundColor = t.secondary
+        headerBar.backgroundColor = t.primary
         titleLabel.textColor = t.textStrong
         backButton.tintColor = t.textStrong
         headerSeparator.backgroundColor = t.border
@@ -114,13 +138,20 @@ final class CanvasWebViewController: ViewController, WKNavigationDelegate {
     }
 
     @objc private func backTapped() {
+        notifyDismiss()
         navigationController?.popViewController(animated: true)
+    }
+
+    private func notifyDismiss() {
+        canvasLoadCheckWorkItem?.cancel()
+        guard let onDismiss else { return }
+        self.onDismiss = nil
+        onDismiss()
     }
 
     private func embedWebViewIfPossible() async {
         guard let context = accountContext else { return }
-        await context.waitForSessionReady()
-        guard let session = context.session else {
+        guard await context.getToken() != nil, let session = context.session else {
             Toast.error("Session unavailable")
             navigationController?.popViewController(animated: true)
             return
@@ -269,11 +300,90 @@ final class CanvasWebViewController: ViewController, WKNavigationDelegate {
         }
     }
 
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        guard !didRetryCanvasLoad else { return }
+        canvasLoadCheckAttemptCount = 0
+        emptyTitleObservationCount = 0
+        scheduleCanvasLoadCheck(after: 1)
+    }
+
+    private func scheduleCanvasLoadCheck(after delay: TimeInterval) {
+        canvasLoadCheckWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self, let webView = self.webView, !self.didRetryCanvasLoad else { return }
+            self.canvasLoadCheckAttemptCount += 1
+            webView.evaluateJavaScript(Self.canvasLoadStateScript) { [weak self, weak webView] result, _ in
+                guard let self, let webView else { return }
+                switch result as? String {
+                case "auth-failed":
+                    self.retryCanvasLoad(in: webView)
+                case "loaded":
+                    self.canvasLoadCheckWorkItem = nil
+                case "empty":
+                    guard self.expectsNonEmptyTitle else {
+                        self.canvasLoadCheckWorkItem = nil
+                        return
+                    }
+                    self.emptyTitleObservationCount += 1
+                    if self.emptyTitleObservationCount >= Self.emptyTitleRetryThreshold {
+                        self.retryCanvasLoad(in: webView)
+                    } else {
+                        self.scheduleCanvasLoadCheck(after: 1)
+                    }
+                default:
+                    if self.expectsNonEmptyTitle,
+                       self.canvasLoadCheckAttemptCount >= Self.canvasLoadMaxCheckCount {
+                        self.retryCanvasLoad(in: webView)
+                    } else if self.canvasLoadCheckAttemptCount < Self.canvasLoadMaxCheckCount {
+                        self.scheduleCanvasLoadCheck(after: 1)
+                    } else {
+                        self.canvasLoadCheckWorkItem = nil
+                    }
+                }
+            }
+        }
+        canvasLoadCheckWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+    }
+
+    private func retryCanvasLoad(in webView: WKWebView) {
+        didRetryCanvasLoad = true
+        canvasLoadCheckWorkItem?.cancel()
+        canvasLoadCheckWorkItem = nil
+        webView.reload()
+    }
+
+    private static let canvasLoadStateScript = """
+    (function() {
+      try {
+        var auth = JSON.parse(localStorage.getItem('persist:auth') || '{}');
+        var isLogin = typeof auth.isLogin === 'string' ? JSON.parse(auth.isLogin) : auth.isLogin;
+        if (isLogin === false) return 'auth-failed';
+      } catch (_) {}
+      var title = document.querySelector(
+        'textarea[data-e2e$="canvas_editor-input-title"], textarea[rows="1"]'
+      );
+      if (!title) return 'waiting';
+      return title.value.trim().length > 0 ? 'loaded' : 'empty';
+    })();
+    """
+
     private static func canvasChromeHideScript() -> String {
         """
         (function() {
           var style = document.createElement('style');
           style.innerHTML = `
+            body::before {
+              content: '';
+              position: fixed;
+              top: 0;
+              right: 0;
+              left: 0;
+              height: 50px;
+              background: var(--bg-secondary);
+              pointer-events: none;
+              z-index: 2147483647;
+            }
             .h-heightTopBar { display: none !important; }
             .w-[72px] { width: 72px; display: none; }
           `;

--- a/MezonChat/Features/ChannelDetail/CanvasWebViewController.swift
+++ b/MezonChat/Features/ChannelDetail/CanvasWebViewController.swift
@@ -205,14 +205,16 @@ final class CanvasWebViewController: ViewController, WKNavigationDelegate {
           try {
             var sessionStr = '\(sessionEscaped)';
             var mezonSessionStr = '\(mezonEscaped)';
+            var sessionData = JSON.parse(sessionStr);
+            sessionData.session_id = sessionData.token;
             var authData = {
               loadingStatus: JSON.stringify("loaded"),
-              session: JSON.stringify(sessionStr),
+              session: JSON.stringify(sessionData),
               isLogin: "true",
               _persist: JSON.stringify({"version":-1,"rehydrated":true})
             };
             localStorage.setItem('persist:auth', JSON.stringify(authData));
-            localStorage.setItem('mezon_session', JSON.stringify(mezonSessionStr));
+            localStorage.setItem('mezon_session', mezonSessionStr);
           } catch (e) {}
         })();
         true;

--- a/MezonChat/Features/ChannelDetail/ChannelDetailContainerNode.swift
+++ b/MezonChat/Features/ChannelDetail/ChannelDetailContainerNode.swift
@@ -74,7 +74,7 @@ final class ChannelDetailContainerNode: ASDisplayNode {
             context: context, clanId: clanId, channelId: channel.channelID,
             channelType: channel.type)
         self.canvasNode = CanvasNode(
-            context: context, clanId: clanId, channelId: Self.canvasListChannelId(for: channel, clanId: clanId, context: context),
+            context: context, clanId: clanId, channelId: channel.channelID,
             channelType: channel.type)
 
         super.init()
@@ -105,19 +105,6 @@ final class ChannelDetailContainerNode: ASDisplayNode {
     override func didLoad() {
         super.didLoad()
         tabsScrollNode.view.showsHorizontalScrollIndicator = false
-    }
-
-    private static func canvasListChannelId(
-        for channel: Mezon_Api_ChannelDescription, clanId: Int64, context: AccountContext
-    ) -> Int64 {
-        let thread = MezonConstants.ChannelType.thread.rawValue
-        let t = channel.type != 0
-            ? channel.type
-            : (context.account.postbox.resolvedChannelDescription(clanId: clanId, channelId: channel.channelID)?.type ?? 0)
-        if t == thread, channel.parentID != 0 {
-            return channel.parentID
-        }
-        return channel.channelID
     }
 
     private static func visibleTabsList(

--- a/MezonChat/Features/ChannelDetail/Tabs/CanvasNode.swift
+++ b/MezonChat/Features/ChannelDetail/Tabs/CanvasNode.swift
@@ -9,9 +9,14 @@ final class CanvasNode: ASDisplayNode {
     private let channelId: Int64
     private let channelType: Int32
     private var canvases: [Mezon_Api_ChannelCanvasItem] = []
+    private var searchQuery = ""
+    private var searchDebounceWorkItem: DispatchWorkItem?
     private var didLoadCanvases = false
+    private var didFinishLoading = false
 
     private let tableNode: ASTableNode
+    private let searchNode = CanvasSearchNode()
+    private let emptyStateNode = ASTextNode2()
 
     init(context: AccountContext, clanId: Int64, channelId: Int64, channelType: Int32) {
         self.context = context
@@ -30,6 +35,30 @@ final class CanvasNode: ASDisplayNode {
         tableNode.view.separatorStyle = .none
         tableNode.view.backgroundColor = .clear
         tableNode.view.delaysContentTouches = false
+        tableNode.view.keyboardDismissMode = .onDrag
+
+        searchNode.onTextChanged = { [weak self] query in
+            guard let self else { return }
+            self.searchDebounceWorkItem?.cancel()
+
+            let workItem = DispatchWorkItem { [weak self] in
+                guard let self else { return }
+                self.searchQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+                self.tableNode.reloadData()
+                self.setNeedsLayout()
+            }
+            self.searchDebounceWorkItem = workItem
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(300), execute: workItem)
+        }
+
+        emptyStateNode.attributedText = NSAttributedString(
+            string: L(L10n.ChannelDetail.noCanvasFound),
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 15.sf, weight: .medium),
+                .foregroundColor: UIColor.theme.textDisabled,
+            ]
+        )
+        emptyStateNode.maximumNumberOfLines = 0
     }
 
     func loadTabDataIfNeeded() {
@@ -59,38 +88,87 @@ final class CanvasNode: ASDisplayNode {
                     token: token
                 )
                 self.canvases = res.channelCanvases
+                self.didFinishLoading = true
                 await self.tableNode.reloadData()
+                self.setNeedsLayout()
             } catch {
             }
         }
     }
 
+    private var displayedCanvases: [Mezon_Api_ChannelCanvasItem] {
+        guard !searchQuery.isEmpty else { return canvases }
+        return canvases.filter {
+            let title = $0.title.isEmpty
+                ? L(L10n.ChannelDetail.untitledCanvas)
+                : $0.title.replacingOccurrences(of: "\n", with: " ")
+            return title.range(
+                of: searchQuery,
+                options: [.caseInsensitive, .diacriticInsensitive]
+            ) != nil
+        }
+    }
+
     private func presentCanvas(for item: Mezon_Api_ChannelCanvasItem) {
-        guard let url = MezonConfig.canvasMobileURL(clanId: clanId, channelId: channelId, canvasId: item.id),
+        guard let url = URL(string: MezonConfig.canvasShareURLString(
+            clanId: clanId, channelId: channelId, canvasId: item.id)),
             let host = tableNode.view.findHostingViewController(),
             let nav = host.navigationController
         else { return }
         let title =
             item.title.isEmpty ? L(L10n.ChannelDetail.untitledCanvas) : item.title.replacingOccurrences(
                 of: "\n", with: " ")
-        let vc = CanvasWebViewController(pageURL: url, canvasTitle: title, accountContext: context)
+        let vc = CanvasWebViewController(
+            pageURL: url,
+            canvasTitle: title,
+            expectsNonEmptyTitle: !item.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+            accountContext: context,
+            onDismiss: { [weak self] in
+                self?.fetchCanvases()
+            }
+        )
         nav.pushViewController(vc, animated: true)
     }
 
     override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
-        return ASWrapperLayoutSpec(layoutElement: tableNode)
+        searchNode.style.height = ASDimension(unit: .points, value: 40.sf)
+        let search = ASInsetLayoutSpec(
+            insets: UIEdgeInsets(top: 12, left: 16, bottom: 8, right: 16),
+            child: searchNode
+        )
+
+        let content: ASLayoutElement
+        if didFinishLoading && displayedCanvases.isEmpty {
+            content = ASCenterLayoutSpec(
+                centeringOptions: .XY,
+                sizingOptions: .minimumXY,
+                child: emptyStateNode
+            )
+        } else {
+            content = tableNode
+        }
+        content.style.flexGrow = 1
+        content.style.flexShrink = 1
+
+        return ASStackLayoutSpec(
+            direction: .vertical,
+            spacing: 0,
+            justifyContent: .start,
+            alignItems: .stretch,
+            children: [search, content]
+        )
     }
 }
 
 extension CanvasNode: ASTableDataSource, ASTableDelegate {
     func tableNode(_ tableNode: ASTableNode, numberOfRowsInSection section: Int) -> Int {
-        return canvases.count
+        return displayedCanvases.count
     }
 
     func tableNode(_ tableNode: ASTableNode, nodeBlockForRowAt indexPath: IndexPath)
         -> ASCellNodeBlock
     {
-        let canvas = canvases[indexPath.row]
+        let canvas = displayedCanvases[indexPath.row]
         let shareURL = MezonConfig.canvasShareURLString(
             clanId: clanId, channelId: channelId, canvasId: canvas.id)
         return {
@@ -106,8 +184,89 @@ extension CanvasNode: ASTableDataSource, ASTableDelegate {
 
     func tableNode(_ tableNode: ASTableNode, didSelectRowAt indexPath: IndexPath) {
         tableNode.deselectRow(at: indexPath, animated: true)
-        let canvas = canvases[indexPath.row]
+        let canvas = displayedCanvases[indexPath.row]
         presentCanvas(for: canvas)
+    }
+}
+
+private final class CanvasSearchNode: ASDisplayNode {
+    private let iconNode = ASImageNode()
+    private let textFieldNode: ASDisplayNode
+    private let textField: UITextField
+    private let clearButton = UIButton(type: .system)
+    var onTextChanged: ((String) -> Void)?
+
+    override init() {
+        let textField = UITextField()
+        self.textField = textField
+        self.textFieldNode = ASDisplayNode(viewBlock: { textField })
+        super.init()
+
+        automaticallyManagesSubnodes = true
+        backgroundColor = UIColor.theme.secondary
+        cornerRadius = 10.sf
+        clipsToBounds = true
+
+        let theme = UIColor.theme
+        iconNode.image = UIImage(systemName: "magnifyingglass")?.withTintColor(
+            theme.text, renderingMode: .alwaysOriginal)
+        iconNode.contentMode = .scaleAspectFit
+        iconNode.style.preferredSize = CGSize(width: 18.sf, height: 18.sf)
+
+        textField.font = UIFont.systemFont(ofSize: 14.sf)
+        textField.textColor = UIColor.theme.textStrong
+        textField.tintColor = UIColor.theme.textStrong
+        textField.returnKeyType = .search
+        textField.autocorrectionType = .no
+        textField.autocapitalizationType = .none
+        textField.clearButtonMode = .never
+        textField.attributedPlaceholder = NSAttributedString(
+            string: L(L10n.ChannelDetail.searchCanvasPlaceholder),
+            attributes: [.foregroundColor: UIColor.theme.textDisabled]
+        )
+
+        clearButton.frame = CGRect(x: 2, y: 4, width: 32, height: 32)
+        clearButton.tintColor = theme.text
+        clearButton.setImage(
+            UIImage(systemName: "xmark.circle.fill")?.withConfiguration(
+                UIImage.SymbolConfiguration(pointSize: 16, weight: .regular)),
+            for: .normal
+        )
+        clearButton.isHidden = true
+        clearButton.accessibilityLabel = L(L10n.Common.close)
+        clearButton.addTarget(self, action: #selector(clearTapped), for: .touchUpInside)
+        let clearButtonContainer = UIView(frame: CGRect(x: 0, y: 0, width: 36, height: 40))
+        clearButtonContainer.addSubview(clearButton)
+        textField.rightView = clearButtonContainer
+        textField.rightViewMode = .always
+        textField.addTarget(self, action: #selector(textChanged), for: .editingChanged)
+    }
+
+    @objc private func textChanged() {
+        clearButton.isHidden = textField.text?.isEmpty ?? true
+        onTextChanged?(textField.text ?? "")
+    }
+
+    @objc private func clearTapped() {
+        textField.text = ""
+        clearButton.isHidden = true
+        onTextChanged?("")
+    }
+
+    override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+        textFieldNode.style.flexGrow = 1
+        textFieldNode.style.flexShrink = 1
+        let row = ASStackLayoutSpec(
+            direction: .horizontal,
+            spacing: 8,
+            justifyContent: .start,
+            alignItems: .center,
+            children: [iconNode, textFieldNode]
+        )
+        return ASInsetLayoutSpec(
+            insets: UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 8),
+            child: row
+        )
     }
 }
 


### PR DESCRIPTION
https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-56
Root Cause
The iOS WebView injected a double-encoded session, and the web app requires session_id for socket authentication while the native session only provides token.
Solution
Parse the native session before injection, use its token as the web session_id, and store correctly encoded values in persist:auth and mezon_session.
Test Cases
Verify that selecting a canvas opens its detail page in the iOS WebView.
