### PR TITLE
260717-IOS-Sync DM Icon

### DIFF
--- a/MezonChat/Core/Utils/MezonConstants.swift
+++ b/MezonChat/Core/Utils/MezonConstants.swift
@@ -2,6 +2,8 @@ import Foundation
 
 enum MezonConstants {
 
+    static let defaultDMLogoURL = "https://cdn.mezon.ai/images/mezon_logo.png"
+
     static let anonymousUserId: Int64 = 1767478432163172999
 
     static let waveStickerFilename = "hello"

--- a/MezonChat/Features/Clans/ClanListContainerNode.swift
+++ b/MezonChat/Features/Clans/ClanListContainerNode.swift
@@ -27,7 +27,6 @@ final class ClanListContainerNode: ASDisplayNode {
         iv.clipsToBounds = true
         iv.backgroundColor = .clear
         iv.layer.cornerRadius = 12.swh
-        iv.image = UIImage(named: "NewMezonLogo")
         iv.translatesAutoresizingMaskIntoConstraints = true
         iv.autoresizingMask = []
         iv.isUserInteractionEnabled = true
@@ -60,6 +59,8 @@ final class ClanListContainerNode: ASDisplayNode {
         collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         self.interaction = interaction
         super.init()
+
+        applySidebarAccountLogo(urlString: nil)
 
         disposables.add(
             (signal |> deliverOnMainQueue).start(next: { [weak self] newState in
@@ -201,19 +202,22 @@ final class ClanListContainerNode: ASDisplayNode {
         sidebarLogoLoadTask?.cancel()
         sidebarLogoLoadTask = nil
         let trimmed = urlString?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        guard !trimmed.isEmpty, URL(string: trimmed) != nil else {
+        let resolvedURL = trimmed.isEmpty ? MezonConstants.defaultDMLogoURL : trimmed
+        guard URL(string: resolvedURL) != nil else {
             sidebarLogoDisplaySource = nil
-            logoImageView.image = UIImage(named: "NewMezonLogo")
+            logoImageView.image = nil
             return
         }
-        sidebarLogoDisplaySource = trimmed
-        let proxied = ImgproxyURL.create(from: trimmed, width: 150, height: 150)
+        sidebarLogoDisplaySource = resolvedURL
+        let proxied = resolvedURL == MezonConstants.defaultDMLogoURL
+            ? resolvedURL
+            : ImgproxyURL.create(from: resolvedURL, width: 150, height: 150)
         if let cached = ImageCache.shared.cachedImage(forURL: proxied) {
             logoImageView.image = cached
             return
         }
-        logoImageView.image = UIImage(named: "NewMezonLogo")
-        loadSidebarAccountLogo(trimmed: trimmed, proxied: proxied, attempt: 0)
+        logoImageView.image = nil
+        loadSidebarAccountLogo(trimmed: resolvedURL, proxied: proxied, attempt: 0)
     }
 
     private func loadSidebarAccountLogo(trimmed: String, proxied: String, attempt: Int) {

--- a/MezonChat/Features/Profile/ProfileSettingViewController.swift
+++ b/MezonChat/Features/Profile/ProfileSettingViewController.swift
@@ -936,7 +936,7 @@ final class ProfileSettingViewController: BaseViewController {
     private func refreshDMIcon() {
         let isDefaultLogo = userDmLogoUrl.isEmpty || userDmLogoUrl == kMezonLogoURL
         if isDefaultLogo {
-            dmIconImageView.image = UIImage(named: "NewMezonLogo")
+            loadRemoteImage(urlString: MezonConstants.defaultDMLogoURL, into: dmIconImageView)
             dmIconRemoveButton.isHidden = true
         } else {
             loadRemoteImage(urlString: userDmLogoUrl, into: dmIconImageView)
@@ -1305,8 +1305,7 @@ final class ProfileSettingViewController: BaseViewController {
             loadAvatarImage(urlString: avatarToShow)
         case .dmIcon:
             userDmLogoUrl = ""
-            dmIconImageView.image = UIImage(named: "NewMezonLogo")
-            dmIconRemoveButton.isHidden = true
+            refreshDMIcon()
         }
     }
 


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-24
Root Cause: iOS used the outdated NewMezonLogo asset as the default DM icon, and the sidebar did not reload the icon when the initial logo URL was empty.
Solution: Use the shared default DM logo URL and load it when the sidebar initializes or the custom DM icon is removed.
Test Cases:
Verify the default DM icon matches Web and Android in Profile Settings.
Verify the default DM icon is displayed correctly in the sidebar.
Verify a custom DM icon is displayed correctly in Profile Settings and the sidebar.
Verify removing a custom DM icon restores the default icon.
Verify the default DM icon remains correct after restarting the app.