### PR TITLE
260720-IOS-Fix compiler image editor for old ios

### DIFF
--- a/MezonChat/Features/ChannelDetail/Tabs/MediaGalleryNode.swift
+++ b/MezonChat/Features/ChannelDetail/Tabs/MediaGalleryNode.swift
@@ -136,7 +136,7 @@ final class MediaGalleryNode: ASDisplayNode {
                 self.collectionNode.performBatch(
                     animated: false,
                     updates: { self.collectionNode.insertItems(at: indexPaths) },
-                    completion: nil
+                    completion: { _ in }
                 )
             } catch {
             }


### PR DESCRIPTION
Root Cause: In an async context, the Swift compiler fails to correctly resolve the overloaded performBatch function when nil is passed as the completion block, confusing it with the auto-synthesized async version and throwing an irrelevant dynamic member lookup error.
Solution: Pass an empty closure { _ in } instead of nil to explicitly disambiguate the function signature and force the compiler to use the synchronous block-based method.

