### PR TITLE
260721-IOS-Improve image editor

### DIFF
--- a/MezonChat/Features/SendMessageInput/MediaPickerViewController.swift
+++ b/MezonChat/Features/SendMessageInput/MediaPickerViewController.swift
@@ -137,7 +137,7 @@ final class MediaPickerViewController: UIViewController {
     private lazy var actionBar: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = UIColor.black.withAlphaComponent(0.18)
+        view.backgroundColor = .clear
         view.isHidden = true
         return view
     }()
@@ -344,7 +344,7 @@ final class MediaPickerViewController: UIViewController {
         let bannerHeight = limitedBanner.heightAnchor.constraint(equalToConstant: 0)
         self.limitedBannerHeightConstraint = bannerHeight
 
-        let editWidth = editButton.widthAnchor.constraint(equalTo: sendButton.widthAnchor, multiplier: 1.0 / 3.0)
+        let editWidth = editButton.widthAnchor.constraint(equalTo: sendButton.widthAnchor, multiplier: 1.0)
         let sendLeadingEdit = sendButton.leadingAnchor.constraint(equalTo: editButton.trailingAnchor, constant: 10)
         let sendLeadingBar = sendButton.leadingAnchor.constraint(equalTo: actionBar.leadingAnchor, constant: 16)
         sendLeadingEditConstraint = sendLeadingEdit
@@ -382,15 +382,15 @@ final class MediaPickerViewController: UIViewController {
             actionBar.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
             actionBar.heightAnchor.constraint(equalToConstant: 72),
 
-            editButton.leadingAnchor.constraint(equalTo: actionBar.leadingAnchor, constant: 16),
-            editButton.topAnchor.constraint(equalTo: actionBar.topAnchor, constant: 10),
-            editButton.bottomAnchor.constraint(equalTo: actionBar.bottomAnchor, constant: -10),
+            editButton.leadingAnchor.constraint(equalTo: actionBar.leadingAnchor, constant: 24),
+            editButton.topAnchor.constraint(equalTo: actionBar.topAnchor, constant: 14),
+            editButton.bottomAnchor.constraint(equalTo: actionBar.bottomAnchor, constant: -14),
             editWidth,
 
             sendLeadingEdit,
-            sendButton.trailingAnchor.constraint(equalTo: actionBar.trailingAnchor, constant: -16),
-            sendButton.topAnchor.constraint(equalTo: actionBar.topAnchor, constant: 10),
-            sendButton.bottomAnchor.constraint(equalTo: actionBar.bottomAnchor, constant: -10),
+            sendButton.trailingAnchor.constraint(equalTo: actionBar.trailingAnchor, constant: -24),
+            sendButton.topAnchor.constraint(equalTo: actionBar.topAnchor, constant: 14),
+            sendButton.bottomAnchor.constraint(equalTo: actionBar.bottomAnchor, constant: -14),
 
             dropdownOverlay.topAnchor.constraint(equalTo: headerView.bottomAnchor),
             dropdownOverlay.leadingAnchor.constraint(equalTo: view.leadingAnchor),

--- a/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
+++ b/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
@@ -503,7 +503,7 @@ final class SendMessageInputViewController: UIViewController {
     }
     private static let replyBannerHeight: CGFloat = 40
 
-    private static var channelAttachmentCache: [String: [UIImage]] = [:]
+    private static var channelAttachmentCache: [String: ([UIImage], [Int: URL])] = [:]
     private static var channelTextDraftCache: [String: ComposerDraftSnapshot] = [:]
     private static var channelEditingStateCache: [String: ComposerEditingStateSnapshot] = [:]
 
@@ -1252,15 +1252,15 @@ final class SendMessageInputViewController: UIViewController {
             stashCurrentComposerDraftIfNeeded()
         }
         let preservedDraft = migrateDraftToNewChannelIdentity ? Self.channelTextDraftCache[oldKey] : nil
-        let preservedAttachmentImages = migrateDraftToNewChannelIdentity ? Self.channelAttachmentCache[oldAttachmentCacheKey] : nil
+        let preservedAttachmentEntry = migrateDraftToNewChannelIdentity ? Self.channelAttachmentCache[oldAttachmentCacheKey] : nil
         channel = newChannel
         topicId = newTopicId
         if migrateDraftToNewChannelIdentity, let preservedDraft {
             let newKey = draftStorageKey(for: channel, topicId: topicId)
             Self.channelTextDraftCache[newKey] = preservedDraft
         }
-        if migrateDraftToNewChannelIdentity, let imgs = preservedAttachmentImages, !imgs.isEmpty {
-            Self.channelAttachmentCache[cacheKey] = imgs
+        if migrateDraftToNewChannelIdentity, let entry = preservedAttachmentEntry, !entry.0.isEmpty {
+            Self.channelAttachmentCache[cacheKey] = entry
         }
         rebindMentionForCurrentChannel()
         if preserveComposerContentsDuringMigration && migrateDraftToNewChannelIdentity {
@@ -2899,14 +2899,15 @@ final class SendMessageInputViewController: UIViewController {
         if pickedImages.isEmpty {
             Self.channelAttachmentCache.removeValue(forKey: cacheKey)
         } else {
-            Self.channelAttachmentCache[cacheKey] = pickedImages
+            Self.channelAttachmentCache[cacheKey] = (pickedImages, pickedFileURLs)
         }
     }
 
     private func restoreFromCache() {
-        guard let cached = Self.channelAttachmentCache[cacheKey], !cached.isEmpty else { return }
-        pickedImages = cached
-        attachmentPreviewView.setImages(cached)
+        guard let (images, urls) = Self.channelAttachmentCache[cacheKey], !images.isEmpty else { return }
+        pickedImages = images
+        pickedFileURLs = urls.filter { FileManager.default.fileExists(atPath: $0.value.path) }
+        attachmentPreviewView.setImages(images)
         let targetH = AttachmentPreviewView.preferredHeight(
             imageCount: pickedImages.count, fileCount: pickedFiles.count)
         previewHeightConstraint?.constant = targetH


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-87
Root Cause: The channelAttachmentCache only cached pickedImages but failed to cache pickedFileURLs, causing the temporary image file URLs to be lost when the user navigated away from the conversation, which subsequently caused the upload process to skip those images.

Solution: Updated the channelAttachmentCache type to store a tuple of both images and their corresponding file URLs ([UIImage], [Int: URL]), ensuring that pickedFileURLs are correctly saved and restored (while filtering out deleted files) when entering or leaving the conversation.

Test Cases:
Pick an image in the chat, navigate back to the channel list, re-enter the chat, and verify the image sends successfully.
Pick multiple images, switch to a different channel, switch back, and verify all images send successfully.
Pick an image, put the app in the background for a short time, return to the app, and verify the image sends successfully.