### PR TITLE
260722-IOS-Handle capture image editor

### DIFF
--- a/MezonChat/Features/SendMessageInput/ImageEditorViewController.swift
+++ b/MezonChat/Features/SendMessageInput/ImageEditorViewController.swift
@@ -737,7 +737,7 @@ private final class ImageEditorCanvasView: UIView, UIGestureRecognizerDelegate {
         var text: String
         var color: UIColor
         var center: CGPoint
-        let fontSize: CGFloat
+        var fontSize: CGFloat
     }
 
     enum CropTarget: Equatable {
@@ -1080,9 +1080,7 @@ private final class ImageEditorCanvasView: UIView, UIGestureRecognizerDelegate {
         let outline: [NSAttributedString.Key: Any] = [
             .font: font,
             .paragraphStyle: paragraph,
-            .foregroundColor: overlay.color,
-            .strokeColor: overlay.color == .black ? UIColor.white : UIColor.black,
-            .strokeWidth: -2.5
+            .foregroundColor: overlay.color
         ]
         (overlay.text as NSString).draw(with: rect, options: [.usesLineFragmentOrigin, .usesFontLeading], attributes: outline, context: nil)
     }
@@ -1267,7 +1265,34 @@ private final class ImageEditorCanvasView: UIView, UIGestureRecognizerDelegate {
         changed()
     }
 
+    private var zoomTextIndex: Int?
+
     @objc private func handlePinch(_ gesture: UIPinchGestureRecognizer) {
+        if mode == .text {
+            if gesture.state == .began {
+                let focus = gesture.location(in: self)
+                var minDistance = CGFloat.greatestFiniteMagnitude
+                zoomTextIndex = nil
+                for (index, overlay) in texts.enumerated() {
+                    let dx = overlay.center.x - focus.x
+                    let dy = overlay.center.y - focus.y
+                    let dist = dx * dx + dy * dy
+                    if dist < minDistance {
+                        minDistance = dist
+                        zoomTextIndex = index
+                    }
+                }
+            }
+            if let index = zoomTextIndex, gesture.state == .began || gesture.state == .changed {
+                texts[index].fontSize = min(max(texts[index].fontSize * gesture.scale, 12), 120)
+                gesture.scale = 1
+                updateLayers()
+            }
+            return
+        }
+        
+        if mode == .draw { return }
+
         guard gesture.state == .began || gesture.state == .changed else {
             if gesture.state == .ended { clampImageToCrop() }
             return

--- a/MezonChat/Features/SendMessageInput/MediaPickerViewController.swift
+++ b/MezonChat/Features/SendMessageInput/MediaPickerViewController.swift
@@ -1059,9 +1059,10 @@ extension MediaPickerViewController: PHPhotoLibraryChangeObserver {
 extension MediaPickerViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
 
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
-        picker.dismiss(animated: true)
-        guard let image = info[.originalImage] as? UIImage else { return }
-
+        guard let image = info[.originalImage] as? UIImage else {
+            picker.dismiss(animated: true)
+            return
+        }
 
         let tempDir = FileManager.default.temporaryDirectory
         let filename = "camera-\(UUID().uuidString).jpg"
@@ -1071,8 +1072,29 @@ extension MediaPickerViewController: UIImagePickerControllerDelegate, UINavigati
         }
 
         let result = MediaPickerResult(image: image, fileURL: fileURL, isVideo: false)
-        onPicked?([result])
-        dismiss(animated: true)
+
+        picker.dismiss(animated: true) { [weak self] in
+            guard let self else { return }
+            self.isPresentingEditor = true
+            let editor = ImageEditorViewController(result: result)
+            let sendEditedResult = self.onEditedSend
+            editor.onCancel = { [weak self] in
+                self?.isPresentingEditor = false
+            }
+            editor.onSendStarted = { [weak self] in
+                guard let self else { return }
+                self.didSendResults = true
+                self.isPresentingEditor = false
+                if let presenter = self.presentingViewController {
+                    presenter.dismiss(animated: true)
+                } else {
+                    self.dismiss(animated: true)
+                }
+            }
+            editor.onSend = { edited in sendEditedResult?(edited) }
+            editor.modalPresentationStyle = .fullScreen
+            self.present(editor, animated: true)
+        }
     }
 
     func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-87
Text Outline Issue: The NSAttributedString used for rendering text included unwanted strokeColor and strokeWidth attributes by default.
Text Zoom Issue: The UIPinchGestureRecognizer only handled zooming the background image and did not support scaling text overlays. Image zooming was not blocked during text and draw modes.
Camera Capture Issue: The attachment picker directly queued captured images for sending without routing them through the image editor preview flow.
Solution:

Text Outline Fix: Removed strokeColor and strokeWidth from the text rendering attributes to display natural text.
Text Zoom Fix: Updated handlePinch to calculate the distance to the nearest text overlay and dynamically update its fontSize (changed from let to var). Blocked image zooming when in text or draw mode.
Camera Capture Fix: Intercepted the camera capture callback and routed the newly captured image to the ImageEditorViewController before adding it to the send queue.
Test Cases:

TC1: Open the image editor, add a text overlay, and verify that the text has no strange borders or outlines.
TC2: Enter text mode, use two fingers to pinch on the screen, and verify that the text closest to your fingers scales up and down smoothly.
TC3: Use two fingers to pinch the screen while in text mode or drawing mode, and verify that the background image and crop area do not zoom or move.
TC4: Open the attachment picker, capture a new image using the camera button, and verify that the image editor opens properly, allowing you to edit the image before sending.