### PR TITLE
260723-IOS-Fix send format date incorrect embed

### DIFF
--- a/MezonChat/Features/Chat/Cells/MessageEmbedNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageEmbedNode.swift
@@ -895,15 +895,19 @@ final class EmbedDatePickerFieldNode: ASDisplayNode, EmbedFormInputNode {
         let wrapper = ASDisplayNode { [weak self] in return self?.button ?? UIView() }
         addSubnode(wrapper)
 
-        if let existing = EmbedFormState.shared.getValue(forComponent: component.id, messageId: messageId), !existing.isEmpty, isValidDateFormat(existing) {
-            button.setTitle(existing, for: .normal)
+        if let existing = EmbedFormState.shared.getValue(forComponent: component.id, messageId: messageId), !existing.isEmpty, parseDate(from: existing) != nil {
+            button.setTitle(formatForDisplay(existing), for: .normal)
             button.setTitleColor(t.textStrong, for: .normal)
-        } else if let existing = EmbedFormState.shared.getValue(forComponent: component.id, messageId: messageId), !existing.isEmpty, !isValidDateFormat(existing) {
+        } else if let existing = EmbedFormState.shared.getValue(forComponent: component.id, messageId: messageId), !existing.isEmpty, parseDate(from: existing) == nil {
             EmbedFormState.shared.clear(messageId: messageId)
-        } else if let def = component.dateValue, !def.isEmpty, isValidDateFormat(def) {
-            button.setTitle(def, for: .normal)
+        } else if let def = component.dateValue, !def.isEmpty, let date = parseDate(from: def) {
+            let df = DateFormatter()
+            df.dateFormat = "dd/MM/yyyy"
+            button.setTitle(df.string(from: date), for: .normal)
             button.setTitleColor(t.textStrong, for: .normal)
-            EmbedFormState.shared.setValue(def, forComponent: component.id, messageId: messageId)
+            
+            df.dateFormat = "yyyy-MM-dd"
+            EmbedFormState.shared.setValue(df.string(from: date), forComponent: component.id, messageId: messageId)
         }
     }
     func measureSize(maxWidth: CGFloat) -> CGSize {
@@ -937,9 +941,13 @@ final class EmbedDatePickerFieldNode: ASDisplayNode, EmbedFormInputNode {
         ])
         alert.addAction(UIAlertAction(title: "Done", style: .default, handler: { _ in
             let df = DateFormatter()
-            df.dateFormat = "dd/MM/yyyy"
+            df.dateFormat = "yyyy-MM-dd"
             let str = df.string(from: picker.date)
-            self.button.setTitle(str, for: .normal)
+            
+            df.dateFormat = "dd/MM/yyyy"
+            let displayStr = df.string(from: picker.date)
+            
+            self.button.setTitle(displayStr, for: .normal)
             self.button.setTitleColor(UIColor.theme.textStrong, for: .normal)
             EmbedFormState.shared.setValue(str, forComponent: self.component.id, messageId: self.messageId)
         }))
@@ -951,10 +959,20 @@ final class EmbedDatePickerFieldNode: ASDisplayNode, EmbedFormInputNode {
         vc.present(alert, animated: true)
     }
 
-    private func isValidDateFormat(_ dateString: String) -> Bool {
+    private func formatForDisplay(_ dateString: String) -> String {
+        guard let date = parseDate(from: dateString) else { return dateString }
         let formatter = DateFormatter()
         formatter.dateFormat = "dd/MM/yyyy"
-        return formatter.date(from: dateString) != nil
+        return formatter.string(from: date)
+    }
+
+    private func parseDate(from dateString: String) -> Date? {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        if let d = formatter.date(from: dateString) { return d }
+        formatter.dateFormat = "dd/MM/yyyy"
+        if let d = formatter.date(from: dateString) { return d }
+        return nil
     }
 }
 


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-106
Root Cause
The EmbedDatePickerFieldNode saved the selected date in display format (dd/MM/yyyy) inside EmbedFormState, which was sent directly to the server. However, the server requires the date to be in the standard API format (yyyy-MM-dd), causing incorrect date values or validation failures during submission.

Solution
Separated the date representations by updating the UI button to show the display format (dd/MM/yyyy), while storing the standard API format (yyyy-MM-dd) in EmbedFormState for server requests. The date parsing logic was also enhanced to handle both formats robustly when loading default values or existing states.

Test Cases
Test Case 1: Verify that the date picker displays the initial default date on the UI in dd/MM/yyyy format.
Test Case 2: Verify that selecting a new date updates the button label in dd/MM/yyyy format while storing it in yyyy-MM-dd format under EmbedFormState.
Test Case 3: Verify that submitting the form successfully sends the date value in the correct yyyy-MM-dd format to the server.