### PR TITLE
260724-IOS-Update UI login

### DIFF
--- a/MezonChat/Core/Localization/L10n.swift
+++ b/MezonChat/Core/Localization/L10n.swift
@@ -1561,7 +1561,7 @@ extension L10n {
         "login.loginFailed":    "Invalid email or password. Please try again.",
         "login.phone":          "Phone number",
         "login.enterEmail":     "Enter your email",
-        "login.enterPhone":     "Enter your phone",
+        "login.enterPhone":     "Enter your phone number",
         "login.chooseAnotherOption":   "Or choose another option",
         "login.emailAddress":   "Email address",
         "login.send":           "Send OTP",

--- a/MezonChat/Features/Auth/Login/LoginContainerNode.swift
+++ b/MezonChat/Features/Auth/Login/LoginContainerNode.swift
@@ -6,7 +6,7 @@ struct LoginInteraction {
     let onEmailChanged: (String) -> Void
     let onPasswordChanged: (String) -> Void
     let onSubmitTapped: () -> Void
-    let onCountryPrefixTapped: () -> Void
+    let onCountryPrefixTapped: (UIView) -> Void
     let onShowPasswordToggled: () -> Void
     let onModeSelected: (LoginMode) -> Void
 }
@@ -320,10 +320,10 @@ private func buildAlternativeItems(mode: LoginMode, interaction: LoginInteractio
 final class PhoneInputComponent: Component {
     let prefix: String
     let phone: String
-    let onPrefixTapped: () -> Void
+    let onPrefixTapped: (UIView) -> Void
     let onPhoneChanged: (String) -> Void
 
-    init(prefix: String, phone: String, onPrefixTapped: @escaping () -> Void, onPhoneChanged: @escaping (String) -> Void) {
+    init(prefix: String, phone: String, onPrefixTapped: @escaping (UIView) -> Void, onPhoneChanged: @escaping (String) -> Void) {
         self.prefix = prefix
         self.phone = phone
         self.onPrefixTapped = onPrefixTapped
@@ -341,7 +341,7 @@ final class PhoneInputComponent: Component {
         private let prefixButton = UIButton(type: .system)
         private let separator = UIView()
         private let textField = UITextField()
-        private var onPrefixTapped: (() -> Void)?
+        private var onPrefixTapped: ((UIView) -> Void)?
         private var onPhoneChanged: ((String) -> Void)?
 
         override init(frame: CGRect) {
@@ -408,7 +408,7 @@ final class PhoneInputComponent: Component {
             return size
         }
 
-        @objc private func prefixTap() { onPrefixTapped?() }
+        @objc private func prefixTap() { onPrefixTapped?(prefixButton) }
         @objc private func textChanged() { onPhoneChanged?(textField.text ?? "") }
     }
 

--- a/MezonChat/Features/Auth/Login/LoginViewController.swift
+++ b/MezonChat/Features/Auth/Login/LoginViewController.swift
@@ -88,7 +88,7 @@ final class LoginViewController: ViewController, AuthScreenStatusBarStyle {
             onEmailChanged: { [weak self] text in self?.setEmail(text) },
             onPasswordChanged: { [weak self] text in self?.setPassword(text) },
             onSubmitTapped: { [weak self] in self?.triggerSubmit() },
-            onCountryPrefixTapped: { [weak self] in self?.showCountryPicker() },
+            onCountryPrefixTapped: { [weak self] anchor in self?.showCountryPicker(anchor: anchor) },
             onShowPasswordToggled: { [weak self] in
                 guard let self else { return }
                 self.setPasswordVisible(!self.isPasswordVisible)
@@ -269,15 +269,68 @@ final class LoginViewController: ViewController, AuthScreenStatusBarStyle {
         }
     }
 
-    private func showCountryPicker() {
-        let sheet = UIAlertController(title: L(L10n.Login.selectCountry), message: nil, preferredStyle: .actionSheet)
+    private var customDropdown: UIView?
+
+    private class CountryButton: UIButton {
+        var prefix: String = ""
+    }
+
+    private func showCountryPicker(anchor: UIView) {
+        if customDropdown != nil {
+            hideCountryPicker()
+            return
+        }
+
+        let overlay = UIButton(type: .custom)
+        overlay.frame = view.bounds
+        overlay.addTarget(self, action: #selector(hideCountryPicker), for: .touchUpInside)
+        view.addSubview(overlay)
+
+        let dropdown = UIView()
+        dropdown.backgroundColor = AppTheme.light.attributes.loginInputBg
+        dropdown.layer.cornerRadius = 8
+        dropdown.layer.borderWidth = 1
+        dropdown.layer.borderColor = AppTheme.light.attributes.loginInputBorder.cgColor
+        dropdown.layer.shadowColor = UIColor.black.cgColor
+        dropdown.layer.shadowOpacity = 0.1
+        dropdown.layer.shadowRadius = 8
+        dropdown.layer.shadowOffset = CGSize(width: 0, height: 4)
+
+        overlay.addSubview(dropdown)
+
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.distribution = .fillEqually
+        dropdown.addSubview(stack)
+
         let countries = [("+84", "🇻🇳 Việt Nam"), ("+81", "🇯🇵 Japan"), ("+1", "🇺🇸 USA")]
         for (prefix, name) in countries {
-            sheet.addAction(UIAlertAction(title: name, style: .default) { [weak self] _ in self?.setCountryPrefix(prefix) })
+            let btn = CountryButton(type: .system)
+            btn.prefix = prefix
+            btn.setTitle("\(name) (\(prefix))", for: .normal)
+            btn.setTitleColor(AppTheme.light.attributes.loginInputTextColor, for: .normal)
+            btn.contentHorizontalAlignment = .left
+            btn.titleEdgeInsets = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
+            btn.addTarget(self, action: #selector(countryButtonTapped(_:)), for: .touchUpInside)
+            stack.addArrangedSubview(btn)
         }
-        sheet.addAction(UIAlertAction(title: L(L10n.Common.cancel), style: .cancel))
-        if let pop = sheet.popoverPresentationController { pop.sourceView = loginNode.phonePrefixButton }
-        present(sheet, animated: true)
+
+        let anchorRect = anchor.convert(anchor.bounds, to: view)
+        
+        dropdown.frame = CGRect(x: anchorRect.minX, y: anchorRect.maxY + 4, width: 220, height: CGFloat(countries.count * 44))
+        stack.frame = dropdown.bounds
+
+        customDropdown = overlay
+    }
+
+    @objc private func countryButtonTapped(_ sender: CountryButton) {
+        setCountryPrefix(sender.prefix)
+        hideCountryPicker()
+    }
+
+    @objc private func hideCountryPicker() {
+        customDropdown?.removeFromSuperview()
+        customDropdown = nil
     }
 
     @objc private func handleLanguageChange() { loginNode.refreshLocalizedStrings() }


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-98
Root Cause: Inconsistent UI properties (font families, element heights, colors), missing input validation, default popup animations, and discrepancy with iOS regarding OTP error handling.

Solution: Synchronized input heights to 48dp, reset password typeface to default, matched UI colors for checkboxes, disabled the "Send OTP" button for invalid inputs, replaced native Toasts with custom Toasts, standardized the "Invalid OTP" error, and removed the country dropdown animation.

Test Cases:
Verify that the "Show password" text and checkbox colors exactly match the alternative text colors.
Verify that the "Send OTP" button remains disabled when the phone number is empty or invalid.
Verify that the country prefix box and the phone number input field have the exact same height and align perfectly.
Verify that the password input placeholder uses the default system font instead of the monospace font.
Verify that entering an incorrect OTP displays a custom "Invalid OTP" toast message regardless of the backend error code.
Verify that clicking the country prefix button opens the dropdown instantly without any transition animations.