### PR TITLE
260729-IOS-Fix bug mention

### DIFF
--- a/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
+++ b/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
@@ -4296,10 +4296,10 @@ final class SendMessageInputViewController: UIViewController {
     private func detectMentionKeyword() -> String? {
         guard let selectedRange = textView.selectedTextRange else { return nil }
         let cursorOffset = textView.offset(from: textView.beginningOfDocument, to: selectedRange.start)
-        let fullText = textView.text ?? ""
-        guard cursorOffset > 0, cursorOffset <= fullText.count else { return nil }
+        let fullNS = (textView.text ?? "") as NSString
+        guard cursorOffset > 0, cursorOffset <= fullNS.length else { return nil }
 
-        let textBefore = String(fullText.prefix(cursorOffset))
+        let textBeforeNS = fullNS.substring(to: cursorOffset) as NSString
 
         for mention in activeMentions {
             if cursorOffset > mention.range.location && cursorOffset <= mention.range.location + mention.range.length {
@@ -4307,15 +4307,16 @@ final class SendMessageInputViewController: UIViewController {
             }
         }
 
-        guard let atIdx = textBefore.lastIndex(of: "@") else { return nil }
-        let atIntIdx = textBefore.distance(from: textBefore.startIndex, to: atIdx)
+        let atRange = textBeforeNS.range(of: "@", options: .backwards)
+        guard atRange.location != NSNotFound else { return nil }
+        let atIntIdx = atRange.location
 
         if atIntIdx > 0 {
-            let charBefore = textBefore[textBefore.index(before: atIdx)]
+            let charBefore = textBeforeNS.substring(with: NSRange(location: atIntIdx - 1, length: 1))
             guard charBefore == " " || charBefore == "\n" else { return nil }
         }
 
-        let keyword = String(textBefore[textBefore.index(after: atIdx)...])
+        let keyword = textBeforeNS.substring(from: atIntIdx + 1)
         return keyword
     }
 
@@ -4564,10 +4565,12 @@ final class SendMessageInputViewController: UIViewController {
         guard let selectedRange = textView.selectedTextRange else { return }
         let cursorOffset = textView.offset(from: textView.beginningOfDocument, to: selectedRange.start)
 
-        let fullText = textView.text ?? ""
-        let textBefore = String(fullText.prefix(cursorOffset))
-        guard let atIdx = textBefore.lastIndex(of: "@") else { return }
-        let atIntIdx = textBefore.distance(from: textBefore.startIndex, to: atIdx)
+        let fullNS = (textView.text ?? "") as NSString
+        guard cursorOffset >= 0, cursorOffset <= fullNS.length else { return }
+        let textBeforeNS = fullNS.substring(to: cursorOffset) as NSString
+        let atRange = textBeforeNS.range(of: "@", options: .backwards)
+        guard atRange.location != NSNotFound else { return }
+        let atIntIdx = atRange.location
         let replaceRange = NSRange(location: atIntIdx, length: cursorOffset - atIntIdx)
 
         let mentionText: String


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-130
Root Cause
The bug occurs due to a string length mismatch in Swift when handling emojis. UITextView.offset() returns a UTF-16 code unit index, but detectMentionKeyword() and insertMention() incorrectly used Swift String.count, .prefix(), and .distance() which are based on Character (grapheme cluster) counts. Since emojis (like 🙈) take 1 Character but 2 UTF-16 units, this mismatch calculates incorrect NSRanges, causing the mention styling to break or overwrite adjacent text.

Solution
Replaced Swift String character-based operations (prefix(), lastIndex(of:), distance()) with NSString UTF-16-based equivalents (substring(to:), range(of:)) to ensure the index system matches UIKit's textView.offset() consistently.

Test Cases
Mention a user containing emoji in their display name.
Mention a second user immediately after a user with an emoji in their name.
Mention a user, type some text with emojis, and then mention a second user.
Verify the sent message correctly highlights all mentions on receiver side.
Verify that editing a message containing emoji mentions correctly restores the mentions in the input composer.