### PR TITLE
260729-IOS-Fix bug render message

### DIFF
--- a/MezonChat/Features/Chat/ForwardMessageViewController.swift
+++ b/MezonChat/Features/Chat/ForwardMessageViewController.swift
@@ -5,13 +5,35 @@ private enum ForwardOutgoing {
     private static let maxExtraTextLen = 2000
 
     static func contentJSONString(for record: MessageRecord) -> String {
-        if var dict = try? JSONSerialization.jsonObject(with: record.content) as? [String: Any] {
+        let parsedDict: [String: Any]?
+        if let d = try? JSONSerialization.jsonObject(with: record.content) as? [String: Any] {
+            parsedDict = d
+        } else if let str = String(data: record.content, encoding: .utf8),
+                  let sanitized = MessageContentParser.sanitizeAndRetryParse(str) {
+            parsedDict = sanitized
+        } else {
+            parsedDict = nil
+        }
+        
+        if var dict = parsedDict {
             dict["fwd"] = true
             if let data = try? JSONSerialization.data(withJSONObject: dict),
                let str = String(data: data, encoding: .utf8) {
                 return str
             }
         }
+        
+        if let str = String(data: record.content, encoding: .utf8) {
+             let extracted = MessageContentParser.regexExtractTextField(str)
+             if !extracted.isEmpty {
+                 let dict: [String: Any] = ["t": extracted, "fwd": true]
+                 if let data = try? JSONSerialization.data(withJSONObject: dict),
+                    let str = String(data: data, encoding: .utf8) {
+                     return str
+                 }
+             }
+        }
+        
         return #"{"fwd":true}"#
     }
 

--- a/MezonChat/Features/Chat/MessageContentParser.swift
+++ b/MezonChat/Features/Chat/MessageContentParser.swift
@@ -205,8 +205,14 @@ enum MessageContentParser {
               !str.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return .empty
         }
-        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            return ParsedContent(text: str, tokens: [], embeds: [], ogpPreviews: [])
+        let json: [String: Any]
+        if let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            json = parsed
+        } else if let sanitized = Self.sanitizeAndRetryParse(str) {
+            json = sanitized
+        } else {
+            let extractedText = Self.regexExtractTextField(str)
+            return ParsedContent(text: extractedText, tokens: [], embeds: [], ogpPreviews: [])
         }
         let text = json["t"] as? String ?? json["text"] as? String ?? ""
         let embeds = parseEmbeds(json["embed"], topLevelComponents: json["components"])
@@ -252,6 +258,45 @@ enum MessageContentParser {
         tokens = tokens.filter { $0.start >= 0 && $0.end <= maxLen && $0.start < $0.end }
 
         return ParsedContent(text: text, tokens: tokens, embeds: embeds, ogpPreviews: ogpPreviews)
+    }
+
+    static func sanitizeAndRetryParse(_ raw: String) -> [String: Any]? {
+        var sanitized = raw
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\r", with: "\\r")
+            .replacingOccurrences(of: "\t", with: "\\t")
+        
+        let surrogatePattern = try? NSRegularExpression(
+            pattern: "\\\\u[Dd][89AaBb][0-9A-Fa-f]{2}(?!\\\\u[Dd][CcDdEeFf][0-9A-Fa-f]{2})",
+            options: []
+        )
+        if let regex = surrogatePattern {
+            sanitized = regex.stringByReplacingMatches(
+                in: sanitized,
+                range: NSRange(sanitized.startIndex..., in: sanitized),
+                withTemplate: "\\\\uFFFD"
+            )
+        }
+        
+        guard let data = sanitized.data(using: .utf8) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+
+    static func regexExtractTextField(_ raw: String) -> String {
+        guard raw.hasPrefix("{") else { return raw }
+        let pattern = "\"t\"\\s*:\\s*\"((?:[^\"\\\\]|\\\\.)*)\""
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(in: raw, range: NSRange(raw.startIndex..., in: raw)),
+              match.numberOfRanges > 1,
+              let range = Range(match.range(at: 1), in: raw) else {
+            return ""
+        }
+        return String(raw[range])
+            .replacingOccurrences(of: "\\n", with: "\n")
+            .replacingOccurrences(of: "\\r", with: "\r")
+            .replacingOccurrences(of: "\\t", with: "\t")
+            .replacingOccurrences(of: "\\\"", with: "\"")
+            .replacingOccurrences(of: "\\\\", with: "\\")
     }
 
     private static func parseEmojis(_ items: [[String: Any]]) -> [ContentToken] {


### PR DESCRIPTION
root cause: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-137
Root Cause
JSONSerialization fails to parse message payloads containing unescaped control characters (e.g., \n) or lone Unicode surrogates, causing the UI to display raw JSON strings and breaking the payload structure when forwarding messages.

Solution
Implemented a two-step parsing fallback (matching Android parity) in MessageContentParser and ForwardOutgoing: first sanitize the string (escape newlines and replace invalid surrogates) to retry parsing, and as a last resort, use Regex to directly extract the "t" (text) field to ensure safe UI rendering and forwarding.

Test Cases
TC1: Verify that standard short messages render and forward correctly without data loss.
TC2: Verify that long messages (or messages with complex unicode/OGP metadata) render as plain text instead of raw JSON strings.
TC3: Verify that forwarding a long message successfully transmits the original text to the destination channel.
TC4: Verify that tapping "Edit" on a long message correctly populates the input bar with plain text instead of raw JSON.