### PR TITLE
270730-IOS-Improve image viewer

### DIFF
--- a/MezonChat/Core/UI/Gallery/GalleryController.swift
+++ b/MezonChat/Core/UI/Gallery/GalleryController.swift
@@ -454,11 +454,20 @@ final class GalleryController: UIViewController {
     private func updateHeader(for index: Int) {
         guard index >= 0, index < items.count else { return }
         let item = items[index]
+        
+        let isAnonymous = item.senderId == "1767478432163172999"
 
-        nameLabel.text = item.senderName.isEmpty ? nil : item.senderName
-        avatarImageView.isHidden = item.senderName.isEmpty
-        nameLabel.isHidden = item.senderName.isEmpty
-        dateLabel.isHidden = item.senderName.isEmpty
+        if isAnonymous {
+            nameLabel.text = "Anonymous"
+            avatarImageView.isHidden = false
+            nameLabel.isHidden = false
+            dateLabel.isHidden = false
+        } else {
+            nameLabel.text = item.senderName.isEmpty ? nil : item.senderName
+            avatarImageView.isHidden = item.senderName.isEmpty
+            nameLabel.isHidden = item.senderName.isEmpty
+            dateLabel.isHidden = item.senderName.isEmpty
+        }
 
         if let ts = item.timestamp {
             dateLabel.text = formatDate(ts)
@@ -466,7 +475,17 @@ final class GalleryController: UIViewController {
             dateLabel.text = nil
         }
 
-        if let avatarURLStr = item.senderAvatarURL, !avatarURLStr.isEmpty {
+        if isAnonymous {
+            avatarImageView.contentMode = .center
+            if let raw = UIImage(named: "Chat/AnonymousIcon") {
+                avatarImageView.image = Self.anonymousAvatarCompositeImage(raw: raw, tint: .white)
+            } else {
+                avatarImageView.image = nil
+            }
+            avatarImageView.backgroundColor = UIColor(white: 0.2, alpha: 1.0)
+        } else if let avatarURLStr = item.senderAvatarURL, !avatarURLStr.isEmpty {
+            avatarImageView.contentMode = .scaleAspectFill
+            avatarImageView.backgroundColor = UIColor.white.withAlphaComponent(0.2)
             let proxyURL = ImgproxyURL.attachmentURL(
                 from: avatarURLStr,
                 width: 100,
@@ -484,6 +503,8 @@ final class GalleryController: UIViewController {
             }
         } else {
             avatarImageView.image = nil
+            avatarImageView.contentMode = .scaleAspectFill
+            avatarImageView.backgroundColor = UIColor.white.withAlphaComponent(0.2)
         }
 
         if items.count > 1 && !items[index].isVideo {
@@ -1092,5 +1113,26 @@ extension GalleryController: UIGestureRecognizerDelegate {
             }
         }
         return true
+    }
+
+    private static func anonymousAvatarCompositeImage(raw: UIImage, tint: UIColor) -> UIImage {
+        let tinted = raw.withRenderingMode(.alwaysTemplate)
+            .withTintColor(tint, renderingMode: .alwaysOriginal)
+        let iconMax = CGSize(width: 22, height: 22)
+        let canvas = CGSize(width: 40, height: 40)
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = UIScreen.main.scale
+        format.opaque = false
+        return UIGraphicsImageRenderer(size: canvas, format: format).image { _ in
+            let tw = max(tinted.size.width, 1)
+            let th = max(tinted.size.height, 1)
+            let scale = min(iconMax.width / tw, iconMax.height / th)
+            let drawSize = CGSize(width: tw * scale, height: th * scale)
+            let origin = CGPoint(
+                x: (canvas.width - drawSize.width) / 2,
+                y: (canvas.height - drawSize.height) / 2
+            )
+            tinted.draw(in: CGRect(origin: origin, size: drawSize))
+        }
     }
 }

--- a/MezonChat/Core/UI/Gallery/GalleryItemNode.swift
+++ b/MezonChat/Core/UI/Gallery/GalleryItemNode.swift
@@ -11,6 +11,7 @@ public struct GalleryItemInfo {
     public let pixelSize: CGSize?
     public let placeholderURL: String?
     public let senderName: String
+    public let senderId: String?
     public let senderAvatarURL: String?
     public let timestamp: Date?
     public let isVideo: Bool
@@ -27,6 +28,7 @@ public struct GalleryItemInfo {
         pixelSize: CGSize? = nil,
         placeholderURL: String? = nil,
         senderName: String = "",
+        senderId: String? = nil,
         senderAvatarURL: String? = nil,
         timestamp: Date? = nil,
         isVideo: Bool = false
@@ -37,6 +39,7 @@ public struct GalleryItemInfo {
         self.pixelSize = pixelSize
         self.placeholderURL = placeholderURL
         self.senderName = senderName
+        self.senderId = senderId
         self.senderAvatarURL = senderAvatarURL
         self.timestamp = timestamp
         self.isVideo = isVideo
@@ -58,6 +61,7 @@ public struct GalleryItemInfo {
         pixelSize: CGSize? = nil,
         placeholderProxySize: Int = 400,
         senderName: String = "",
+        senderId: String? = nil,
         senderAvatarURL: String? = nil,
         timestamp: Date? = nil
     ) -> GalleryItemInfo {
@@ -84,6 +88,7 @@ public struct GalleryItemInfo {
             pixelSize: pixelSize,
             placeholderURL: placeholderURL,
             senderName: senderName,
+            senderId: senderId,
             senderAvatarURL: senderAvatarURL,
             timestamp: timestamp,
             isVideo: false

--- a/MezonChat/Features/ChannelDetail/Tabs/MediaGalleryNode.swift
+++ b/MezonChat/Features/ChannelDetail/Tabs/MediaGalleryNode.swift
@@ -191,6 +191,7 @@ final class MediaGalleryNode: ASDisplayNode {
         guard index >= 0, index < attachments.count else { return }
         let proxySide = Int(flowLayout.itemSize.width * UIScreen.main.scale)
         let items: [GalleryItemInfo] = attachments.enumerated().map { (itemIndex, att) in
+            let uploader = resolvedUploaderInfo(uploaderId: att.uploader)
             let isVideo = Self.isVideo(att)
             let imageThumbURL = ImgproxyURL.attachmentURL(
                 from: att.url, width: proxySide, height: proxySide, resizeType: "fill")
@@ -214,8 +215,9 @@ final class MediaGalleryNode: ASDisplayNode {
                     sourceURL: att.url,
                     image: videoPreview,
                     placeholderURL: nil,
-                    senderName: "",
-                    senderAvatarURL: nil,
+                    senderName: uploader.name,
+                    senderId: String(att.uploader),
+                    senderAvatarURL: uploader.avatarURL,
                     timestamp: ts,
                     isVideo: true
                 )
@@ -225,14 +227,34 @@ final class MediaGalleryNode: ASDisplayNode {
                 image: preview,
                 pixelSize: GalleryItemInfo.pixelSize(width: Int(att.width), height: Int(att.height)),
                 placeholderProxySize: 150,
-                senderName: "",
-                senderAvatarURL: nil,
+                senderName: uploader.name,
+                senderId: String(att.uploader),
+                senderAvatarURL: uploader.avatarURL,
                 timestamp: ts
             )
         }
         let gallery = GalleryController(items: items, initialIndex: index)
         guard let vc = view.findViewController() else { return }
         vc.present(gallery, animated: true)
+    }
+
+    private func resolvedUploaderInfo(uploaderId: Int64) -> (name: String, avatarURL: String?) {
+        guard uploaderId != 0 else { return ("", nil) }
+        let idString = String(uploaderId)
+        var name = ""
+        var avatarURL: String?
+        context.account.postbox.read { tx in
+            guard let profile = tx.getProfile(userId: idString) else { return }
+            if let displayName = profile.displayName, !displayName.isEmpty {
+                name = displayName
+            } else if !profile.username.isEmpty {
+                name = profile.username
+            }
+            if let avatar = profile.avatarUrl, !avatar.isEmpty {
+                avatarURL = avatar
+            }
+        }
+        return (name.isEmpty ? idString : name, avatarURL)
     }
 
     override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {

--- a/MezonChat/Features/ChannelDetail/Tabs/PinnedMessagesNode.swift
+++ b/MezonChat/Features/ChannelDetail/Tabs/PinnedMessagesNode.swift
@@ -921,6 +921,7 @@ private final class PinnedMessageCellNode: ASCellNode, ASNetworkImageNodeDelegat
                     image: itemIndex == index ? att.localImage : nil,
                     placeholderURL: nil,
                     senderName: displayNameForGallery,
+                    senderId: String(pinForGallery.senderID),
                     senderAvatarURL: avatarURLForGallery,
                     timestamp: Self.galleryTimestamp(for: pinForGallery),
                     isVideo: true
@@ -931,6 +932,7 @@ private final class PinnedMessageCellNode: ASCellNode, ASNetworkImageNodeDelegat
                 image: itemIndex == index ? att.localImage : nil,
                 pixelSize: GalleryItemInfo.pixelSize(width: att.width, height: att.height),
                 senderName: displayNameForGallery,
+                senderId: String(pinForGallery.senderID),
                 senderAvatarURL: avatarURLForGallery,
                 timestamp: Self.galleryTimestamp(for: pinForGallery)
             )

--- a/MezonChat/Features/Chat/Cells/MessageBubbleNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageBubbleNode.swift
@@ -1223,6 +1223,7 @@ final class MessageBubbleNode: ASDisplayNode {
                     image: preview ?? (itemIndex == index ? att.localImage : nil),
                     placeholderURL: nil,
                     senderName: display.senderDisplayName,
+                    senderId: display.message.senderId,
                     senderAvatarURL: display.avatarURL,
                     timestamp: display.message.createdAt,
                     isVideo: true
@@ -1235,6 +1236,7 @@ final class MessageBubbleNode: ASDisplayNode {
                     ?? (itemIndex == index ? att.localImage : nil),
                 pixelSize: GalleryItemInfo.pixelSize(width: att.width, height: att.height),
                 senderName: display.senderDisplayName,
+                senderId: display.message.senderId,
                 senderAvatarURL: display.avatarURL,
                 timestamp: display.message.createdAt
             )
@@ -1255,6 +1257,7 @@ final class MessageBubbleNode: ASDisplayNode {
                 sourceURL: url,
                 placeholderProxySize: EmbedItemNode.embedImageProxyDimension,
                 senderName: display.senderDisplayName,
+                senderId: display.message.senderId,
                 senderAvatarURL: display.avatarURL,
                 timestamp: display.message.createdAt
             ),

--- a/MezonChat/Features/Chat/ChatViewController.swift
+++ b/MezonChat/Features/Chat/ChatViewController.swift
@@ -6019,6 +6019,7 @@ final class ChatViewController: ViewController {
                 image: previewImage ?? attachment.localImage,
                 placeholderURL: nil,
                 senderName: display.senderDisplayName,
+                senderId: display.message.senderId,
                 senderAvatarURL: display.avatarURL,
                 timestamp: display.message.createdAt,
                 isVideo: true
@@ -6031,6 +6032,7 @@ final class ChatViewController: ViewController {
                 ?? attachment.localImage,
             pixelSize: GalleryItemInfo.pixelSize(width: attachment.width, height: attachment.height),
             senderName: display.senderDisplayName,
+            senderId: display.message.senderId,
             senderAvatarURL: display.avatarURL,
             timestamp: display.message.createdAt
         )
@@ -6111,6 +6113,7 @@ final class ChatViewController: ViewController {
                 image: nil,
                 placeholderURL: nil,
                 senderName: uploader.name,
+                senderId: String(attachment.uploader),
                 senderAvatarURL: uploader.avatarURL,
                 timestamp: timestamp,
                 isVideo: true
@@ -6121,6 +6124,7 @@ final class ChatViewController: ViewController {
             pixelSize: GalleryItemInfo.pixelSize(width: attachment.width, height: attachment.height),
             placeholderProxySize: 150,
             senderName: uploader.name,
+            senderId: String(attachment.uploader),
             senderAvatarURL: uploader.avatarURL,
             timestamp: timestamp
         )


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-134
Root Cause
The GalleryItemInfo model did not store the sender's user ID, making it impossible to detect anonymous messages. Thus, the header fell back to showing the raw numeric user ID (resolved from the database) and lacked the incognito icon.
The "Media" tab in Channel Details hardcoded the sender name and avatar to empty values when launching the gallery.
The anonymous avatar icon was scaled up incorrectly to fill the entire circular frame because there was no custom padding applied.

Solution
Added senderId to the GalleryItemInfo model and updated all call sites (MessageBubbleNode, ChatViewController, PinnedMessagesNode, and MediaGalleryNode) to pass the sender ID.
Implemented resolvedUploaderInfo in MediaGalleryNode to query the local database and resolve actual uploader names/avatars for images opened from the Media tab.
Added a check in GalleryController to detect anonymous sender IDs, override the display name with "Anonymous", and render a custom-scaled composite icon (22x22 inside a 40x40 circle) with the correct background color.

Test Cases
TC1: Open an image sent anonymously in the chat room to verify the header shows "Anonymous" and a properly scaled/padded incognito avatar.
TC2: Open an image from the "Media" (Phương tiện) tab in Channel Details and verify the header correctly displays the sender name, avatar, and timestamp.
TC3: Open an image from the "Pinned" (Ghim) tab in Channel Details and verify the header shows the correct sender details (including anonymous format if applicable).