### PR TITLE
260803-IOS-Update animated image

### DIFF
--- a/MezonChat/Core/MezonEngine/MezonEngine+MediaPanel.swift
+++ b/MezonChat/Core/MezonEngine/MezonEngine+MediaPanel.swift
@@ -116,8 +116,7 @@ enum KlipyGIFClient {
     }
 
     static func fetchTrendingData(page: Int = 1, perPage: Int = 30) async throws -> Data {
-        // Klipy uses /stickers/trending with format_filter=gif for trending gifs
-        let urlStr = "\(MezonEnvironment.klipyBaseURL)/\(MezonEnvironment.klipyAPIKey)/stickers/trending"
+        let urlStr = "\(MezonEnvironment.klipyBaseURL)/\(MezonEnvironment.klipyAPIKey)/gifs/trending"
         return try await getJSON(urlString: urlStr, extraItems: [
             URLQueryItem(name: "page", value: "\(page)"),
             URLQueryItem(name: "per_page", value: "\(perPage)"),

--- a/MezonChat/Features/ChannelSettings/Webhook/WebhookEditViewController.swift
+++ b/MezonChat/Features/ChannelSettings/Webhook/WebhookEditViewController.swift
@@ -440,7 +440,7 @@ final class WebhookEditViewController: BaseViewController {
         }
         avatarView.showSkeleton()
         imageTask = URLSession.shared.dataTask(with: url) { [weak self] data, _, error in
-            guard error == nil, let data = data, let image = UIImage(data: data) else { 
+            guard error == nil, let data = data, let image = UIImage.decompressedImage(from: data) else { 
                 DispatchQueue.main.async {
                     self?.avatarImageView.isHidden = true
                     self?.avatarView.showPlaceholder()

--- a/MezonChat/Features/ChannelSettings/Webhook/WebhookListViewController.swift
+++ b/MezonChat/Features/ChannelSettings/Webhook/WebhookListViewController.swift
@@ -538,7 +538,7 @@ final class WebhookItemCell: UITableViewCell {
             }
             avatarView.showSkeleton()
             imageTask = URLSession.shared.dataTask(with: url) { [weak self] data, _, error in
-                guard error == nil, let data = data, let image = UIImage(data: data) else {
+                guard error == nil, let data = data, let image = UIImage.decompressedImage(from: data) else {
                     DispatchQueue.main.async {
                         self?.avatarImageView.isHidden = true
                         self?.avatarView.showPlaceholder()

--- a/MezonChat/Features/DirectMessages/DmListItemCell.swift
+++ b/MezonChat/Features/DirectMessages/DmListItemCell.swift
@@ -259,8 +259,11 @@ final class DmListItemCell: UITableViewCell {
         avatarLoadGeneration += 1
         let gen = avatarLoadGeneration
         let proxied = ImgproxyURL.avatarProxyURL(from: url.absoluteString, width: 100, height: 100)
+        let raw = url.absoluteString
         let proxiedKey = proxied as NSString
-        if let cached = Self.avatarMemoryCache.object(forKey: proxiedKey) ?? ImageCache.shared.memoryImage(forKey: proxied) {
+        let rawKey = raw as NSString
+        
+        if let cached = Self.avatarMemoryCache.object(forKey: proxiedKey) ?? ImageCache.shared.memoryImage(forKey: proxied) ?? Self.avatarMemoryCache.object(forKey: rawKey) ?? ImageCache.shared.memoryImage(forKey: raw) {
             Self.avatarMemoryCache.setObject(cached, forKey: proxiedKey)
             guard gen == avatarLoadGeneration else { return }
             isAvatarLoadInFlight = false
@@ -279,19 +282,31 @@ final class DmListItemCell: UITableViewCell {
         }
 
         ImageCache.shared.loadAvatar(urlString: proxied) { [weak self] image in
-            if let image { Self.avatarMemoryCache.setObject(image, forKey: proxiedKey) }
-            guard let self, gen == self.avatarLoadGeneration else { return }
-            self.isAvatarLoadInFlight = false
             if let image {
+                Self.avatarMemoryCache.setObject(image, forKey: proxiedKey)
+                guard let self, gen == self.avatarLoadGeneration else { return }
+                self.isAvatarLoadInFlight = false
                 self.groupIconView.isHidden = true
                 self.avatarImageView.image = image
                 self.textAvatar.showImageMode()
-            } else if let fallbackUsername {
-                self.avatarImageView.image = nil
-                self.textAvatar.configure(username: fallbackUsername, fontSize: 16.sf)
             } else {
-                self.avatarImageView.image = nil
-                self.showGroupAvatarPlaceholder()
+                guard let self, gen == self.avatarLoadGeneration else { return }
+                ImageCache.shared.loadAvatar(urlString: raw) { [weak self] rawImage in
+                    if let rawImage { Self.avatarMemoryCache.setObject(rawImage, forKey: rawKey) }
+                    guard let self, gen == self.avatarLoadGeneration else { return }
+                    self.isAvatarLoadInFlight = false
+                    if let rawImage {
+                        self.groupIconView.isHidden = true
+                        self.avatarImageView.image = rawImage
+                        self.textAvatar.showImageMode()
+                    } else if let fallbackUsername {
+                        self.avatarImageView.image = nil
+                        self.textAvatar.configure(username: fallbackUsername, fontSize: 16.sf)
+                    } else {
+                        self.avatarImageView.image = nil
+                        self.showGroupAvatarPlaceholder()
+                    }
+                }
             }
         }
     }

--- a/MezonChat/Features/Profile/ProfileContainerNode.swift
+++ b/MezonChat/Features/Profile/ProfileContainerNode.swift
@@ -650,8 +650,9 @@ final class ProfileContainerNode: ASDisplayNode {
 
         if let url = user?.avatarURL, !url.absoluteString.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             let proxiedURLString = ImgproxyURL.create(from: url.absoluteString, width: 150, height: 150)
+            let rawURLString = url.absoluteString
             currentAvatarLoadKey = proxiedURLString
-            if let cached = ImageCache.shared.memoryImage(forKey: proxiedURLString) {
+            if let cached = ImageCache.shared.memoryImage(forKey: proxiedURLString) ?? ImageCache.shared.memoryImage(forKey: rawURLString) {
                 avatarImageView.image = cached
                 avatarPlaceholderLabel.isHidden = true
                 avatarContainerView.backgroundColor = .clear
@@ -666,15 +667,27 @@ final class ProfileContainerNode: ASDisplayNode {
                 ImageCache.shared.loadAvatar(urlString: proxiedURLString) { [weak self] image in
                     guard let self else { return }
                     guard self.currentAvatarLoadKey == proxiedURLString else { return }
-                    guard let image else {
-                        self.applyProfileAvatarPlaceholder()
-                        return
+                    if let image {
+                        self.avatarImageView.image = image
+                        self.avatarPlaceholderLabel.isHidden = true
+                        self.avatarContainerView.backgroundColor = .clear
+                        self.headerBackgroundView.backgroundColor = image.dominantColor() ?? .mezonSecondaryBackground
+                        self.statusBubbleShapeLayer.fillColor = UIColor.mezonSecondaryBackground.cgColor
+                    } else {
+                        ImageCache.shared.loadAvatar(urlString: rawURLString) { [weak self] rawImage in
+                            guard let self else { return }
+                            guard self.currentAvatarLoadKey == proxiedURLString else { return }
+                            if let rawImage {
+                                self.avatarImageView.image = rawImage
+                                self.avatarPlaceholderLabel.isHidden = true
+                                self.avatarContainerView.backgroundColor = .clear
+                                self.headerBackgroundView.backgroundColor = rawImage.dominantColor() ?? .mezonSecondaryBackground
+                                self.statusBubbleShapeLayer.fillColor = UIColor.mezonSecondaryBackground.cgColor
+                            } else {
+                                self.applyProfileAvatarPlaceholder()
+                            }
+                        }
                     }
-                    self.avatarImageView.image = image
-                    self.avatarPlaceholderLabel.isHidden = true
-                    self.avatarContainerView.backgroundColor = .clear
-                    self.headerBackgroundView.backgroundColor = image.dominantColor() ?? .mezonSecondaryBackground
-                    self.statusBubbleShapeLayer.fillColor = UIColor.mezonSecondaryBackground.cgColor
                 }
             }
         } else {


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-31
Root Cause
When loading avatars (for user profiles or DM/group lists), the app processes URLs via Imgproxy to optimize sizes. If the uploaded animated avatar URL lacks a .gif or .webp file extension, the helper fails to bypass Imgproxy. Consequently, the request goes through Imgproxy with a strict 2MB limit (mb:2097152), causing large animated files to fail with HTTP error 422, which triggers the fallback to the default/text avatar.

Solution
Implemented a fallback loading mechanism in ProfileContainerNode.swift and DmListItemCell.swift. The app first attempts to load the avatar via the optimized Imgproxy URL; if that fails (returns nil due to proxy processing errors), it falls back to downloading the raw URL (url.absoluteString) and decoding the animated GIF/WebP directly.

Test Cases
Verify that a user profile with an animated GIF/WebP avatar displays the animated image correctly on the profile screen instead of a text initials placeholder.
Verify that a group DM with an animated GIF/WebP avatar correctly displays the animation in the DM list instead of the default group icon.
Verify that normal static avatars still load correctly and continue to use the optimized Imgproxy URLs to save bandwidth.