### PR TITLE
260804-IOS-Fix topic tab bug

### DIFF
--- a/MezonChat/Core/Postbox/Messages/MessageTable.swift
+++ b/MezonChat/Core/Postbox/Messages/MessageTable.swift
@@ -907,10 +907,8 @@ final class MessageTable: Table {
         guard topicId != 0 else { return nil }
         if var records = cache[channelId],
            let index = records.firstIndex(where: { $0.id == messageId && !$0.isDeleted }) {
-            let record = records[index]
-            guard record.code == Self.topicMessageCode || Self.contentContainsTopicField(record.content) else { return nil }
             let updated = Self.withTopicMetadata(
-                record,
+                records[index],
                 topicId: topicId,
                 creatorId: creatorId,
                 replyCount: nil
@@ -922,7 +920,6 @@ final class MessageTable: Table {
         }
 
         guard let existing = getMessageById(messageId, channelId: channelId) else { return nil }
-        guard existing.code == Self.topicMessageCode || Self.contentContainsTopicField(existing.content) else { return nil }
         let updated = Self.withTopicMetadata(
             existing,
             topicId: topicId,
@@ -1106,15 +1103,6 @@ final class MessageTable: Table {
             record,
             content: data(from: json, fallback: record.content)
         )
-    }
-
-    private static func contentContainsTopicField(_ content: Data) -> Bool {
-        guard !content.isEmpty,
-              let json = try? JSONSerialization.jsonObject(with: content) as? [String: Any] else { return false }
-        if let tp = json["tp"] as? String, !tp.isEmpty, tp != "0" { return true }
-        if let tp = json["tp"] as? Int, tp != 0 { return true }
-        if let tp = json["tp"] as? Double, tp != 0 { return true }
-        return false
     }
 
     private static func withTopicMeta(_ record: MessageRecord, replyCount: Int, lastSentTimestamp: Int64) -> MessageRecord {

--- a/MezonChat/Core/Postbox/Messages/MessageTable.swift
+++ b/MezonChat/Core/Postbox/Messages/MessageTable.swift
@@ -907,8 +907,10 @@ final class MessageTable: Table {
         guard topicId != 0 else { return nil }
         if var records = cache[channelId],
            let index = records.firstIndex(where: { $0.id == messageId && !$0.isDeleted }) {
+            let record = records[index]
+            guard record.code == Self.topicMessageCode || Self.contentContainsTopicField(record.content) else { return nil }
             let updated = Self.withTopicMetadata(
-                records[index],
+                record,
                 topicId: topicId,
                 creatorId: creatorId,
                 replyCount: nil
@@ -920,6 +922,7 @@ final class MessageTable: Table {
         }
 
         guard let existing = getMessageById(messageId, channelId: channelId) else { return nil }
+        guard existing.code == Self.topicMessageCode || Self.contentContainsTopicField(existing.content) else { return nil }
         let updated = Self.withTopicMetadata(
             existing,
             topicId: topicId,
@@ -1103,6 +1106,15 @@ final class MessageTable: Table {
             record,
             content: data(from: json, fallback: record.content)
         )
+    }
+
+    private static func contentContainsTopicField(_ content: Data) -> Bool {
+        guard !content.isEmpty,
+              let json = try? JSONSerialization.jsonObject(with: content) as? [String: Any] else { return false }
+        if let tp = json["tp"] as? String, !tp.isEmpty, tp != "0" { return true }
+        if let tp = json["tp"] as? Int, tp != 0 { return true }
+        if let tp = json["tp"] as? Double, tp != 0 { return true }
+        return false
     }
 
     private static func withTopicMeta(_ record: MessageRecord, replyCount: Int, lastSentTimestamp: Int64) -> MessageRecord {

--- a/MezonChat/Features/Chat/ChatViewController.swift
+++ b/MezonChat/Features/Chat/ChatViewController.swift
@@ -3030,7 +3030,7 @@ final class ChatViewController: ViewController {
                 return "{}"
             }()
             let callLog = Self.parseCallLog(from: record.content)
-            let topicData = Self.parseTopicData(from: record.content, code: record.code)
+            let topicData = topicId != 0 ? nil : Self.parseTopicData(from: record.content, code: record.code)
             let isMe = isSenderCurrentUser(senderId: record.senderId, currentUserId: currentUserId)
             let profileInfo = profilesBySenderId[record.senderId]
             let trimmedStoredAvatar = record.senderAvatarURL?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""

--- a/MezonChat/Features/Chat/ChatViewController.swift
+++ b/MezonChat/Features/Chat/ChatViewController.swift
@@ -1762,7 +1762,11 @@ final class ChatViewController: ViewController {
     private func normalizedDisplayOrder(_ displays: [ChatMessageDisplay]) -> [ChatMessageDisplay] {
         Self.applyCombine(to: Self.sortMessagesLikeChannelStore(displays))
     }
-    private func setChannelLabel(_ v: String) { channelLabel = v; needsReloadPipe.putNext(()) }
+    private func setChannelLabel(_ v: String) {
+        if topicId != 0 { return }
+        channelLabel = v
+        needsReloadPipe.putNext(())
+    }
     private func clearLastSeenMessageId() {
         guard lastSeenMessageId != nil else { return }
         lastSeenMessageId = nil
@@ -3160,16 +3164,15 @@ final class ChatViewController: ViewController {
     private static let messageCodeTopic: Int32 = 9
 
     private static func parseTopicData(from data: Data, code: Int32) -> TopicData? {
+        guard code == messageCodeTopic else { return nil }
         guard !data.isEmpty,
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
 
-        let hasTp = json["tp"] != nil
-        guard code == messageCodeTopic || hasTp else { return nil }
         let topicId: String
         if let tp = json["tp"] as? String, !tp.isEmpty { topicId = tp }
         else if let tp = json["tp"] as? Int, tp != 0 { topicId = "\(tp)" }
         else if let tp = json["tp"] as? Double, tp != 0 { topicId = "\(Int64(tp))" }
-        else { return nil }
+        else { return nil } 
         let creatorId: String
         if let cid = json["cid"] as? String { creatorId = cid }
         else if let cid = json["cid"] as? Int { creatorId = "\(cid)" }

--- a/MezonChat/Features/Notifications/NotificationsViewController.swift
+++ b/MezonChat/Features/Notifications/NotificationsViewController.swift
@@ -118,16 +118,15 @@ final class NotificationsViewController: ViewController {
                     self.setItems(self.enrichTopicItems(topics))
                 })
 
-            if let token {
-                do {
-                    try await context.engine.topicDiscussion.listTopics(
-                        clanId: clanId, token: token)
-                } catch {
-                }
+            defer { setIsLoading(false) }
+            guard let token else { return }
+            do {
+                try await context.engine.topicDiscussion.listTopics(
+                    clanId: clanId, token: token)
+                loadedCategories.insert(category)
+                lastLoadedClanId = clanId
+            } catch {
             }
-            loadedCategories.insert(category)
-            lastLoadedClanId = clanId
-            setIsLoading(false)
             return
         }
 
@@ -137,8 +136,6 @@ final class NotificationsViewController: ViewController {
         }
 
         defer {
-            loadedCategories.insert(category)
-            lastLoadedClanId = clanId
             if isLoadMore { setIsLoadingMore(false) } else { setIsLoading(false) }
         }
 
@@ -161,6 +158,8 @@ final class NotificationsViewController: ViewController {
                 notificationId: notificationId,
                 token: token
             )
+            loadedCategories.insert(category)
+            lastLoadedClanId = clanId
         } catch {
         }
     }

--- a/MezonChat/Features/Notifications/NotificationsViewController.swift
+++ b/MezonChat/Features/Notifications/NotificationsViewController.swift
@@ -17,6 +17,7 @@ final class NotificationsViewController: ViewController {
     private(set) var isLoading: Bool = false
     private(set) var isLoadingMore: Bool = false
     private(set) var currentCategory: Int32 = 1
+    private var lastLoadedClanId: Int64 = 0
 
     private var loadedCategories: Set<Int32> = []
 
@@ -66,7 +67,9 @@ final class NotificationsViewController: ViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         notificationsNode.applyTheme()
-        if items.isEmpty {
+        let clanId = context.currentClanId
+        if items.isEmpty || clanId != lastLoadedClanId {
+            loadedCategories.removeAll()
             Task { await fetchNotifications(category: currentCategory) }
         }
     }
@@ -123,6 +126,7 @@ final class NotificationsViewController: ViewController {
                 }
             }
             loadedCategories.insert(category)
+            lastLoadedClanId = clanId
             setIsLoading(false)
             return
         }
@@ -134,6 +138,7 @@ final class NotificationsViewController: ViewController {
 
         defer {
             loadedCategories.insert(category)
+            lastLoadedClanId = clanId
             if isLoadMore { setIsLoadingMore(false) } else { setIsLoading(false) }
         }
 


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-142
1. Bug 1: Unintended "View Topic" UI on mention messages
Root Cause: The backend API incorrectly returns ack.code = 9 (Topic Code) when sending messages mentioning Tag Profiles, and broadcasts a SdTopicEvent socket message afterwards, which causes the iOS client to overwrite the message's local database code to 9 and parse topic metadata.
Solution: Added a guard in updateMessageTopicMetadata to ensure a message's code can only be updated to 9 if it is already identified as a topic root or contains a tp field.
Test Cases:
TC1: Send a message mentioning a Tag Profile to verify the "View Topic" button does not appear.
TC2: Reply to a message in a thread to verify the "View Topic" button still displays correctly.

2. Bug 2: Chat screen title changes when topic events are received
Root Cause: The setChannelLabel method updates the navigation bar title whenever a channel name change event is triggered, regardless of whether the current view is a main channel or a topic detail screen.
Solution: Added a guard check if topicId != 0 { return } inside setChannelLabel to ignore channel name updates when displaying a topic.
Test Cases:
TC1: Open a Topic Detail screen and verify its header title does not change to the parent channel name when messages are sent.

3. Bug 3: Notification list stays blank when switching clans
Root Cause: The NotificationsViewController caches loaded categories and does not reload notifications if items are already populated, failing to recognize when the user has switched to a different clan.
Solution: Track the lastLoadedClanId and clear loadedCategories to force a reload whenever a clan change is detected in viewWillAppear.
Test Cases:
TC1: Switch to another clan and open the Notifications screen to verify it successfully loads the notifications for the new clan.