### PR TITLE
260805-IOS-Handle jump to msg tab messages

### DIFF
--- a/MezonChat/Features/Notifications/NotificationsViewController.swift
+++ b/MezonChat/Features/Notifications/NotificationsViewController.swift
@@ -242,7 +242,7 @@ final class NotificationsViewController: ViewController {
             context.currentClanId = record.clanID
             let vc = ChatViewController(
                 clanId: record.clanID, channel: channel, context: self.context)
-            if record.category == 1 && record.messageID != 0 {
+            if record.messageID != 0 {
                 vc.pendingJumpToMessageId = String(record.messageID)
             }
             hostingNavigationController()?.pushViewController(vc, animated: true)


### PR DESCRIPTION
task: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-96
Root Cause
The application previously restricted the message-jumping logic exclusively to notifications belonging to the Mentions tab (category == 1). Consequently, tapping notifications from the Messages tab (category == 2) did not scroll/jump to the specific message in the chat room despite having a valid message ID.

Solution
Removed the category constraint to allow the app to set pendingJumpToMessageId and navigate/scroll to the targeted message for any notification containing a valid messageID.

Test Cases
Tap a notification item in the Mentions tab and verify the app navigates to the chat room and scrolls to the matched message.
Tap a notification item in the Messages tab and verify the app navigates to the private message or channel and scrolls to the matched message.