### PR TITLE
260810-IOS-Handle preview msg and markdown render

### DIFF
--- a/MezonChat/Core/AccountContext/AccountContextImpl.swift
+++ b/MezonChat/Core/AccountContext/AccountContextImpl.swift
@@ -1169,9 +1169,12 @@ final class AccountContextImpl: AccountContext {
                             "timestampSeconds": now, "fromSelf": true
                         ] as [String: Any]
                     )
-                    return
+                    let isDmListMessage = clanId == 0
+                        && (messageCopy.mode == MezonConstants.ChannelStreamMode.dm.rawValue
+                            || messageCopy.mode == MezonConstants.ChannelStreamMode.group.rawValue)
+                    guard isDmListMessage else { return }
                 }
-                let incrementDmBadge = Self.shouldIncrementDmBadgeForSocketMessage(
+                let incrementDmBadge = !isSelf && Self.shouldIncrementDmBadgeForSocketMessage(
                     messageCopy, channelId: channelId,
                     currentUserId: self.currentUser?.id, currentClanId: self.currentClanId
                 )
@@ -1185,8 +1188,11 @@ final class AccountContextImpl: AccountContext {
                 if let raw = try? messageCopy.serializedData() {
                     userInfo["serializedChannelMessage"] = raw
                 }
+                let notificationName = isSelf
+                    ? Notification.Name("MezonDMListMessageReceived")
+                    : Notification.Name("MezonNewMessageReceived")
                 NotificationCenter.default.post(
-                    name: Notification.Name("MezonNewMessageReceived"), object: nil, userInfo: userInfo
+                    name: notificationName, object: nil, userInfo: userInfo
                 )
             }
 
@@ -1233,6 +1239,17 @@ final class AccountContextImpl: AccountContext {
                     mentionsJSON: existing.mentionsJSON
                 )
                 tx.addMessages([updated])
+            }
+            if update.clanID == 0, update.topicID == 0 {
+                let updateCopy = update
+                Task { @MainActor in
+                    guard let raw = try? updateCopy.serializedData() else { return }
+                    NotificationCenter.default.post(
+                        name: Notification.Name("MezonChannelMessageUpdated"),
+                        object: nil,
+                        userInfo: ["serializedChannelMessageUpdate": raw]
+                    )
+                }
             }
 
         case .reaction(let reaction):

--- a/MezonChat/Core/Localization/L10n.swift
+++ b/MezonChat/Core/Localization/L10n.swift
@@ -1074,6 +1074,7 @@ enum L10n {
 
         static let groupCreated   = "directMessage.groupCreated"
         static let previewAttachment = "directMessage.previewAttachment"
+        static let previewFile      = "directMessage.previewFile"
         static let previewLink    = "directMessage.previewLink"
         static let previewLocation = "directMessage.previewLocation"
         static let previewContact = "directMessage.previewContact"
@@ -2224,6 +2225,7 @@ extension L10n {
         "directMessage.createFailed": "Could not create group.",
         "directMessage.groupCreated": "Group created",
         "directMessage.previewAttachment": "Attachment",
+        "directMessage.previewFile": "File",
         "directMessage.previewLink": "Link",
         "directMessage.previewLocation": "Location",
         "directMessage.previewContact": "Contact",
@@ -3468,6 +3470,7 @@ extension L10n {
         "directMessage.createFailed": "Không thể tạo nhóm.",
         "directMessage.groupCreated": "Nhóm đã được tạo",
         "directMessage.previewAttachment": "Đính kèm",
+        "directMessage.previewFile": "Tệp",
         "directMessage.previewLink": "Liên kết",
         "directMessage.previewLocation": "Vị trí",
         "directMessage.previewContact": "Danh bạ",

--- a/MezonChat/Features/Chat/ForwardMessageViewController.swift
+++ b/MezonChat/Features/Chat/ForwardMessageViewController.swift
@@ -740,7 +740,11 @@ final class ForwardMessageViewController: UIViewController {
                 var dms = try await context.account.network.listDirectMessageChannels(token: token)
                 do {
                     let badgeResponse = try await context.account.network.listChannelBadgeCount(clanId: 0, token: token)
-                    ChannelUnreadBadgeSync.mergeSocketBadgeRows(into: &dms, badgeRows: badgeResponse.channeldesc)
+                    ChannelUnreadBadgeSync.mergeSocketBadgeRows(
+                        into: &dms,
+                        badgeRows: badgeResponse.channeldesc,
+                        preserveContentAcrossMessageIds: false
+                    )
                 } catch {}
 
                 dmList = dms.filter { ch in

--- a/MezonChat/Features/Clans/ClanListViewController.swift
+++ b/MezonChat/Features/Clans/ClanListViewController.swift
@@ -630,7 +630,11 @@ final class ClanListViewController: ViewController {
                     let badgeRows = try await self.context.account.network.listChannelBadgeCount(clanId: 0, token: token)
                         .channeldesc
                     guard self.context.isStillCurrentSession(epoch: startEpoch) else { return }
-                    ChannelUnreadBadgeSync.mergeSocketBadgeRows(into: &channels, badgeRows: badgeRows)
+                    ChannelUnreadBadgeSync.mergeSocketBadgeRows(
+                        into: &channels,
+                        badgeRows: badgeRows,
+                        preserveContentAcrossMessageIds: false
+                    )
                 } catch {
                 }
                 let unread = channels.filter { $0.countMessUnread > 0 }

--- a/MezonChat/Features/DirectMessages/DirectMessagesViewController.swift
+++ b/MezonChat/Features/DirectMessages/DirectMessagesViewController.swift
@@ -14,6 +14,111 @@ struct DirectMessagesState {
         incomingFriendRequestCount: 0, messageActivityRows: [], resolvedAvatarURLByChannelId: [:])
 }
 
+enum DMListPreviewCache {
+    static func content(_ content: String, hasAttachments: Bool) -> String {
+        guard hasAttachments else { return content }
+
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            return #"{"attachments":[{}]}"#
+        }
+
+        guard let data = trimmed.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) else {
+            return content
+        }
+
+        let markedJSON: Any
+        if let object = json as? [String: Any] {
+            markedJSON = addingAttachmentMarker(to: object)
+        } else if let encodedObject = json as? String,
+                  let encodedData = encodedObject.data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: encodedData) as? [String: Any] {
+            markedJSON = addingAttachmentMarker(to: object)
+        } else {
+            return content
+        }
+
+        guard JSONSerialization.isValidJSONObject(markedJSON),
+              let markedData = try? JSONSerialization.data(withJSONObject: markedJSON),
+              let markedContent = String(data: markedData, encoding: .utf8) else {
+            return content
+        }
+        return markedContent
+    }
+
+    @MainActor
+    static func updateLastSentMessage(
+        context: AccountContext,
+        channelId: Int64,
+        fallbackChannel: Mezon_Api_ChannelDescription? = nil,
+        ack: Mezon_Realtime_ChannelMessageAck,
+        content: String,
+        hasAttachments: Bool
+    ) {
+        guard ack.messageID != 0,
+              var channel = context.account.postbox.getDMChannelDescription(channelId: channelId)
+                ?? fallbackChannel else { return }
+
+        let now = UInt32(Date().timeIntervalSince1970)
+        let timestamp = ack.createTimeSeconds > 0 ? ack.createTimeSeconds : now
+        if channel.hasLastSentMessage {
+            let existing = channel.lastSentMessage
+            let existingIsNewer = existing.timestampSeconds > timestamp
+                || (existing.timestampSeconds == timestamp
+                    && existing.id != 0 && existing.id > ack.messageID)
+            guard !existingIsNewer else { return }
+        }
+        var header = Mezon_Api_ChannelMessageHeader()
+        header.id = ack.messageID
+        header.timestampSeconds = timestamp
+        header.senderID = Int64(context.currentUser?.id ?? "") ?? 0
+        header.content = self.content(content, hasAttachments: hasAttachments)
+        channel.lastSentMessage = header
+        channel.updateTimeSeconds = max(channel.updateTimeSeconds, timestamp)
+        context.account.postbox.updateCachedDMChannelDescription(channel)
+        NotificationCenter.default.post(
+            name: .mezonChannelDescriptionDidUpdate,
+            object: nil,
+            userInfo: ["clanId": Int64(0), "channelId": channelId]
+        )
+    }
+
+    private static func addingAttachmentMarker(to object: [String: Any]) -> [String: Any] {
+        var result = object
+        if let nested = result["content"] as? [String: Any] {
+            result["content"] = markedPayload(nested)
+        } else if let nestedString = result["content"] as? String,
+                  let nestedData = nestedString.data(using: .utf8),
+                  let nestedJSON = try? JSONSerialization.jsonObject(with: nestedData),
+                  let nested = nestedJSON as? [String: Any] {
+            let markedNested = markedPayload(nested)
+            if JSONSerialization.isValidJSONObject(markedNested),
+               let data = try? JSONSerialization.data(withJSONObject: markedNested),
+               let string = String(data: data, encoding: .utf8) {
+                result["content"] = string
+            } else {
+                result = markedPayload(result)
+            }
+        } else {
+            result = markedPayload(result)
+        }
+        return result
+    }
+
+    private static func markedPayload(_ payload: [String: Any]) -> [String: Any] {
+        if let attachments = payload["attachments"] as? [Any], !attachments.isEmpty {
+            return payload
+        }
+        if let attachments = payload["a"] as? [Any], !attachments.isEmpty {
+            return payload
+        }
+        var result = payload
+        result["attachments"] = [[String: Any]()]
+        return result
+    }
+}
+
 final class DirectMessagesViewController: ViewController {
 
     private let context: AccountContext
@@ -114,6 +219,8 @@ final class DirectMessagesViewController: ViewController {
         view.backgroundColor = UIColor.theme.secondary
         NotificationCenter.default.addObserver(self, selector: #selector(handleChannelMarkedAsRead(_:)), name: Notification.Name("MezonChannelMarkedAsRead"), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleNewMessageReceived(_:)), name: Notification.Name("MezonNewMessageReceived"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleNewMessageReceived(_:)), name: Notification.Name("MezonDMListMessageReceived"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleChannelMessageUpdated(_:)), name: Notification.Name("MezonChannelMessageUpdated"), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleSocketReconnectForDMBadges(_:)), name: .mezonSocketStatusChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleChannelDescriptionDidUpdate(_:)), name: .mezonChannelDescriptionDidUpdate, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleDirectMessagesThemeChange), name: ThemeManager.didChangeNotification, object: nil)
@@ -193,7 +300,11 @@ final class DirectMessagesViewController: ViewController {
             let rows = badgeResponse.channeldesc
             guard !rows.isEmpty else { return }
             var updated = directMessages
-            ChannelUnreadBadgeSync.mergeSocketBadgeRows(into: &updated, badgeRows: rows)
+            ChannelUnreadBadgeSync.mergeSocketBadgeRows(
+                into: &updated,
+                badgeRows: rows,
+                preserveContentAcrossMessageIds: false
+            )
             updated.sort { ch1, ch2 in
                 let t1 = ch1.hasLastSentMessage ? ch1.lastSentMessage.timestampSeconds : 0
                 let t2 = ch2.hasLastSentMessage ? ch2.lastSentMessage.timestampSeconds : 0
@@ -230,7 +341,8 @@ final class DirectMessagesViewController: ViewController {
             let isDmOrGroup =
                 m.mode == MezonConstants.ChannelStreamMode.dm.rawValue
                 || m.mode == MezonConstants.ChannelStreamMode.group.rawValue
-            if isDmOrGroup, !isMutation, Self.applyUpdateDmLastSentMessage(m, to: &directMessages) {
+            if isDmOrGroup, !isMutation,
+               Self.applyUpdateDmLastSentMessage(m, to: &directMessages) {
                 needsReload = true
             }
         }
@@ -281,8 +393,41 @@ final class DirectMessagesViewController: ViewController {
         h.id = m.messageID
         h.timestampSeconds = m.createTimeSeconds
         h.senderID = m.senderID
-        h.content = m.content
+        h.content = DMListPreviewCache.content(
+            m.content,
+            hasAttachments: !m.attachments.isEmpty
+        )
         return h
+    }
+
+    @objc private func handleChannelMessageUpdated(_ notification: Notification) {
+        guard let data = notification.userInfo?["serializedChannelMessageUpdate"] as? Data,
+              let update = try? Mezon_Realtime_ChannelMessageUpdate(serializedBytes: data),
+              update.clanID == 0,
+              update.topicID == 0,
+              let index = directMessages.firstIndex(where: { $0.channelID == update.channelID }),
+              directMessages[index].hasLastSentMessage,
+              directMessages[index].lastSentMessage.id == update.messageID else {
+            return
+        }
+
+        let hasAttachments = !update.attachments.isEmpty
+        let updatedContent = update.content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard hasAttachments || !updatedContent.isEmpty else { return }
+
+        var header = directMessages[index].lastSentMessage
+        let baseContent = updatedContent.isEmpty ? header.content : update.content
+        header.content = DMListPreviewCache.content(
+            baseContent,
+            hasAttachments: hasAttachments
+        )
+        if update.createTimeSeconds > 0 {
+            header.timestampSeconds = update.createTimeSeconds
+        }
+        directMessages[index].lastSentMessage = header
+        directMessagesPipe.putNext(directMessages)
+        needsReloadPipe.putNext(())
+        persistDmChannelListToPostbox()
     }
 
     @discardableResult
@@ -292,8 +437,22 @@ final class DirectMessagesViewController: ViewController {
         var incoming = lastSentHeader(from: m)
         if list[idx].hasLastSentMessage {
             let existing = list[idx].lastSentMessage
+            let incomingIsOlder: Bool
+            if incoming.id != 0, existing.id != 0 {
+                incomingIsOlder = incoming.id < existing.id
+                    || (incoming.id == existing.id
+                        && incoming.timestampSeconds < existing.timestampSeconds)
+            } else {
+                incomingIsOlder = incoming.timestampSeconds != 0
+                    && incoming.timestampSeconds < existing.timestampSeconds
+            }
+            guard !incomingIsOlder else { return false }
+            let isSameMessage = incoming.id != 0 && incoming.id == existing.id
+            let hasNoNewerIdentity = incoming.id == 0
+                && incoming.timestampSeconds <= existing.timestampSeconds
             if incoming.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-               !existing.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+               !existing.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+               isSameMessage || hasNoNewerIdentity {
                 incoming.content = existing.content
             }
             if incoming.id == 0 { incoming.id = existing.id }
@@ -898,14 +1057,21 @@ final class DirectMessagesViewController: ViewController {
             let existing = cached.lastSentMessage
             let incomingBlank = incoming.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             let existingHasPreview = !existing.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            let existingLooksNewer =
-                existing.id > incoming.id
-                || (existing.id == incoming.id && existing.timestampSeconds > incoming.timestampSeconds)
+            let existingLooksNewer: Bool
+            if existing.id != 0, incoming.id != 0 {
+                existingLooksNewer = existing.id > incoming.id
+                    || (existing.id == incoming.id
+                        && existing.timestampSeconds > incoming.timestampSeconds)
+            } else {
+                existingLooksNewer = existing.timestampSeconds > incoming.timestampSeconds
+            }
+            let hasNoNewerIdentity = incoming.id == 0
+                && incoming.timestampSeconds <= existing.timestampSeconds
 
             var next = incoming
-            if existingLooksNewer, existingHasPreview {
+            if existingLooksNewer {
                 next = existing
-            } else if incomingBlank, existingHasPreview {
+            } else if incomingBlank, existingHasPreview, hasNoNewerIdentity {
                 next.content = existing.content
                 if next.senderID == 0 { next.senderID = existing.senderID }
                 if next.id == 0 { next.id = existing.id }
@@ -1241,7 +1407,10 @@ final class DirectMessagesViewController: ViewController {
                     let badgeResponse = try await self.context.account.network.listChannelBadgeCount(
                         clanId: 0, token: token)
                     ChannelUnreadBadgeSync.mergeSocketBadgeRows(
-                        into: &channels, badgeRows: badgeResponse.channeldesc)
+                        into: &channels,
+                        badgeRows: badgeResponse.channeldesc,
+                        preserveContentAcrossMessageIds: false
+                    )
                     channels = Self.mergeDmApiRowsPreservingCachedPreview(channels, cached: cachedRows)
                 } catch {
                 }
@@ -1282,7 +1451,10 @@ final class DirectMessagesViewController: ViewController {
                     let badgeResponse = try await self.context.account.network.listChannelBadgeCount(
                         clanId: 0, token: token)
                     ChannelUnreadBadgeSync.mergeSocketBadgeRows(
-                        into: &channels, badgeRows: badgeResponse.channeldesc)
+                        into: &channels,
+                        badgeRows: badgeResponse.channeldesc,
+                        preserveContentAcrossMessageIds: false
+                    )
                     channels = Self.mergeDmApiRowsPreservingCachedPreview(channels, cached: cachedRows)
                 } catch {
                 }

--- a/MezonChat/Features/DirectMessages/DmListItemCell.swift
+++ b/MezonChat/Features/DirectMessages/DmListItemCell.swift
@@ -419,8 +419,26 @@ final class DmListItemCell: UITableViewCell {
             }
             return Self.previewWhenNoMessageBody()
         }
-        let body = Self.normalizeJsonEscapedSlashes(in: preview)
+        let body = Self.stripHeadingMarkdown(
+            from: Self.normalizeJsonEscapedSlashes(in: preview)
+        )
         return Self.appendPreviewEllipsisIfTruncated(body)
+    }
+
+    private static let headingMarkdownRegex = try? NSRegularExpression(
+        pattern: #"^#{1,6}\s+"#,
+        options: [.anchorsMatchLines]
+    )
+
+    private static func stripHeadingMarkdown(from text: String) -> String {
+        guard let headingMarkdownRegex else { return text }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        return headingMarkdownRegex.stringByReplacingMatches(
+            in: text,
+            options: [],
+            range: range,
+            withTemplate: ""
+        )
     }
 
     private static func appendPreviewEllipsisIfTruncated(_ body: String) -> String {

--- a/MezonChat/Features/DirectMessages/DmListItemCell.swift
+++ b/MezonChat/Features/DirectMessages/DmListItemCell.swift
@@ -433,7 +433,7 @@ final class DmListItemCell: UITableViewCell {
     private static let contentKeysAllowingEmptyAttachmentInference: Set<String> = ["t", "mk", "ej", "hg"]
 
     private static func attachmentBracketPreviewText() -> String {
-        "[\(L(L10n.DirectMessage.previewAttachment))]"
+        "[\(L(L10n.DirectMessage.previewFile))]"
     }
 
     private static func shouldInferAttachmentOnlyListPreview(msg: Mezon_Api_ChannelMessageHeader) -> Bool {

--- a/MezonChat/Features/SendMessageInput/AttachmentUploadCoordinator.swift
+++ b/MezonChat/Features/SendMessageInput/AttachmentUploadCoordinator.swift
@@ -600,6 +600,15 @@ final class AttachmentUploadCoordinator {
                 return
             }
             register(session, key: "\(ack.messageID)")
+            if p.clanId == 0, p.topicId == 0 {
+                DMListPreviewCache.updateLastSentMessage(
+                    context: context,
+                    channelId: p.channelId,
+                    ack: ack,
+                    content: contentStr,
+                    hasAttachments: !attachments.isEmpty
+                )
+            }
             context.account.postbox.write { tx in
                 let pending = tx.getMessageById(p.localId)
                 let attachmentsJSON: Data = {

--- a/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
+++ b/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
@@ -1906,32 +1906,18 @@ final class SendMessageInputViewController: UIViewController {
 
     private func updateCachedDMLastSentMessageIfNeeded(
         ack: Mezon_Realtime_ChannelMessageAck,
-        fallbackContent: String
+        fallbackContent: String,
+        hasAttachments: Bool = false
     ) {
-        let isDmListChannel = channel.type == MezonConstants.ChannelType.dm.rawValue
-            || channel.type == MezonConstants.ChannelType.group.rawValue
-            || clanId == 0
-        guard isDmListChannel else { return }
+        guard clanId == 0, topicId == 0 else { return }
 
-        let now = UInt32(Date().timeIntervalSince1970)
-        let timestamp = ack.createTimeSeconds > 0 ? ack.createTimeSeconds : now
-        var header = Mezon_Api_ChannelMessageHeader()
-        header.id = ack.messageID
-        header.timestampSeconds = timestamp
-        header.senderID = Int64(context.currentUser?.id ?? "") ?? 0
-        header.content = fallbackContent
-
-        var updated = context.account.postbox.getDMChannelDescription(channelId: channel.channelID) ?? channel
-        updated.lastSentMessage = header
-        updated.updateTimeSeconds = max(updated.updateTimeSeconds, timestamp)
-        context.account.postbox.updateCachedDMChannelDescription(updated)
-        NotificationCenter.default.post(
-            name: .mezonChannelDescriptionDidUpdate,
-            object: nil,
-            userInfo: [
-                "clanId": Int64(0),
-                "channelId": channel.channelID,
-            ]
+        DMListPreviewCache.updateLastSentMessage(
+            context: context,
+            channelId: channel.channelID,
+            fallbackChannel: channel,
+            ack: ack,
+            content: fallbackContent,
+            hasAttachments: hasAttachments
         )
     }
 
@@ -6263,6 +6249,11 @@ final class SendMessageInputViewController: UIViewController {
                         topicId: self.topicId,
                         token: token
                     )
+                    self.updateCachedDMLastSentMessageIfNeeded(
+                        ack: ack,
+                        fallbackContent: contentStr,
+                        hasAttachments: !uploadedAttachments.isEmpty
+                    )
                     if !sendAsAnonymous {
                         let fallbackSenderId = self.context.currentUser?.id ?? ""
                         let fallbackClanId: String? = clanId == 0 ? nil : "\(clanId)"
@@ -6475,6 +6466,11 @@ final class SendMessageInputViewController: UIViewController {
                     avatar: avatar,
                     topicId: self.topicId,
                     token: token
+                )
+                self.updateCachedDMLastSentMessageIfNeeded(
+                    ack: ack,
+                    fallbackContent: contentStr,
+                    hasAttachments: !attachments.isEmpty
                 )
                 self.markOnboardingWelcomeMessageSentIfNeeded(
                     ack: ack,

--- a/MezonChat/Features/Sharing/SharingViewController.swift
+++ b/MezonChat/Features/Sharing/SharingViewController.swift
@@ -1219,7 +1219,11 @@ final class SharingViewController: UIViewController {
                 var dms = try await self.context.account.network.listDirectMessageChannels(token: token)
                 do {
                     let badgeResponse = try await self.context.account.network.listChannelBadgeCount(clanId: 0, token: token)
-                    ChannelUnreadBadgeSync.mergeSocketBadgeRows(into: &dms, badgeRows: badgeResponse.channeldesc)
+                    ChannelUnreadBadgeSync.mergeSocketBadgeRows(
+                        into: &dms,
+                        badgeRows: badgeResponse.channeldesc,
+                        preserveContentAcrossMessageIds: false
+                    )
                 } catch {
                 }
                 dmList = dms

--- a/MezonChat/Networking/MezonSocket.swift
+++ b/MezonChat/Networking/MezonSocket.swift
@@ -1252,7 +1252,11 @@ enum MezonApiNameRegistry {
 }
 
 enum ChannelUnreadBadgeSync {
-    static func mergeSocketBadgeRows(into channels: inout [Mezon_Api_ChannelDescription], badgeRows: [Mezon_Api_ChannelDescription]) {
+    static func mergeSocketBadgeRows(
+        into channels: inout [Mezon_Api_ChannelDescription],
+        badgeRows: [Mezon_Api_ChannelDescription],
+        preserveContentAcrossMessageIds: Bool = true
+    ) {
         guard !badgeRows.isEmpty else { return }
         var byId: [Int64: Mezon_Api_ChannelDescription] = [:]
         for row in badgeRows {
@@ -1272,12 +1276,29 @@ enum ChannelUnreadBadgeSync {
                     var inc = bi
                     if channels[i].hasLastSentMessage {
                         let ex = channels[i].lastSentMessage
-                        if inc.content.isEmpty, !ex.content.isEmpty {
-                            inc.content = ex.content
-                            if inc.senderID == 0 { inc.senderID = ex.senderID }
-                            if inc.id == 0 { inc.id = ex.id }
+                        let existingLooksNewer: Bool
+                        if ex.id != 0, inc.id != 0 {
+                            existingLooksNewer = ex.id > inc.id
+                                || (ex.id == inc.id && ex.timestampSeconds > inc.timestampSeconds)
+                        } else {
+                            existingLooksNewer = ex.timestampSeconds > inc.timestampSeconds
                         }
-                        inc.timestampSeconds = max(inc.timestampSeconds, ex.timestampSeconds)
+                        if !preserveContentAcrossMessageIds, existingLooksNewer {
+                            inc = ex
+                        } else {
+                            let isSameMessage = inc.id != 0 && inc.id == ex.id
+                            let hasNoNewerIdentity = inc.id == 0
+                                && inc.timestampSeconds <= ex.timestampSeconds
+                            let canReuseExistingContent = preserveContentAcrossMessageIds
+                                || isSameMessage || hasNoNewerIdentity
+                            if inc.content.isEmpty, !ex.content.isEmpty,
+                               canReuseExistingContent {
+                                inc.content = ex.content
+                                if inc.senderID == 0 { inc.senderID = ex.senderID }
+                                if inc.id == 0 { inc.id = ex.id }
+                            }
+                            inc.timestampSeconds = max(inc.timestampSeconds, ex.timestampSeconds)
+                        }
                     }
                     channels[i].lastSentMessage = inc
                 }


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-51
Issue 1: DM Attachment Preview
Root cause: iOS did not preserve attachment information when the last DM had empty text content, causing the preview to appear blank or reuse stale text.
Solution: Store an attachment marker in the DM preview cache and display the localized [File] preview for attachment-only messages.
Test cases:
Verify that sent and received images display [File] in the DM list.
Verify that GIF, PNG, MP4, and MP3 attachments display [File].
Verify that PDF, XLSX, ZIP, and other files display [File].
Verify that a message containing text and an attachment displays the text preview.
Verify that the attachment preview remains correct after refresh or reconnect.

Issue 2: DM Markdown Heading Preview
Root cause: iOS displayed the raw Markdown heading marker from the message text in the DM preview.
Solution: Remove one to six leading # characters followed by whitespace before rendering the DM preview.
Test cases:
Verify that # Heading is displayed as Heading.
Verify that ###### Heading is displayed as Heading.
Verify that #hashtag remains unchanged.
Verify that C# remains unchanged.
Verify that normal non-heading messages remain unchanged.
