### PR TITLE
260810-IOS-Update banner avatar color

### DIFF
--- a/MezonChat/Features/Profile/ProfileContainerNode.swift
+++ b/MezonChat/Features/Profile/ProfileContainerNode.swift
@@ -27,7 +27,7 @@ final class ProfileContainerNode: ASDisplayNode {
 
     private let headerBackgroundView: UIView = {
         let v = UIView()
-        v.backgroundColor = .mezonSecondaryBackground
+        v.backgroundColor = .mezonPrimary
         return v
     }()
 
@@ -375,7 +375,7 @@ final class ProfileContainerNode: ASDisplayNode {
         friendsChevron.tintColor = .mezonTextSecondary
 
         if avatarImageView.image == nil {
-            headerBackgroundView.backgroundColor = .mezonSecondaryBackground
+            headerBackgroundView.backgroundColor = .mezonPrimary
             avatarContainerView.backgroundColor = UIColor.theme.secondaryLight
             avatarPlaceholderLabel.isHidden = false
         } else {
@@ -630,7 +630,7 @@ final class ProfileContainerNode: ASDisplayNode {
         avatarImageView.image = nil
         avatarPlaceholderLabel.isHidden = false
         avatarContainerView.backgroundColor = UIColor.theme.secondaryLight
-        headerBackgroundView.backgroundColor = .mezonSecondaryBackground
+        headerBackgroundView.backgroundColor = .mezonPrimary
         statusBubbleShapeLayer.fillColor = UIColor.mezonSecondaryBackground.cgColor
     }
 
@@ -656,13 +656,13 @@ final class ProfileContainerNode: ASDisplayNode {
                 avatarImageView.image = cached
                 avatarPlaceholderLabel.isHidden = true
                 avatarContainerView.backgroundColor = .clear
-                headerBackgroundView.backgroundColor = cached.dominantColor() ?? .mezonSecondaryBackground
+                headerBackgroundView.backgroundColor = cached.dominantColor() ?? .mezonPrimary
                 statusBubbleShapeLayer.fillColor = UIColor.mezonSecondaryBackground.cgColor
             } else {
                 avatarImageView.image = nil
                 avatarPlaceholderLabel.isHidden = false
                 avatarContainerView.backgroundColor = UIColor.theme.secondaryLight
-                headerBackgroundView.backgroundColor = .mezonSecondaryBackground
+                headerBackgroundView.backgroundColor = .mezonPrimary
                 statusBubbleShapeLayer.fillColor = UIColor.mezonSecondaryBackground.cgColor
                 ImageCache.shared.loadAvatar(urlString: proxiedURLString) { [weak self] image in
                     guard let self else { return }
@@ -671,7 +671,7 @@ final class ProfileContainerNode: ASDisplayNode {
                         self.avatarImageView.image = image
                         self.avatarPlaceholderLabel.isHidden = true
                         self.avatarContainerView.backgroundColor = .clear
-                        self.headerBackgroundView.backgroundColor = image.dominantColor() ?? .mezonSecondaryBackground
+                        self.headerBackgroundView.backgroundColor = image.dominantColor() ?? .mezonPrimary
                         self.statusBubbleShapeLayer.fillColor = UIColor.mezonSecondaryBackground.cgColor
                     } else if proxiedURLString != rawURLString {
                         ImageCache.shared.loadAvatar(urlString: rawURLString) { [weak self] rawImage in
@@ -681,7 +681,7 @@ final class ProfileContainerNode: ASDisplayNode {
                                 self.avatarImageView.image = rawImage
                                 self.avatarPlaceholderLabel.isHidden = true
                                 self.avatarContainerView.backgroundColor = .clear
-                                self.headerBackgroundView.backgroundColor = rawImage.dominantColor() ?? .mezonSecondaryBackground
+                                self.headerBackgroundView.backgroundColor = rawImage.dominantColor() ?? .mezonPrimary
                                 self.statusBubbleShapeLayer.fillColor = UIColor.mezonSecondaryBackground.cgColor
                             } else {
                                 self.applyProfileAvatarPlaceholder()


### PR DESCRIPTION
task: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-218
Root Cause: The default profile banner used the secondary color, making it blend into the surrounding background in the light theme.
Solution: Use the primary color for the default and fallback banner while preserving the avatar’s dominant color when available.
Test Cases:
Verify the banner uses the primary color when the user has no avatar.
Verify the banner uses the avatar’s dominant color when an avatar is available.
Verify the banner falls back to the primary color when avatar loading fails.
Verify the banner colors update correctly after switching themes.

