### PR TITLE
260811-IOS-Handle markdown preview DM

### DIFF
--- a/MezonChat/Features/DirectMessages/DmListItemCell.swift
+++ b/MezonChat/Features/DirectMessages/DmListItemCell.swift
@@ -419,8 +419,26 @@ final class DmListItemCell: UITableViewCell {
             }
             return Self.previewWhenNoMessageBody()
         }
-        let body = Self.normalizeJsonEscapedSlashes(in: preview)
+        let body = Self.stripHeadingMarkdown(
+            from: Self.normalizeJsonEscapedSlashes(in: preview)
+        )
         return Self.appendPreviewEllipsisIfTruncated(body)
+    }
+
+    private static let headingMarkdownRegex = try? NSRegularExpression(
+        pattern: #"^#{1,6}\s+"#,
+        options: [.anchorsMatchLines]
+    )
+
+    private static func stripHeadingMarkdown(from text: String) -> String {
+        guard let headingMarkdownRegex else { return text }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        return headingMarkdownRegex.stringByReplacingMatches(
+            in: text,
+            options: [],
+            range: range,
+            withTemplate: ""
+        )
     }
 
     private static func appendPreviewEllipsisIfTruncated(_ body: String) -> String {


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-51
Root cause: The DM list rendered raw Markdown text, so the heading prefix remained visible.
Solution: Strip valid Markdown heading prefixes before rendering the preview.
Test cases:
Verify # alo12434 displays as alo12434.
Verify ###### title displays as title.
Verify #hashtag remains unchanged.
Verify normal text and attachment previews remain unchanged.