### PR TITLE
260811-IOS-Handle fallback postbox data reply

### DIFF
--- a/MezonChat/Features/Chat/Cells/MessageReplyNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageReplyNode.swift
@@ -69,7 +69,9 @@ final class MessageReplyNode: ASDisplayNode {
         let name = ref.messageSenderClanNick.isEmpty
             ? (ref.messageSenderDisplayName.isEmpty ? ref.messageSenderUsername : ref.messageSenderDisplayName)
             : ref.messageSenderClanNick
-        let displayName = name.isEmpty ? "Anonymous" : name
+        let displayName = ref.messageSenderID == MezonConstants.anonymousUserId
+            ? "Anonymous"
+            : (name.isEmpty ? "\(ref.messageSenderID)" : name)
 
         nameNode.attributedText = NSAttributedString(
             string: displayName,
@@ -136,7 +138,7 @@ final class MessageReplyNode: ASDisplayNode {
             avatarImageNode.isHidden = true
             avatarPlaceholderNode.isHidden = false
             
-            let charSource = ref.messageSenderUsername
+            let charSource = ref.messageSenderUsername.isEmpty ? displayName : ref.messageSenderUsername
             let charStr = String(charSource.prefix(1)).uppercased()
             
             avatarPlaceholderNode.attributedText = NSAttributedString(

--- a/MezonChat/Features/Chat/ChatViewController.swift
+++ b/MezonChat/Features/Chat/ChatViewController.swift
@@ -2926,6 +2926,60 @@ final class ChatViewController: ViewController {
         return out
     }
 
+    private func enrichReplyRefsFromPostbox(
+        _ refsByMessageId: [String: Mezon_Api_MessageRef]
+    ) -> [String: Mezon_Api_MessageRef] {
+        let refsToEnrich = refsByMessageId.filter { _, ref in
+            guard ref.messageSenderID != 0,
+                  ref.messageSenderID != MezonConstants.anonymousUserId else { return false }
+            let hasName = !ref.messageSenderClanNick.isEmpty
+                || !ref.messageSenderDisplayName.isEmpty
+                || !ref.messageSenderUsername.isEmpty
+            return !hasName || ref.messageSenderAvatar.isEmpty
+        }
+        guard !refsToEnrich.isEmpty else { return refsByMessageId }
+
+        var result = refsByMessageId
+        let senderIds = Set(refsToEnrich.values.map(\.messageSenderID))
+        context.account.postbox.read { tx in
+            var membersByUserId: [Int64: ClanMemberRecord] = [:]
+            if clanId != 0 {
+                for member in tx.getClanMembers(clanId: clanId) where senderIds.contains(member.userId) {
+                    membersByUserId[member.userId] = member
+                    if membersByUserId.count == senderIds.count { break }
+                }
+            }
+            for (messageId, ref) in refsToEnrich {
+                let senderId = ref.messageSenderID
+                let member = membersByUserId[senderId]
+                let profile = tx.getProfile(userId: "\(senderId)")
+                var enriched = ref
+
+                if ref.messageSenderClanNick.isEmpty,
+                   ref.messageSenderDisplayName.isEmpty,
+                   ref.messageSenderUsername.isEmpty {
+                    let memberDisplayName = member?.displayName ?? ""
+                    let memberUsername = member?.username ?? ""
+                    enriched.messageSenderClanNick = member?.clanNick ?? ""
+                    enriched.messageSenderDisplayName = memberDisplayName.isEmpty
+                        ? profile?.displayName ?? ""
+                        : memberDisplayName
+                    enriched.messageSenderUsername = memberUsername.isEmpty
+                        ? profile?.username ?? ""
+                        : memberUsername
+                }
+
+                let avatar = member?.resolvedAvatarURL(fallbackProfileAvatar: profile?.avatarUrl)
+                    ?? profile?.avatarUrl
+                if ref.messageSenderAvatar.isEmpty, let avatar, !avatar.isEmpty {
+                    enriched.messageSenderAvatar = avatar
+                }
+                result[messageId] = enriched
+            }
+        }
+        return result
+    }
+
     private func buildDisplayMessages(from records: [MessageRecord]) -> [ChatMessageDisplay] {
         let currentUserId = context.currentUser?.id
         let validRecords = records.filter { !$0.id.isEmpty && !$0.channelId.isEmpty }
@@ -2933,6 +2987,13 @@ final class ChatViewController: ViewController {
 
         let senderIds = Set(validRecords.map(\.senderId))
         let profilesBySenderId = cachedSenderProfilesBySenderId(senderIds: senderIds)
+        var replyInfoByMessageId: [String: (ref: Mezon_Api_MessageRef?, isDeletedReply: Bool)] = [:]
+        for record in validRecords {
+            replyInfoByMessageId[record.id] = Self.firstReplyRef(from: record.referencesData)
+        }
+        let enrichedReplyRefsByMessageId = enrichReplyRefsFromPostbox(
+            replyInfoByMessageId.compactMapValues { $0.ref }
+        )
 
         let currentUserRoleIds: Set<Int64> = {
             guard let roleList = context.engine.clanData.getUserPermissions(clanId: clanId) else { return [] }
@@ -3017,7 +3078,9 @@ final class ChatViewController: ViewController {
             }
 
             let reactions = Self.parseReactions(record.reactionsJSON, currentUserId: currentUserId)
-            let (replyRef, isDeletedReply) = Self.firstReplyRef(from: record.referencesData)
+            let replyInfo = replyInfoByMessageId[record.id] ?? (ref: nil, isDeletedReply: false)
+            let replyRef = enrichedReplyRefsByMessageId[record.id] ?? replyInfo.ref
+            let isDeletedReply = replyInfo.isDeletedReply
             let bodyEmpty = parsed.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             let senderLabel = record.senderDisplayName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
             let isWelcome = record.senderId == "0" && bodyEmpty && senderLabel == "system"


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-237
Root cause: Reply references sometimes omit sender name and avatar, while iOS trusted only the reference data and incorrectly defaulted missing names to Anonymous.
Solution: For non-anonymous senders, fill missing reply identity from Postbox using clanNick → displayName → username and clanAvatar → user/profile avatar, while preserving reference data.
Test cases:
Verify a reply with complete reference identity remains unchanged.
Verify missing name and avatar are resolved from Postbox.
Verify only a missing name is filled from Postbox.
Verify only a missing avatar is filled from Postbox.
Verify the anonymous user ID always displays Anonymous.
Verify a cache miss displays the sender ID instead of Anonymous.