### PR TITLE
260813-IOS-Fix bug order sort clan member

### DIFF
--- a/MezonChat/Core/MezonEngine/MezonEngine+ClanData.swift
+++ b/MezonChat/Core/MezonEngine/MezonEngine+ClanData.swift
@@ -262,9 +262,10 @@ extension MezonEngine {
         private func persistClanUsersResponse(clanId: Int64, response: Mezon_Api_ClanUserList) {
             let responseMembers = response.clanUsers.map { ClanMemberRecord(from: $0) }
             let existingMembers = postbox.read { tx in tx.getClanMembers(clanId: clanId) }
-            var merged: [Int64: ClanMemberRecord] = Dictionary(existingMembers.map { ($0.userId, $0) }, uniquingKeysWith: { $1 })
-            for m in responseMembers { merged[m.userId] = m }
-            let finalMembers = Array(merged.values)
+            var seenUserIds = Set<Int64>()
+            let finalMembers = (responseMembers + existingMembers).filter {
+                seenUserIds.insert($0.userId).inserted
+            }
             postbox.write { tx in
                 for clanUser in response.clanUsers {
                     tx.updateProfile(ProfileRecord(from: clanUser))


### PR DESCRIPTION
task: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-25
Root Cause: iOS merged clan members using Dictionary.values, which did not preserve the member order returned by the API, unlike Android.

Solution: Preserve the API response order while removing duplicate members and appending cached-only members afterward.

Test Cases:
Verify the iOS member list order matches Android for the same clan.
Verify the member order remains correct after reopening the member list.
