### PR TITLE
260813-IOS-Fix bug realtime tab DM

### DIFF
--- a/MezonChat/Core/AccountContext/AccountContextImpl.swift
+++ b/MezonChat/Core/AccountContext/AccountContextImpl.swift
@@ -1169,9 +1169,12 @@ final class AccountContextImpl: AccountContext {
                             "timestampSeconds": now, "fromSelf": true
                         ] as [String: Any]
                     )
-                    return
+                    let isDmListMessage = clanId == 0
+                        && (messageCopy.mode == MezonConstants.ChannelStreamMode.dm.rawValue
+                            || messageCopy.mode == MezonConstants.ChannelStreamMode.group.rawValue)
+                    guard isDmListMessage else { return }
                 }
-                let incrementDmBadge = Self.shouldIncrementDmBadgeForSocketMessage(
+                let incrementDmBadge = !isSelf && Self.shouldIncrementDmBadgeForSocketMessage(
                     messageCopy, channelId: channelId,
                     currentUserId: self.currentUser?.id, currentClanId: self.currentClanId
                 )
@@ -1185,8 +1188,11 @@ final class AccountContextImpl: AccountContext {
                 if let raw = try? messageCopy.serializedData() {
                     userInfo["serializedChannelMessage"] = raw
                 }
+                let notificationName = isSelf
+                    ? Notification.Name("MezonDMListMessageReceived")
+                    : Notification.Name("MezonNewMessageReceived")
                 NotificationCenter.default.post(
-                    name: Notification.Name("MezonNewMessageReceived"), object: nil, userInfo: userInfo
+                    name: notificationName, object: nil, userInfo: userInfo
                 )
             }
 

--- a/MezonChat/Core/Display/TabBarControllerImpl.swift
+++ b/MezonChat/Core/Display/TabBarControllerImpl.swift
@@ -62,7 +62,9 @@ open class TabBarControllerImpl: ViewController, TabBarController {
                 let bottomInset = validLayout.safeInsets.bottom
                 let tabBarHeight = TabBarNode.barHeight + bottomInset
                 updatedLayout.intrinsicInsets.bottom = tabBarHeight
-                self.controllers[index].containerLayoutUpdated(updatedLayout, transition: .immediate)
+                let controller = self.controllers[index]
+                controller.loadViewIfNeeded()
+                controller.containerLayoutUpdated(updatedLayout, transition: .immediate)
             }
 
             self.pendingControllerDisposable.set(

--- a/MezonChat/Features/DirectMessages/DirectMessagesViewController.swift
+++ b/MezonChat/Features/DirectMessages/DirectMessagesViewController.swift
@@ -114,6 +114,7 @@ final class DirectMessagesViewController: ViewController {
         view.backgroundColor = UIColor.theme.secondary
         NotificationCenter.default.addObserver(self, selector: #selector(handleChannelMarkedAsRead(_:)), name: Notification.Name("MezonChannelMarkedAsRead"), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleNewMessageReceived(_:)), name: Notification.Name("MezonNewMessageReceived"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleNewMessageReceived(_:)), name: Notification.Name("MezonDMListMessageReceived"), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleSocketReconnectForDMBadges(_:)), name: .mezonSocketStatusChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleChannelDescriptionDidUpdate(_:)), name: .mezonChannelDescriptionDidUpdate, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleDirectMessagesThemeChange), name: ThemeManager.didChangeNotification, object: nil)


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-269
Root Cause: The custom tab bar triggered layout before UIKit loaded the DM controller, causing viewDidLoad and its socket observers to be skipped; self-authored DM events were also filtered out.
Solution: Load the controller through UIKit before layout and forward self-authored DM/group socket events to the DM list without incrementing unread count.

Test Cases:
Verify an incoming DM updates the preview, timestamp, and order in real time while staying on the Messages tab.
Verify a DM sent from another device using the same account updates the list without increasing unread count.
