### PR TITLE
260818-IOS-Update share video and improve app stability

### DIFF
--- a/MezonChat/Core/Localization/L10n.swift
+++ b/MezonChat/Core/Localization/L10n.swift
@@ -1138,6 +1138,8 @@ enum L10n {
         static let videoSaved = "gallery.videoSaved"
         static let videoSaveFailed = "gallery.videoSaveFailed"
         static let videoDownloading = "gallery.videoDownloading"
+        static let videoPreparingForShare = "gallery.videoPreparingForShare"
+        static let videoShareFailed = "gallery.videoShareFailed"
         static let videoSaving = "gallery.videoSaving"
         static let imageLoadFailed = "gallery.imageLoadFailed"
         static let photoPermissionDenied = "gallery.photoPermissionDenied"
@@ -2272,6 +2274,8 @@ extension L10n {
         "gallery.videoSaved": "Video saved",
         "gallery.videoSaveFailed": "Could not save video",
         "gallery.videoDownloading": "Downloading video...",
+        "gallery.videoPreparingForShare": "Preparing video...",
+        "gallery.videoShareFailed": "Could not prepare video for sharing",
         "gallery.videoSaving": "Saving video...",
         "gallery.imageLoadFailed": "Could not load image",
         "gallery.photoPermissionDenied": "Allow photo access to save images",
@@ -3543,6 +3547,8 @@ extension L10n {
         "gallery.videoSaved": "Đã lưu video",
         "gallery.videoSaveFailed": "Không thể lưu video",
         "gallery.videoDownloading": "Đang tải video...",
+        "gallery.videoPreparingForShare": "Đang chuẩn bị video...",
+        "gallery.videoShareFailed": "Không thể chuẩn bị video để chia sẻ",
         "gallery.videoSaving": "Đang lưu video...",
         "gallery.imageLoadFailed": "Không thể tải ảnh",
         "gallery.photoPermissionDenied": "Vui lòng cấp quyền ảnh để lưu ảnh",

--- a/MezonChat/Core/UI/Gallery/ChatVideoGalleryItemNode.swift
+++ b/MezonChat/Core/UI/Gallery/ChatVideoGalleryItemNode.swift
@@ -5,6 +5,7 @@ import AsyncDisplayKit
 final class ChatVideoGalleryItemNode: GalleryItemNode {
 
     private var playerNode: UniversalVideoPlayerNode?
+    var isPlaying: Bool { playerNode?.isPlaying == true }
     var controlsBottomInset: CGFloat = 0 {
         didSet { playerNode?.controlsBottomInset = controlsBottomInset }
     }
@@ -50,5 +51,12 @@ final class ChatVideoGalleryItemNode: GalleryItemNode {
             playerNode?.pause()
         }
     }
-}
 
+    func play() {
+        playerNode?.play()
+    }
+
+    func pause() {
+        playerNode?.pause()
+    }
+}

--- a/MezonChat/Core/UI/Gallery/GalleryController.swift
+++ b/MezonChat/Core/UI/Gallery/GalleryController.swift
@@ -4,21 +4,7 @@ import AsyncDisplayKit
 import Photos
 import AVFoundation
 
-private struct GalleryVideoSharePayload: Codable {
-    static let internalScheme = "mezon-video-share"
-    static let appGroupIdentifier = "group.mezon.mobile"
-    static let tokenKeyPrefix = "mezon.video-share.token."
-    static let tokenLifetime: TimeInterval = 10 * 60
-
-    let url: String
-    let thumbnail: String
-    let filename: String
-    let filetype: String
-    let size: Int64
-    let width: Int
-    let height: Int
-    let durationSeconds: Int
-
+private extension ExistingVideoSharePayload {
     init?(item: GalleryItemInfo) {
         let source = (item.sourceURL ?? item.url).trimmingCharacters(in: .whitespacesAndNewlines)
         guard !source.isEmpty, let sourceURL = URL(string: source) else { return nil }
@@ -32,16 +18,19 @@ private struct GalleryVideoSharePayload: Codable {
             ? metadataFilename
             : (!remoteFilename.isEmpty ? remoteFilename : "video.\(fallbackExtension)")
 
-        url = source
-        thumbnail = metadata?.thumbnail ?? ""
-        filename = (candidateFilename as NSString).pathExtension.isEmpty
+        let filename = (candidateFilename as NSString).pathExtension.isEmpty
             ? "\(candidateFilename).\(fallbackExtension)"
             : candidateFilename
-        filetype = Self.resolvedMimeType(metadata?.filetype, pathExtension: fallbackExtension)
-        size = max(metadata?.size ?? 0, 0)
-        width = max(Int(item.pixelSize?.width ?? 0), 0)
-        height = max(Int(item.pixelSize?.height ?? 0), 0)
-        durationSeconds = max(metadata?.durationSeconds ?? 0, 0)
+        self.init(
+            url: source,
+            thumbnail: metadata?.thumbnail ?? "",
+            filename: filename,
+            filetype: Self.resolvedMimeType(metadata?.filetype, pathExtension: fallbackExtension),
+            size: max(metadata?.size ?? 0, 0),
+            width: max(Int(item.pixelSize?.width ?? 0), 0),
+            height: max(Int(item.pixelSize?.height ?? 0), 0),
+            durationSeconds: max(metadata?.durationSeconds ?? 0, 0)
+        )
     }
 
     private static func resolvedMimeType(_ raw: String?, pathExtension: String) -> String {
@@ -63,11 +52,6 @@ private struct GalleryVideoSharePayload: Codable {
     }
 }
 
-private struct GalleryVideoShareTokenRecord: Codable {
-    let createdAt: TimeInterval
-    let payload: GalleryVideoSharePayload
-}
-
 private enum GalleryVideoSharePreparationError: Error {
     case unavailable
 }
@@ -76,9 +60,8 @@ private final class GalleryVideoActivityItemProvider: UIActivityItemProvider {
     private static let mezonActivityIdentifier = "mezon.mobile.mezonsharing"
     private static let shareCacheMaxBytes: Int64 = 512 * 1024 * 1024
 
-    private let payload: GalleryVideoSharePayload
+    private let payload: ExistingVideoSharePayload
     private let sourceURL: URL
-    private let failurePlaceholderURL: URL
     private let stateLock = NSLock()
     private var activeDownloadTask: URLSessionDownloadTask?
     private var downloadedURL: URL?
@@ -90,12 +73,12 @@ private final class GalleryVideoActivityItemProvider: UIActivityItemProvider {
     var preparationFailedHandler: ((Error, @escaping () -> Void) -> Void)?
     var photoLibrarySaveHandler: (() -> Void)?
 
-    init(payload: GalleryVideoSharePayload) {
+    init?(payload: ExistingVideoSharePayload) {
+        guard let sourceURL = URL(string: payload.url) else { return nil }
         let placeholderURL = FileManager.default.temporaryDirectory
             .appendingPathComponent((payload.filename as NSString).lastPathComponent)
         self.payload = payload
-        self.sourceURL = URL(string: payload.url)!
-        self.failurePlaceholderURL = placeholderURL
+        self.sourceURL = sourceURL
         super.init(placeholderItem: placeholderURL as NSURL)
     }
 
@@ -118,8 +101,9 @@ private final class GalleryVideoActivityItemProvider: UIActivityItemProvider {
         case .success(let fileURL):
             return fileURL as NSURL
         case .failure(let error):
+            cancel()
             notifyPreparationFailedAndWait(error: error)
-            return failurePlaceholderURL as NSURL
+            return NSNull()
         }
     }
 
@@ -165,21 +149,21 @@ private final class GalleryVideoActivityItemProvider: UIActivityItemProvider {
             try? FileManager.default.removeItem(at: fileURL)
         }
         if let tokenKey,
-           let defaults = UserDefaults(suiteName: GalleryVideoSharePayload.appGroupIdentifier) {
+           let defaults = UserDefaults(suiteName: ExistingVideoSharePayload.appGroupIdentifier) {
             defaults.removeObject(forKey: tokenKey)
             defaults.synchronize()
         }
     }
 
     private func makeInternalMarkerURL() -> URL? {
-        guard let defaults = UserDefaults(suiteName: GalleryVideoSharePayload.appGroupIdentifier) else {
+        guard let defaults = UserDefaults(suiteName: ExistingVideoSharePayload.appGroupIdentifier) else {
             return nil
         }
         removeExpiredInternalTokens(from: defaults)
 
         let token = UUID().uuidString.lowercased()
-        let key = GalleryVideoSharePayload.tokenKeyPrefix + token
-        let record = GalleryVideoShareTokenRecord(
+        let key = ExistingVideoSharePayload.tokenKeyPrefix + token
+        let record = ExistingVideoShareTokenRecord(
             createdAt: Date().timeIntervalSince1970,
             payload: payload
         )
@@ -188,7 +172,7 @@ private final class GalleryVideoActivityItemProvider: UIActivityItemProvider {
         defaults.synchronize()
 
         var components = URLComponents()
-        components.scheme = GalleryVideoSharePayload.internalScheme
+        components.scheme = ExistingVideoSharePayload.internalScheme
         components.host = "attachment"
         components.queryItems = [URLQueryItem(name: "token", value: token)]
         guard let markerURL = components.url else {
@@ -205,11 +189,11 @@ private final class GalleryVideoActivityItemProvider: UIActivityItemProvider {
     private func removeExpiredInternalTokens(from defaults: UserDefaults) {
         let now = Date().timeIntervalSince1970
         for (key, value) in defaults.dictionaryRepresentation()
-        where key.hasPrefix(GalleryVideoSharePayload.tokenKeyPrefix) {
+        where key.hasPrefix(ExistingVideoSharePayload.tokenKeyPrefix) {
             guard let data = value as? Data,
-                  let record = try? JSONDecoder().decode(GalleryVideoShareTokenRecord.self, from: data),
+                  let record = try? JSONDecoder().decode(ExistingVideoShareTokenRecord.self, from: data),
                   record.createdAt <= now,
-                  now - record.createdAt <= GalleryVideoSharePayload.tokenLifetime else {
+                  now - record.createdAt <= ExistingVideoSharePayload.tokenLifetime else {
                 defaults.removeObject(forKey: key)
                 continue
             }
@@ -1208,8 +1192,9 @@ final class GalleryController: UIViewController {
             let item = self.items[self.pagingNode.centralItemIndex]
             var shareItems: [Any] = []
             var videoProvider: GalleryVideoActivityItemProvider?
-            if item.isVideo, let payload = GalleryVideoSharePayload(item: item) {
-                let provider = GalleryVideoActivityItemProvider(payload: payload)
+            if item.isVideo,
+               let payload = ExistingVideoSharePayload(item: item),
+               let provider = GalleryVideoActivityItemProvider(payload: payload) {
                 videoProvider = provider
                 shareItems.append(provider)
             } else if let node = self.pagingNode.currentItemNode() as? ChatImageGalleryItemNode,

--- a/MezonChat/Core/UI/Gallery/GalleryController.swift
+++ b/MezonChat/Core/UI/Gallery/GalleryController.swift
@@ -4,6 +4,468 @@ import AsyncDisplayKit
 import Photos
 import AVFoundation
 
+private struct GalleryVideoSharePayload: Codable {
+    static let internalScheme = "mezon-video-share"
+    static let appGroupIdentifier = "group.mezon.mobile"
+    static let tokenKeyPrefix = "mezon.video-share.token."
+    static let tokenLifetime: TimeInterval = 10 * 60
+
+    let url: String
+    let thumbnail: String
+    let filename: String
+    let filetype: String
+    let size: Int64
+    let width: Int
+    let height: Int
+    let durationSeconds: Int
+
+    init?(item: GalleryItemInfo) {
+        let source = (item.sourceURL ?? item.url).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !source.isEmpty, let sourceURL = URL(string: source) else { return nil }
+
+        let metadata = item.videoShareMetadata
+        let rawMetadataFilename = metadata?.filename.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let metadataFilename = (rawMetadataFilename as NSString).lastPathComponent
+        let remoteFilename = sourceURL.lastPathComponent.removingPercentEncoding ?? sourceURL.lastPathComponent
+        let fallbackExtension = sourceURL.pathExtension.isEmpty ? "mp4" : sourceURL.pathExtension.lowercased()
+        let candidateFilename = !metadataFilename.isEmpty
+            ? metadataFilename
+            : (!remoteFilename.isEmpty ? remoteFilename : "video.\(fallbackExtension)")
+
+        url = source
+        thumbnail = metadata?.thumbnail ?? ""
+        filename = (candidateFilename as NSString).pathExtension.isEmpty
+            ? "\(candidateFilename).\(fallbackExtension)"
+            : candidateFilename
+        filetype = Self.resolvedMimeType(metadata?.filetype, pathExtension: fallbackExtension)
+        size = max(metadata?.size ?? 0, 0)
+        width = max(Int(item.pixelSize?.width ?? 0), 0)
+        height = max(Int(item.pixelSize?.height ?? 0), 0)
+        durationSeconds = max(metadata?.durationSeconds ?? 0, 0)
+    }
+
+    private static func resolvedMimeType(_ raw: String?, pathExtension: String) -> String {
+        let mime = raw?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+        if mime.hasPrefix("video/") { return mime }
+        switch pathExtension.lowercased() {
+        case "mov": return "video/quicktime"
+        case "m4v": return "video/x-m4v"
+        case "webm": return "video/webm"
+        case "mkv": return "video/x-matroska"
+        case "3gp": return "video/3gpp"
+        case "3g2": return "video/3gpp2"
+        case "mpeg", "mpg": return "video/mpeg"
+        case "ogv", "ogg": return "video/ogg"
+        case "ts": return "video/mp2t"
+        case "avi": return "video/x-msvideo"
+        default: return "video/mp4"
+        }
+    }
+}
+
+private struct GalleryVideoShareTokenRecord: Codable {
+    let createdAt: TimeInterval
+    let payload: GalleryVideoSharePayload
+}
+
+private enum GalleryVideoSharePreparationError: Error {
+    case unavailable
+}
+
+private final class GalleryVideoActivityItemProvider: UIActivityItemProvider {
+    private static let mezonActivityIdentifier = "mezon.mobile.mezonsharing"
+    private static let shareCacheMaxBytes: Int64 = 512 * 1024 * 1024
+
+    private let payload: GalleryVideoSharePayload
+    private let sourceURL: URL
+    private let failurePlaceholderURL: URL
+    private let stateLock = NSLock()
+    private var activeDownloadTask: URLSessionDownloadTask?
+    private var downloadedURL: URL?
+    private var issuedTokenKey: String?
+    private var preparationError: Error?
+    private var didRequestPhotoLibrarySave = false
+    var preparationProgressHandler: ((Double) -> Void)?
+    var preparationFinishedHandler: (() -> Void)?
+    var preparationFailedHandler: ((Error, @escaping () -> Void) -> Void)?
+    var photoLibrarySaveHandler: (() -> Void)?
+
+    init(payload: GalleryVideoSharePayload) {
+        let placeholderURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent((payload.filename as NSString).lastPathComponent)
+        self.payload = payload
+        self.sourceURL = URL(string: payload.url)!
+        self.failurePlaceholderURL = placeholderURL
+        super.init(placeholderItem: placeholderURL as NSURL)
+    }
+
+    deinit {
+        cancelAndCleanup()
+    }
+
+    override var item: Any {
+        if Self.isMezonActivity(activityType), let markerURL = makeInternalMarkerURL() {
+            return markerURL as NSURL
+        }
+        if activityType == .saveToCameraRoll {
+            requestPhotoLibrarySave()
+            return NSItemProvider()
+        }
+        if Self.isAuxiliarySystemAction(activityType) {
+            return NSItemProvider()
+        }
+        switch downloadVideoForExternalActivity() {
+        case .success(let fileURL):
+            return fileURL as NSURL
+        case .failure(let error):
+            notifyPreparationFailedAndWait(error: error)
+            return failurePlaceholderURL as NSURL
+        }
+    }
+
+    static func isMezonActivity(_ activityType: UIActivity.ActivityType?) -> Bool {
+        let identifier = activityType?.rawValue.lowercased() ?? ""
+        return identifier == mezonActivityIdentifier || identifier.hasSuffix(".mezonsharing")
+    }
+
+    private static func isAuxiliarySystemAction(_ activityType: UIActivity.ActivityType?) -> Bool {
+        guard let activityType else { return false }
+        let identifier = activityType.rawValue.lowercased()
+        return identifier.contains("savetofiles")
+            || identifier.contains("addtoiclouddrive")
+            || identifier.contains("streamshareservice")
+    }
+
+    private func requestPhotoLibrarySave() {
+        stateLock.lock()
+        guard !didRequestPhotoLibrarySave else {
+            stateLock.unlock()
+            return
+        }
+        didRequestPhotoLibrarySave = true
+        let handler = photoLibrarySaveHandler
+        stateLock.unlock()
+        DispatchQueue.main.async {
+            handler?()
+        }
+    }
+
+    func cancelAndCleanup() {
+        stateLock.lock()
+        let task = activeDownloadTask
+        activeDownloadTask = nil
+        let fileURL = downloadedURL
+        downloadedURL = nil
+        let tokenKey = issuedTokenKey
+        issuedTokenKey = nil
+        stateLock.unlock()
+
+        task?.cancel()
+        if let fileURL {
+            try? FileManager.default.removeItem(at: fileURL)
+        }
+        if let tokenKey,
+           let defaults = UserDefaults(suiteName: GalleryVideoSharePayload.appGroupIdentifier) {
+            defaults.removeObject(forKey: tokenKey)
+            defaults.synchronize()
+        }
+    }
+
+    private func makeInternalMarkerURL() -> URL? {
+        guard let defaults = UserDefaults(suiteName: GalleryVideoSharePayload.appGroupIdentifier) else {
+            return nil
+        }
+        removeExpiredInternalTokens(from: defaults)
+
+        let token = UUID().uuidString.lowercased()
+        let key = GalleryVideoSharePayload.tokenKeyPrefix + token
+        let record = GalleryVideoShareTokenRecord(
+            createdAt: Date().timeIntervalSince1970,
+            payload: payload
+        )
+        guard let data = try? JSONEncoder().encode(record) else { return nil }
+        defaults.set(data, forKey: key)
+        defaults.synchronize()
+
+        var components = URLComponents()
+        components.scheme = GalleryVideoSharePayload.internalScheme
+        components.host = "attachment"
+        components.queryItems = [URLQueryItem(name: "token", value: token)]
+        guard let markerURL = components.url else {
+            defaults.removeObject(forKey: key)
+            return nil
+        }
+
+        stateLock.lock()
+        issuedTokenKey = key
+        stateLock.unlock()
+        return markerURL
+    }
+
+    private func removeExpiredInternalTokens(from defaults: UserDefaults) {
+        let now = Date().timeIntervalSince1970
+        for (key, value) in defaults.dictionaryRepresentation()
+        where key.hasPrefix(GalleryVideoSharePayload.tokenKeyPrefix) {
+            guard let data = value as? Data,
+                  let record = try? JSONDecoder().decode(GalleryVideoShareTokenRecord.self, from: data),
+                  record.createdAt <= now,
+                  now - record.createdAt <= GalleryVideoSharePayload.tokenLifetime else {
+                defaults.removeObject(forKey: key)
+                continue
+            }
+        }
+    }
+
+    private func downloadVideoForExternalActivity() -> Result<URL, Error> {
+        if sourceURL.isFileURL {
+            return FileManager.default.fileExists(atPath: sourceURL.path)
+                ? .success(sourceURL)
+                : .failure(GalleryVideoSharePreparationError.unavailable)
+        }
+
+        stateLock.lock()
+        if let downloadedURL, FileManager.default.fileExists(atPath: downloadedURL.path) {
+            stateLock.unlock()
+            return .success(downloadedURL)
+        }
+        stateLock.unlock()
+
+        notifyPreparationProgress(0)
+        defer { notifyPreparationFinished() }
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mezon_video_shares", isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            let expectedBytes = max(payload.size, 0)
+            try trimShareCache(in: directory, incomingBytes: expectedBytes)
+            try ensureAvailableCapacity(for: expectedBytes, in: directory)
+        } catch {
+            return .failure(error)
+        }
+
+        let safeFilename = (payload.filename as NSString).lastPathComponent
+        let destination = directory.appendingPathComponent("\(UUID().uuidString)_\(safeFilename)")
+        let completion = DispatchSemaphore(value: 0)
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = 30
+        configuration.timeoutIntervalForResource = 30 * 60
+        let session = URLSession(configuration: configuration)
+        let task = session.downloadTask(with: sourceURL) { [weak self] temporaryURL, response, error in
+            defer { completion.signal() }
+            guard let self else { return }
+            if let error {
+                self.setPreparationError(error)
+                return
+            }
+            guard let temporaryURL,
+                  let response = response as? HTTPURLResponse,
+                  (200...299).contains(response.statusCode) else {
+                self.setPreparationError(GalleryVideoSharePreparationError.unavailable)
+                return
+            }
+            do {
+                if FileManager.default.fileExists(atPath: destination.path) {
+                    try FileManager.default.removeItem(at: destination)
+                }
+                try FileManager.default.moveItem(at: temporaryURL, to: destination)
+                let values = try destination.resourceValues(forKeys: [.fileSizeKey])
+                guard let fileSize = values.fileSize else {
+                    throw GalleryVideoSharePreparationError.unavailable
+                }
+                try self.trimShareCache(
+                    in: directory,
+                    incomingBytes: Int64(fileSize),
+                    retaining: destination
+                )
+                self.stateLock.lock()
+                self.downloadedURL = destination
+                self.stateLock.unlock()
+            } catch {
+                try? FileManager.default.removeItem(at: destination)
+                self.setPreparationError(error)
+            }
+        }
+
+        stateLock.lock()
+        preparationError = nil
+        activeDownloadTask = task
+        stateLock.unlock()
+        let progressObservation = task.progress.observe(\.fractionCompleted) { [weak self] progress, _ in
+            self?.notifyPreparationProgress(progress.fractionCompleted)
+        }
+        task.resume()
+        completion.wait()
+        progressObservation.invalidate()
+        session.finishTasksAndInvalidate()
+
+        stateLock.lock()
+        if activeDownloadTask === task {
+            activeDownloadTask = nil
+        }
+        let result = downloadedURL
+        let error = preparationError
+        preparationError = nil
+        stateLock.unlock()
+        if let result {
+            return .success(result)
+        }
+        return .failure(error ?? GalleryVideoSharePreparationError.unavailable)
+    }
+
+    private func trimShareCache(
+        in directory: URL,
+        incomingBytes: Int64,
+        retaining retainedURL: URL? = nil
+    ) throws {
+        let keys: Set<URLResourceKey> = [
+            .isRegularFileKey,
+            .fileSizeKey,
+            .contentModificationDateKey,
+            .creationDateKey
+        ]
+        let files = try FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: Array(keys),
+            options: .skipsHiddenFiles
+        )
+        let retainedPath = retainedURL?.standardizedFileURL.path
+        var entries: [(url: URL, size: Int64, date: Date)] = []
+
+        for file in files {
+            guard file.standardizedFileURL.path != retainedPath else { continue }
+            let values = try file.resourceValues(forKeys: keys)
+            guard values.isRegularFile == true else { continue }
+            entries.append((
+                url: file,
+                size: Int64(values.fileSize ?? 0),
+                date: values.contentModificationDate ?? values.creationDate ?? .distantPast
+            ))
+        }
+
+        let allowedCachedBytes = max(Self.shareCacheMaxBytes - max(incomingBytes, 0), 0)
+        var cachedBytes = entries.reduce(Int64(0)) { $0 + $1.size }
+        guard cachedBytes > allowedCachedBytes else { return }
+
+        for entry in entries.sorted(by: { $0.date < $1.date }) {
+            try FileManager.default.removeItem(at: entry.url)
+            cachedBytes -= entry.size
+            if cachedBytes <= allowedCachedBytes { return }
+        }
+        if cachedBytes > allowedCachedBytes {
+            throw GalleryVideoSharePreparationError.unavailable
+        }
+    }
+
+    private func ensureAvailableCapacity(for incomingBytes: Int64, in directory: URL) throws {
+        guard incomingBytes > 0 else { return }
+        let values = try directory.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
+        if let availableBytes = values.volumeAvailableCapacityForImportantUsage,
+           availableBytes < incomingBytes {
+            throw GalleryVideoSharePreparationError.unavailable
+        }
+    }
+
+    private func setPreparationError(_ error: Error) {
+        stateLock.lock()
+        preparationError = error
+        stateLock.unlock()
+    }
+
+    private func notifyPreparationProgress(_ progress: Double) {
+        let handler = preparationProgressHandler
+        DispatchQueue.main.async {
+            handler?(min(max(progress, 0), 1))
+        }
+    }
+
+    private func notifyPreparationFinished() {
+        let handler = preparationFinishedHandler
+        DispatchQueue.main.async {
+            handler?()
+        }
+    }
+
+    private func notifyPreparationFailedAndWait(error: Error) {
+        guard let handler = preparationFailedHandler else { return }
+        let acknowledgement = DispatchSemaphore(value: 0)
+        DispatchQueue.main.async {
+            handler(error) {
+                acknowledgement.signal()
+            }
+        }
+        _ = acknowledgement.wait(timeout: .now() + 5)
+    }
+}
+
+private final class GalleryVideoSharePreparationOverlay: UIView {
+    private let panel = UIView()
+    private let spinner = UIActivityIndicatorView(style: .large)
+    private let label = UILabel()
+    private let progressView = UIProgressView(progressViewStyle: .default)
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = UIColor.black.withAlphaComponent(0.55)
+        isUserInteractionEnabled = true
+
+        panel.translatesAutoresizingMaskIntoConstraints = false
+        panel.backgroundColor = UIColor(red: 0.12, green: 0.12, blue: 0.16, alpha: 0.96)
+        panel.layer.cornerRadius = 14
+        addSubview(panel)
+
+        spinner.translatesAutoresizingMaskIntoConstraints = false
+        spinner.color = .white
+        panel.addSubview(spinner)
+
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .systemFont(ofSize: 14, weight: .medium)
+        label.textColor = .white
+        label.textAlignment = .center
+        label.numberOfLines = 2
+        panel.addSubview(label)
+
+        progressView.translatesAutoresizingMaskIntoConstraints = false
+        progressView.progressTintColor = .systemBlue
+        progressView.trackTintColor = UIColor.white.withAlphaComponent(0.25)
+        panel.addSubview(progressView)
+
+        NSLayoutConstraint.activate([
+            panel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            panel.centerYAnchor.constraint(equalTo: centerYAnchor),
+            panel.widthAnchor.constraint(equalToConstant: 240),
+
+            spinner.topAnchor.constraint(equalTo: panel.topAnchor, constant: 22),
+            spinner.centerXAnchor.constraint(equalTo: panel.centerXAnchor),
+
+            label.topAnchor.constraint(equalTo: spinner.bottomAnchor, constant: 12),
+            label.leadingAnchor.constraint(equalTo: panel.leadingAnchor, constant: 16),
+            label.trailingAnchor.constraint(equalTo: panel.trailingAnchor, constant: -16),
+
+            progressView.topAnchor.constraint(equalTo: label.bottomAnchor, constant: 14),
+            progressView.leadingAnchor.constraint(equalTo: panel.leadingAnchor, constant: 20),
+            progressView.trailingAnchor.constraint(equalTo: panel.trailingAnchor, constant: -20),
+            progressView.bottomAnchor.constraint(equalTo: panel.bottomAnchor, constant: -22),
+        ])
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    func update(progress: Float) {
+        let clampedProgress = min(max(progress, 0), 1)
+        let percent = Int((clampedProgress * 100).rounded())
+        label.text = "\(L(L10n.Gallery.videoPreparingForShare)) \(percent)%"
+        progressView.setProgress(clampedProgress, animated: progress > 0)
+        spinner.startAnimating()
+    }
+
+    func stop() {
+        spinner.stopAnimating()
+        progressView.progress = 0
+    }
+}
+
 final class GalleryController: UIViewController {
     private enum PhotoLibrarySaveAuthorizationResult {
         case authorized
@@ -44,6 +506,8 @@ final class GalleryController: UIViewController {
     private let videoSaveSpinner = UIActivityIndicatorView(style: .large)
     private let videoSaveLabel = UILabel()
     private let videoSaveProgressView = UIProgressView(progressViewStyle: .default)
+    private var videoSharePreparationOverlay: GalleryVideoSharePreparationOverlay?
+    private var shouldResumeVideoPlaybackWhenActive = false
 
     init(items: [GalleryItemInfo], initialIndex: Int, channelItemsLoader: (() async -> [GalleryItemInfo])? = nil) {
         self.items = items
@@ -69,6 +533,19 @@ final class GalleryController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationWillResignActive),
+            name: UIApplication.willResignActiveNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
 
         view.backgroundColor = .black
 
@@ -145,6 +622,34 @@ final class GalleryController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         performDeferredSetupIfNeeded()
+        resumeVideoPlaybackIfPossible()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc private func applicationWillResignActive() {
+        guard let videoNode = pagingNode.currentItemNode() as? ChatVideoGalleryItemNode else { return }
+        if videoNode.isPlaying {
+            shouldResumeVideoPlaybackWhenActive = true
+        }
+        videoNode.pause()
+    }
+
+    @objc private func applicationDidBecomeActive() {
+        resumeVideoPlaybackIfPossible()
+    }
+
+    private func resumeVideoPlaybackIfPossible() {
+        guard shouldResumeVideoPlaybackWhenActive,
+              UIApplication.shared.applicationState == .active,
+              viewIfLoaded?.window != nil,
+              presentedViewController == nil,
+              let videoNode = pagingNode.currentItemNode() as? ChatVideoGalleryItemNode
+        else { return }
+        shouldResumeVideoPlaybackWhenActive = false
+        videoNode.play()
     }
 
     private func performDeferredSetupIfNeeded() {
@@ -330,6 +835,36 @@ final class GalleryController: UIViewController {
         videoSaveBackdrop.isHidden = true
         videoSavePanel.isHidden = true
         isSavingVideo = false
+    }
+
+    private func showVideoSharePreparationOverlay(progress: Float, over activity: UIActivityViewController) {
+        guard let hostView = activity.presentationController?.containerView ?? activity.view.window else { return }
+        let overlay: GalleryVideoSharePreparationOverlay
+        if let existing = videoSharePreparationOverlay {
+            overlay = existing
+        } else {
+            overlay = GalleryVideoSharePreparationOverlay()
+            overlay.translatesAutoresizingMaskIntoConstraints = false
+            videoSharePreparationOverlay = overlay
+        }
+        if overlay.superview !== hostView {
+            overlay.removeFromSuperview()
+            hostView.addSubview(overlay)
+            NSLayoutConstraint.activate([
+                overlay.topAnchor.constraint(equalTo: hostView.topAnchor),
+                overlay.leadingAnchor.constraint(equalTo: hostView.leadingAnchor),
+                overlay.trailingAnchor.constraint(equalTo: hostView.trailingAnchor),
+                overlay.bottomAnchor.constraint(equalTo: hostView.bottomAnchor),
+            ])
+        }
+        overlay.update(progress: progress)
+        hostView.bringSubviewToFront(overlay)
+    }
+
+    private func hideVideoSharePreparationOverlay() {
+        videoSharePreparationOverlay?.stop()
+        videoSharePreparationOverlay?.removeFromSuperview()
+        videoSharePreparationOverlay = nil
     }
 
     override func viewDidLayoutSubviews() {
@@ -634,6 +1169,7 @@ final class GalleryController: UIViewController {
     }
 
     @objc private func closeTapped() {
+        shouldResumeVideoPlaybackWhenActive = false
         dismiss(animated: true)
     }
 
@@ -671,17 +1207,85 @@ final class GalleryController: UIViewController {
             guard let self else { return }
             let item = self.items[self.pagingNode.centralItemIndex]
             var shareItems: [Any] = []
-            if let node = self.pagingNode.currentItemNode() as? ChatImageGalleryItemNode,
+            var videoProvider: GalleryVideoActivityItemProvider?
+            if item.isVideo, let payload = GalleryVideoSharePayload(item: item) {
+                let provider = GalleryVideoActivityItemProvider(payload: payload)
+                videoProvider = provider
+                shareItems.append(provider)
+            } else if let node = self.pagingNode.currentItemNode() as? ChatImageGalleryItemNode,
                let image = node.currentImage {
                 shareItems.append(image)
             } else if let url = URL(string: item.url) {
                 shareItems.append(url)
             }
             guard !shareItems.isEmpty else { return }
+            let currentVideoNode = self.pagingNode.currentItemNode() as? ChatVideoGalleryItemNode
+            let shouldResumePlayback = currentVideoNode?.isPlaying == true
+            if shouldResumePlayback {
+                self.shouldResumeVideoPlaybackWhenActive = true
+                currentVideoNode?.pause()
+            }
             let activity = UIActivityViewController(activityItems: shareItems, applicationActivities: nil)
+            if let videoProvider {
+                activity.excludedActivityTypes = [.copyToPasteboard]
+                let videoURLString = item.sourceURL ?? item.url
+                videoProvider.photoLibrarySaveHandler = { [weak self, weak activity] in
+                    guard let self else { return }
+                    let save: () -> Void = { [weak self] in
+                        self?.saveVideoToPhotoLibrary(urlString: videoURLString)
+                    }
+                    if activity?.presentingViewController != nil {
+                        activity?.dismiss(animated: false, completion: save)
+                    } else {
+                        save()
+                    }
+                }
+            }
+            videoProvider?.preparationProgressHandler = { [weak self, weak activity] progress in
+                guard let self, let activity else { return }
+                self.showVideoSharePreparationOverlay(progress: Float(progress), over: activity)
+            }
+            videoProvider?.preparationFinishedHandler = { [weak self] in
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                    self?.hideVideoSharePreparationOverlay()
+                }
+            }
+            videoProvider?.preparationFailedHandler = { [weak self, weak activity] error, acknowledge in
+                guard let self else {
+                    acknowledge()
+                    return
+                }
+                let finish = {
+                    self.hideVideoSharePreparationOverlay()
+                    if (error as? URLError)?.code != .cancelled {
+                        Toast.error(L(L10n.Gallery.videoShareFailed))
+                    }
+                    self.resumeVideoPlaybackIfPossible()
+                    acknowledge()
+                }
+                if activity?.presentingViewController != nil {
+                    activity?.dismiss(animated: false, completion: finish)
+                } else {
+                    finish()
+                }
+            }
             if let popover = activity.popoverPresentationController {
                 popover.sourceView = self.moreButton
                 popover.sourceRect = self.moreButton.bounds
+            }
+            let providerToCleanup = videoProvider
+            activity.completionWithItemsHandler = { [weak self] activityType, _, _, _ in
+                providerToCleanup?.cancelAndCleanup()
+                DispatchQueue.main.async {
+                    guard let self else { return }
+                    self.hideVideoSharePreparationOverlay()
+                    if GalleryVideoActivityItemProvider.isMezonActivity(activityType) {
+                        self.shouldResumeVideoPlaybackWhenActive = false
+                    } else if shouldResumePlayback {
+                        self.shouldResumeVideoPlaybackWhenActive = true
+                        self.resumeVideoPlaybackIfPossible()
+                    }
+                }
             }
             self.present(activity, animated: true)
         })

--- a/MezonChat/Core/UI/Gallery/GalleryItemNode.swift
+++ b/MezonChat/Core/UI/Gallery/GalleryItemNode.swift
@@ -2,6 +2,28 @@ import Foundation
 import UIKit
 import AsyncDisplayKit
 
+public struct GalleryVideoShareMetadata {
+    public let filename: String
+    public let filetype: String
+    public let size: Int64
+    public let durationSeconds: Int
+    public let thumbnail: String
+
+    public init(
+        filename: String = "",
+        filetype: String = "",
+        size: Int64 = 0,
+        durationSeconds: Int = 0,
+        thumbnail: String = ""
+    ) {
+        self.filename = filename
+        self.filetype = filetype
+        self.size = size
+        self.durationSeconds = durationSeconds
+        self.thumbnail = thumbnail
+    }
+}
+
 public struct GalleryItemInfo {
     public static let detailProxySize = 700
 
@@ -15,6 +37,7 @@ public struct GalleryItemInfo {
     public let senderAvatarURL: String?
     public let timestamp: Date?
     public let isVideo: Bool
+    public let videoShareMetadata: GalleryVideoShareMetadata?
 
     public var stableIdentity: String {
         if let sourceURL, !sourceURL.isEmpty { return sourceURL }
@@ -31,7 +54,8 @@ public struct GalleryItemInfo {
         senderId: String? = nil,
         senderAvatarURL: String? = nil,
         timestamp: Date? = nil,
-        isVideo: Bool = false
+        isVideo: Bool = false,
+        videoShareMetadata: GalleryVideoShareMetadata? = nil
     ) {
         self.url = url
         self.sourceURL = sourceURL
@@ -43,6 +67,7 @@ public struct GalleryItemInfo {
         self.senderAvatarURL = senderAvatarURL
         self.timestamp = timestamp
         self.isVideo = isVideo
+        self.videoShareMetadata = videoShareMetadata
     }
 
     public static func pixelSize(width: Int?, height: Int?) -> CGSize? {

--- a/MezonChat/Core/UI/Video/MezonVideoPlayerNode.swift
+++ b/MezonChat/Core/UI/Video/MezonVideoPlayerNode.swift
@@ -112,7 +112,7 @@ final class MezonVideoPlayerNode: ASDisplayNode {
 
         let bottomConfig = UIImage.SymbolConfiguration(pointSize: 18, weight: .regular)
         bottomPlayPauseButton.setImage(UIImage(systemName: "play.fill", withConfiguration: bottomConfig), for: .normal)
-        installSafeWhiteTint(on: bottomPlayPauseButton.imageNode)
+        bottomPlayPauseButton.imageNode.installSafeWhiteTint()
         bottomPlayPauseButton.addTarget(self, action: #selector(playPauseTapped), forControlEvents: .touchUpInside)
 
 
@@ -158,19 +158,9 @@ final class MezonVideoPlayerNode: ASDisplayNode {
         let config = UIImage.SymbolConfiguration(pointSize: pointSize, weight: .bold)
         let image = UIImage(systemName: iconName, withConfiguration: config)
         button.setImage(image, for: .normal)
-        installSafeWhiteTint(on: button.imageNode)
+        button.imageNode.installSafeWhiteTint()
         button.backgroundColor = UIColor.black.withAlphaComponent(0.35)
         button.clipsToBounds = true
-    }
-
-    private func installSafeWhiteTint(on imageNode: ASImageNode) {
-        let tintBlock = ASImageNodeTintColorModificationBlock(.white)
-        imageNode.imageModificationBlock = { image, traitCollection in
-            let size = image.size
-            guard size.width.isFinite, size.height.isFinite,
-                  size.width > 0, size.height > 0, image.scale > 0 else { return nil }
-            return tintBlock(image, traitCollection)
-        }
     }
 
 

--- a/MezonChat/Core/UI/Video/MezonVideoPlayerNode.swift
+++ b/MezonChat/Core/UI/Video/MezonVideoPlayerNode.swift
@@ -36,6 +36,10 @@ final class MezonVideoPlayerNode: ASDisplayNode {
     var setOverlayVisible: ((Bool) -> Void)?
     var onPlaybackFailed: (() -> Void)?
     var setPagingEnabled: ((Bool) -> Void)?
+    var isPlaying: Bool {
+        guard let player else { return false }
+        return player.rate != 0 || player.timeControlStatus != .paused
+    }
     var controlsBottomInset: CGFloat = 0 {
         didSet {
             guard oldValue != controlsBottomInset else { return }
@@ -108,7 +112,7 @@ final class MezonVideoPlayerNode: ASDisplayNode {
 
         let bottomConfig = UIImage.SymbolConfiguration(pointSize: 18, weight: .regular)
         bottomPlayPauseButton.setImage(UIImage(systemName: "play.fill", withConfiguration: bottomConfig), for: .normal)
-        bottomPlayPauseButton.imageNode.imageModificationBlock = ASImageNodeTintColorModificationBlock(.white)
+        installSafeWhiteTint(on: bottomPlayPauseButton.imageNode)
         bottomPlayPauseButton.addTarget(self, action: #selector(playPauseTapped), forControlEvents: .touchUpInside)
 
 
@@ -154,9 +158,19 @@ final class MezonVideoPlayerNode: ASDisplayNode {
         let config = UIImage.SymbolConfiguration(pointSize: pointSize, weight: .bold)
         let image = UIImage(systemName: iconName, withConfiguration: config)
         button.setImage(image, for: .normal)
-        button.imageNode.imageModificationBlock = ASImageNodeTintColorModificationBlock(.white)
+        installSafeWhiteTint(on: button.imageNode)
         button.backgroundColor = UIColor.black.withAlphaComponent(0.35)
         button.clipsToBounds = true
+    }
+
+    private func installSafeWhiteTint(on imageNode: ASImageNode) {
+        let tintBlock = ASImageNodeTintColorModificationBlock(.white)
+        imageNode.imageModificationBlock = { image, traitCollection in
+            let size = image.size
+            guard size.width.isFinite, size.height.isFinite,
+                  size.width > 0, size.height > 0, image.scale > 0 else { return nil }
+            return tintBlock(image, traitCollection)
+        }
     }
 
 

--- a/MezonChat/Core/UI/Video/UniversalVideoPlayerNode.swift
+++ b/MezonChat/Core/UI/Video/UniversalVideoPlayerNode.swift
@@ -3,6 +3,18 @@ import UIKit
 import AsyncDisplayKit
 import AVFoundation
 
+extension ASImageNode {
+    func installSafeWhiteTint() {
+        let tintBlock = ASImageNodeTintColorModificationBlock(.white)
+        imageModificationBlock = { image, traitCollection in
+            let size = image.size
+            guard size.width.isFinite, size.height.isFinite,
+                  size.width > 0, size.height > 0, image.scale > 0 else { return nil }
+            return tintBlock(image, traitCollection)
+        }
+    }
+}
+
 final class UniversalVideoPlayerNode: ASDisplayNode {
     
     private var avPlayerNode: MezonVideoPlayerNode?

--- a/MezonChat/Core/UI/Video/UniversalVideoPlayerNode.swift
+++ b/MezonChat/Core/UI/Video/UniversalVideoPlayerNode.swift
@@ -14,6 +14,7 @@ final class UniversalVideoPlayerNode: ASDisplayNode {
     
     var setOverlayVisible: ((Bool) -> Void)?
     var setPagingEnabled: ((Bool) -> Void)?
+    var isPlaying: Bool { avPlayerNode?.isPlaying == true || vlcPlayerNode?.isPlaying == true }
     var controlsBottomInset: CGFloat = 0 {
         didSet {
             avPlayerNode?.controlsBottomInset = controlsBottomInset

--- a/MezonChat/Core/UI/Video/VLCVideoPlayerNode.swift
+++ b/MezonChat/Core/UI/Video/VLCVideoPlayerNode.swift
@@ -50,6 +50,7 @@ final class VLCVideoPlayerNode: ASDisplayNode {
 
     var setOverlayVisible: ((Bool) -> Void)?
     var setPagingEnabled: ((Bool) -> Void)?
+    var isPlaying: Bool { wantsPlay || vlcPlayer?.isPlaying == true }
     var controlsBottomInset: CGFloat = 0 {
         didSet {
             guard oldValue != controlsBottomInset else { return }
@@ -104,7 +105,7 @@ final class VLCVideoPlayerNode: ASDisplayNode {
         
         let bottomConfig = UIImage.SymbolConfiguration(pointSize: 18, weight: .regular)
         bottomPlayPauseButton.setImage(UIImage(systemName: "play.fill", withConfiguration: bottomConfig), for: .normal)
-        bottomPlayPauseButton.imageNode.imageModificationBlock = ASImageNodeTintColorModificationBlock(.white)
+        installSafeWhiteTint(on: bottomPlayPauseButton.imageNode)
         bottomPlayPauseButton.addTarget(self, action: #selector(playPauseTapped), forControlEvents: .touchUpInside)
         
         self.timeSlider.minimumTrackTintColor = .white
@@ -172,9 +173,19 @@ final class VLCVideoPlayerNode: ASDisplayNode {
         let config = UIImage.SymbolConfiguration(pointSize: pointSize, weight: .bold)
         let image = UIImage(systemName: iconName, withConfiguration: config)
         button.setImage(image, for: .normal)
-        button.imageNode.imageModificationBlock = ASImageNodeTintColorModificationBlock(.white)
+        installSafeWhiteTint(on: button.imageNode)
         button.backgroundColor = UIColor.black.withAlphaComponent(0.35)
         button.clipsToBounds = true
+    }
+
+    private func installSafeWhiteTint(on imageNode: ASImageNode) {
+        let tintBlock = ASImageNodeTintColorModificationBlock(.white)
+        imageNode.imageModificationBlock = { image, traitCollection in
+            let size = image.size
+            guard size.width.isFinite, size.height.isFinite,
+                  size.width > 0, size.height > 0, image.scale > 0 else { return nil }
+            return tintBlock(image, traitCollection)
+        }
     }
     
     private func setupVLCPlayer(url: URL) {

--- a/MezonChat/Core/UI/Video/VLCVideoPlayerNode.swift
+++ b/MezonChat/Core/UI/Video/VLCVideoPlayerNode.swift
@@ -105,7 +105,7 @@ final class VLCVideoPlayerNode: ASDisplayNode {
         
         let bottomConfig = UIImage.SymbolConfiguration(pointSize: 18, weight: .regular)
         bottomPlayPauseButton.setImage(UIImage(systemName: "play.fill", withConfiguration: bottomConfig), for: .normal)
-        installSafeWhiteTint(on: bottomPlayPauseButton.imageNode)
+        bottomPlayPauseButton.imageNode.installSafeWhiteTint()
         bottomPlayPauseButton.addTarget(self, action: #selector(playPauseTapped), forControlEvents: .touchUpInside)
         
         self.timeSlider.minimumTrackTintColor = .white
@@ -173,19 +173,9 @@ final class VLCVideoPlayerNode: ASDisplayNode {
         let config = UIImage.SymbolConfiguration(pointSize: pointSize, weight: .bold)
         let image = UIImage(systemName: iconName, withConfiguration: config)
         button.setImage(image, for: .normal)
-        installSafeWhiteTint(on: button.imageNode)
+        button.imageNode.installSafeWhiteTint()
         button.backgroundColor = UIColor.black.withAlphaComponent(0.35)
         button.clipsToBounds = true
-    }
-
-    private func installSafeWhiteTint(on imageNode: ASImageNode) {
-        let tintBlock = ASImageNodeTintColorModificationBlock(.white)
-        imageNode.imageModificationBlock = { image, traitCollection in
-            let size = image.size
-            guard size.width.isFinite, size.height.isFinite,
-                  size.width > 0, size.height > 0, image.scale > 0 else { return nil }
-            return tintBlock(image, traitCollection)
-        }
     }
     
     private func setupVLCPlayer(url: URL) {

--- a/MezonChat/Core/Utils/ExistingVideoSharePayload.swift
+++ b/MezonChat/Core/Utils/ExistingVideoSharePayload.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct ExistingVideoSharePayload: Codable {
+    static let internalScheme = "mezon-video-share"
+    static let appGroupIdentifier = "group.mezon.mobile"
+    static let tokenKeyPrefix = "mezon.video-share.token."
+    static let tokenLifetime: TimeInterval = 10 * 60
+
+    let url: String
+    let thumbnail: String
+    let filename: String
+    let filetype: String
+    let size: Int64
+    let width: Int
+    let height: Int
+    let durationSeconds: Int
+}
+
+struct ExistingVideoShareTokenRecord: Codable {
+    let createdAt: TimeInterval
+    let payload: ExistingVideoSharePayload
+}

--- a/MezonChat/Core/Utils/SharingManager.swift
+++ b/MezonChat/Core/Utils/SharingManager.swift
@@ -19,6 +19,17 @@ final class SharingManager {
         var height: CGFloat?
     }
 
+    struct ExistingVideoAttachment: Codable {
+        var url: String
+        var thumbnail: String
+        var filename: String
+        var filetype: String
+        var size: Int64
+        var width: Int
+        var height: Int
+        var durationSeconds: Int
+    }
+
     enum SharedMediaType: Int, Codable {
         case image = 0
         case video = 1
@@ -28,6 +39,7 @@ final class SharingManager {
     enum SharedContent {
         case media([SharedMediaFile])
         case text([String])
+        case existingVideo(ExistingVideoAttachment)
     }
 
     func loadSharedContent(type: String) -> SharedContent? {
@@ -39,6 +51,11 @@ final class SharingManager {
         }
 
         switch type {
+        case "existingVideo":
+            guard let data = userDefaults.data(forKey: sharedKey),
+                  let attachment = try? JSONDecoder().decode(ExistingVideoAttachment.self, from: data) else { return nil }
+            return .existingVideo(attachment)
+
         case "media", "file":
             guard let data = userDefaults.data(forKey: sharedKey) else { return nil }
             guard let files = try? JSONDecoder().decode([SharedMediaFile].self, from: data) else { return nil }
@@ -49,6 +66,10 @@ final class SharingManager {
             return texts.isEmpty ? nil : .text(texts)
 
         default:
+            if let data = userDefaults.data(forKey: sharedKey),
+               let attachment = try? JSONDecoder().decode(ExistingVideoAttachment.self, from: data) {
+                return .existingVideo(attachment)
+            }
             if let data = userDefaults.data(forKey: sharedKey),
                let files = try? JSONDecoder().decode([SharedMediaFile].self, from: data), !files.isEmpty {
                 return .media(files)

--- a/MezonChat/Core/Utils/SharingManager.swift
+++ b/MezonChat/Core/Utils/SharingManager.swift
@@ -5,7 +5,6 @@ final class SharingManager {
 
     static let shared = SharingManager()
 
-    private let appGroupIdentifier = "group.mezon.mobile"
     private let sharedKey = "mezon.mobile.sharing"
 
     private init() {}
@@ -43,7 +42,9 @@ final class SharingManager {
     }
 
     func loadSharedContent(type: String) -> SharedContent? {
-        guard let userDefaults = UserDefaults(suiteName: appGroupIdentifier) else { return nil }
+        guard let userDefaults = UserDefaults(
+            suiteName: ExistingVideoSharePayload.appGroupIdentifier
+        ) else { return nil }
 
         defer {
             userDefaults.removeObject(forKey: sharedKey)
@@ -82,7 +83,9 @@ final class SharingManager {
     }
 
     func hasPendingSharedContent() -> Bool {
-        guard let userDefaults = UserDefaults(suiteName: appGroupIdentifier) else { return false }
+        guard let userDefaults = UserDefaults(
+            suiteName: ExistingVideoSharePayload.appGroupIdentifier
+        ) else { return false }
         return userDefaults.object(forKey: sharedKey) != nil
     }
 

--- a/MezonChat/Features/ChannelDetail/Tabs/MediaGalleryNode.swift
+++ b/MezonChat/Features/ChannelDetail/Tabs/MediaGalleryNode.swift
@@ -214,12 +214,18 @@ final class MediaGalleryNode: ASDisplayNode {
                     url: att.url,
                     sourceURL: att.url,
                     image: videoPreview,
+                    pixelSize: GalleryItemInfo.pixelSize(width: att.width, height: att.height),
                     placeholderURL: nil,
                     senderName: uploader.name,
                     senderId: String(att.uploader),
                     senderAvatarURL: uploader.avatarURL,
                     timestamp: ts,
-                    isVideo: true
+                    isVideo: true,
+                    videoShareMetadata: GalleryVideoShareMetadata(
+                        filename: att.filename,
+                        filetype: att.filetype,
+                        size: Int64(att.filesize) ?? 0
+                    )
                 )
             }
             return GalleryItemInfo.imageItem(

--- a/MezonChat/Features/ChannelDetail/Tabs/PinnedMessagesNode.swift
+++ b/MezonChat/Features/ChannelDetail/Tabs/PinnedMessagesNode.swift
@@ -919,12 +919,19 @@ private final class PinnedMessageCellNode: ASCellNode, ASNetworkImageNodeDelegat
                     url: att.url,
                     sourceURL: att.url,
                     image: itemIndex == index ? att.localImage : nil,
+                    pixelSize: GalleryItemInfo.pixelSize(width: att.width, height: att.height),
                     placeholderURL: nil,
                     senderName: displayNameForGallery,
                     senderId: String(pinForGallery.senderID),
                     senderAvatarURL: avatarURLForGallery,
                     timestamp: Self.galleryTimestamp(for: pinForGallery),
-                    isVideo: true
+                    isVideo: true,
+                    videoShareMetadata: GalleryVideoShareMetadata(
+                        filename: att.filename,
+                        filetype: att.filetype,
+                        durationSeconds: att.durationSeconds ?? 0,
+                        thumbnail: att.thumbnail
+                    )
                 )
             }
             return GalleryItemInfo.imageItem(

--- a/MezonChat/Features/Chat/Cells/MessageBubbleNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageBubbleNode.swift
@@ -1221,12 +1221,19 @@ final class MessageBubbleNode: ASDisplayNode {
                     url: att.url,
                     sourceURL: att.url,
                     image: preview ?? (itemIndex == index ? att.localImage : nil),
+                    pixelSize: GalleryItemInfo.pixelSize(width: att.width, height: att.height),
                     placeholderURL: nil,
                     senderName: display.senderDisplayName,
                     senderId: display.message.senderId,
                     senderAvatarURL: display.avatarURL,
                     timestamp: display.message.createdAt,
-                    isVideo: true
+                    isVideo: true,
+                    videoShareMetadata: GalleryVideoShareMetadata(
+                        filename: att.filename,
+                        filetype: att.filetype,
+                        durationSeconds: att.durationSeconds ?? 0,
+                        thumbnail: att.thumbnail
+                    )
                 )
             }
             return GalleryItemInfo.imageItem(

--- a/MezonChat/Features/Chat/ChatViewController.swift
+++ b/MezonChat/Features/Chat/ChatViewController.swift
@@ -6281,12 +6281,19 @@ final class ChatViewController: ViewController {
                 url: attachment.url,
                 sourceURL: attachment.url,
                 image: previewImage ?? attachment.localImage,
+                pixelSize: GalleryItemInfo.pixelSize(width: attachment.width, height: attachment.height),
                 placeholderURL: nil,
                 senderName: display.senderDisplayName,
                 senderId: display.message.senderId,
                 senderAvatarURL: display.avatarURL,
                 timestamp: display.message.createdAt,
-                isVideo: true
+                isVideo: true,
+                videoShareMetadata: GalleryVideoShareMetadata(
+                    filename: attachment.filename,
+                    filetype: attachment.filetype,
+                    durationSeconds: attachment.durationSeconds ?? 0,
+                    thumbnail: attachment.thumbnail
+                )
             )
         }
         return GalleryItemInfo.imageItem(
@@ -6375,12 +6382,18 @@ final class ChatViewController: ViewController {
                 url: attachment.url,
                 sourceURL: attachment.url,
                 image: nil,
+                pixelSize: GalleryItemInfo.pixelSize(width: attachment.width, height: attachment.height),
                 placeholderURL: nil,
                 senderName: uploader.name,
                 senderId: String(attachment.uploader),
                 senderAvatarURL: uploader.avatarURL,
                 timestamp: timestamp,
-                isVideo: true
+                isVideo: true,
+                videoShareMetadata: GalleryVideoShareMetadata(
+                    filename: attachment.filename,
+                    filetype: attachment.filetype,
+                    size: Int64(attachment.filesize) ?? 0
+                )
             )
         }
         return GalleryItemInfo.imageItem(

--- a/MezonChat/Features/Main/MezonRootController.swift
+++ b/MezonChat/Features/Main/MezonRootController.swift
@@ -775,9 +775,22 @@ final class MezonRootController: NavigationController {
 
         let sharingVC = SharingViewController(context: context, sharedContent: content)
         guard let windowRoot = view.window?.rootViewController else { return }
-
+        let shouldDismissVideoGallery: Bool
+        if case .existingVideo = content {
+            shouldDismissVideoGallery = true
+        } else {
+            shouldDismissVideoGallery = false
+        }
         dismissShareSheetStack(from: windowRoot) { [weak self] anchor in
             guard let self else { return }
+            if shouldDismissVideoGallery, anchor is GalleryController {
+                anchor.dismiss(animated: false) { [weak self] in
+                    guard let self else { return }
+                    let nextAnchor = self.resolvedSharePresentationAnchor(from: windowRoot)
+                    self.presentSharingViewController(sharingVC, on: nextAnchor)
+                }
+                return
+            }
             self.presentSharingViewController(sharingVC, on: anchor)
         }
     }

--- a/MezonChat/Features/Sharing/SharingViewController.swift
+++ b/MezonChat/Features/Sharing/SharingViewController.swift
@@ -1584,17 +1584,11 @@ final class SharingViewController: UIViewController {
                     let resolvedFilename = !filename.isEmpty
                         ? filename
                         : (!remoteFilename.isEmpty ? remoteFilename : "video.mp4")
-                    let filetype = existingVideo.filetype.hasPrefix("video/")
-                        ? existingVideo.filetype
-                        : SendMessageInputViewController.mimeType(
-                            for: (resolvedFilename as NSString).pathExtension.lowercased()
-                        )
-
                     var attachment = Mezon_Api_MessageAttachment()
                     attachment.url = url
                     attachment.thumbnail = existingVideo.thumbnail
                     attachment.filename = resolvedFilename
-                    attachment.filetype = filetype
+                    attachment.filetype = "video"
                     attachment.size = Int32(clamping: max(existingVideo.size, 0))
                     attachment.width = Int32(clamping: max(existingVideo.width, 0))
                     attachment.height = Int32(clamping: max(existingVideo.height, 0))

--- a/MezonChat/Features/Sharing/SharingViewController.swift
+++ b/MezonChat/Features/Sharing/SharingViewController.swift
@@ -37,6 +37,7 @@ final class SharingViewController: UIViewController {
     private var diffableDataSource: UITableViewDiffableDataSource<Section, SharingSuggestionItem>!
 
     private var sharedMediaFiles: [SharingManager.SharedMediaFile] = []
+    private var existingVideoAttachment: SharingManager.ExistingVideoAttachment?
 
     private let headerView: UIView = {
         let v = UIView()
@@ -366,6 +367,8 @@ final class SharingViewController: UIViewController {
             if let first = trimmed.first {
                 textField.text = first
             }
+        case .existingVideo(let attachment):
+            existingVideoAttachment = attachment
         }
     }
 
@@ -479,7 +482,9 @@ final class SharingViewController: UIViewController {
         let bottomConstraint = bottomArea.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         self.bottomAreaBottomConstraint = bottomConstraint
 
-        let attachHeight = attachmentScrollView.heightAnchor.constraint(equalToConstant: sharedMediaFiles.isEmpty ? 0 : 80)
+        let attachHeight = attachmentScrollView.heightAnchor.constraint(
+            equalToConstant: hasAttachmentPreview ? 80 : 0
+        )
         self.attachmentHeightConstraint = attachHeight
 
         NSLayoutConstraint.activate([
@@ -553,6 +558,9 @@ final class SharingViewController: UIViewController {
 
         if !sharedMediaFiles.isEmpty {
             buildAttachmentPreviews()
+        }
+        if existingVideoAttachment != nil {
+            buildExistingVideoPreview()
         }
 
         tableView.delegate = self
@@ -972,6 +980,84 @@ final class SharingViewController: UIViewController {
         }
     }
 
+    private func buildExistingVideoPreview() {
+        guard let attachment = existingVideoAttachment else { return }
+        let thumbSize: CGFloat = 70
+        let wrapper = UIView()
+        wrapper.translatesAutoresizingMaskIntoConstraints = false
+        wrapper.widthAnchor.constraint(equalToConstant: thumbSize).isActive = true
+        wrapper.heightAnchor.constraint(equalToConstant: thumbSize).isActive = true
+        wrapper.layer.cornerRadius = 6
+        wrapper.clipsToBounds = true
+
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        imageView.backgroundColor = UIColor.theme.tertiary
+        wrapper.addSubview(imageView)
+        NSLayoutConstraint.activate([
+            imageView.topAnchor.constraint(equalTo: wrapper.topAnchor),
+            imageView.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor),
+            imageView.leadingAnchor.constraint(equalTo: wrapper.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: wrapper.trailingAnchor),
+        ])
+        if !attachment.thumbnail.isEmpty {
+            _ = ImageCache.shared.loadImage(urlString: attachment.thumbnail) { [weak imageView] image in
+                imageView?.image = image
+            }
+        }
+
+        let overlay = UIView()
+        overlay.translatesAutoresizingMaskIntoConstraints = false
+        overlay.backgroundColor = UIColor.black.withAlphaComponent(0.4)
+        wrapper.addSubview(overlay)
+        NSLayoutConstraint.activate([
+            overlay.topAnchor.constraint(equalTo: wrapper.topAnchor),
+            overlay.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor),
+            overlay.leadingAnchor.constraint(equalTo: wrapper.leadingAnchor),
+            overlay.trailingAnchor.constraint(equalTo: wrapper.trailingAnchor),
+        ])
+        let playIcon = UIImageView(image: UIImage(systemName: "play.fill"))
+        playIcon.translatesAutoresizingMaskIntoConstraints = false
+        playIcon.tintColor = .white
+        playIcon.contentMode = .scaleAspectFit
+        overlay.addSubview(playIcon)
+        NSLayoutConstraint.activate([
+            playIcon.centerXAnchor.constraint(equalTo: overlay.centerXAnchor),
+            playIcon.centerYAnchor.constraint(equalTo: overlay.centerYAnchor),
+            playIcon.widthAnchor.constraint(equalToConstant: 20),
+            playIcon.heightAnchor.constraint(equalToConstant: 20),
+        ])
+
+        let removeButton = UIButton(type: .system)
+        removeButton.translatesAutoresizingMaskIntoConstraints = false
+        let removeConfig = UIImage.SymbolConfiguration(pointSize: 10, weight: .bold)
+        removeButton.setImage(UIImage(systemName: "xmark", withConfiguration: removeConfig), for: .normal)
+        removeButton.tintColor = .white
+        removeButton.backgroundColor = UIColor.black.withAlphaComponent(0.5)
+        removeButton.layer.cornerRadius = 10
+        removeButton.addTarget(self, action: #selector(removeExistingVideo(_:)), for: .touchUpInside)
+        wrapper.addSubview(removeButton)
+        NSLayoutConstraint.activate([
+            removeButton.topAnchor.constraint(equalTo: wrapper.topAnchor, constant: 2),
+            removeButton.trailingAnchor.constraint(equalTo: wrapper.trailingAnchor, constant: -2),
+            removeButton.widthAnchor.constraint(equalToConstant: 20),
+            removeButton.heightAnchor.constraint(equalToConstant: 20),
+        ])
+        attachmentStackView.addArrangedSubview(wrapper)
+    }
+
+    @objc private func removeExistingVideo(_ sender: UIButton) {
+        existingVideoAttachment = nil
+        sender.superview?.removeFromSuperview()
+        if !hasAttachmentPreview {
+            attachmentHeightConstraint?.constant = 0
+            UIView.animate(withDuration: 0.2) { self.view.layoutIfNeeded() }
+        }
+        updateSendButton()
+    }
+
     @objc private func removeAttachment(_ sender: UIButton) {
         let idx = sender.tag
         guard idx < sharedMediaFiles.count else { return }
@@ -1113,9 +1199,13 @@ final class SharingViewController: UIViewController {
     }
 
     private func hasShareableContent() -> Bool {
-        if !sharedMediaFiles.isEmpty { return true }
+        if hasAttachmentPreview { return true }
         let comment = (textField.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         return !comment.isEmpty
+    }
+
+    private var hasAttachmentPreview: Bool {
+        !sharedMediaFiles.isEmpty || existingVideoAttachment != nil
     }
 
     @objc private func searchTextChanged(_ tf: UITextField) {
@@ -1486,6 +1576,32 @@ final class SharingViewController: UIViewController {
             do {
                 var uploadedAttachments: [Mezon_Api_MessageAttachment] = []
 
+                if let existingVideo = self.existingVideoAttachment {
+                    let url = existingVideo.url.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !url.isEmpty else { throw SharingSendError.fileUnavailable }
+                    let remoteFilename = URL(string: url)?.lastPathComponent ?? ""
+                    let filename = existingVideo.filename.trimmingCharacters(in: .whitespacesAndNewlines)
+                    let resolvedFilename = !filename.isEmpty
+                        ? filename
+                        : (!remoteFilename.isEmpty ? remoteFilename : "video.mp4")
+                    let filetype = existingVideo.filetype.hasPrefix("video/")
+                        ? existingVideo.filetype
+                        : SendMessageInputViewController.mimeType(
+                            for: (resolvedFilename as NSString).pathExtension.lowercased()
+                        )
+
+                    var attachment = Mezon_Api_MessageAttachment()
+                    attachment.url = url
+                    attachment.thumbnail = existingVideo.thumbnail
+                    attachment.filename = resolvedFilename
+                    attachment.filetype = filetype
+                    attachment.size = Int32(clamping: max(existingVideo.size, 0))
+                    attachment.width = Int32(clamping: max(existingVideo.width, 0))
+                    attachment.height = Int32(clamping: max(existingVideo.height, 0))
+                    attachment.duration = Int32(clamping: max(existingVideo.durationSeconds, 0))
+                    uploadedAttachments.append(attachment)
+                }
+
                 for file in self.sharedMediaFiles {
                     try Task.checkCancellation()
                     guard let fileURL = SharingManager.shared.localFileURL(from: file.path) else {
@@ -1594,7 +1710,7 @@ final class SharingViewController: UIViewController {
                 }
                 let isPublic = channel.channelPrivate == 0
 
-                if uploadedAttachments.isEmpty, !self.sharedMediaFiles.isEmpty {
+                if uploadedAttachments.isEmpty, self.hasAttachmentPreview {
                     throw SharingSendError.fileUnavailable
                 }
 
@@ -1624,7 +1740,7 @@ final class SharingViewController: UIViewController {
             } catch {
                 SentryLogger.capture(error, extras: [
                     "where": "Sharing.sendWithAttachments",
-                    "mediaCount": self.sharedMediaFiles.count,
+                    "mediaCount": self.sharedMediaFiles.count + (self.existingVideoAttachment == nil ? 0 : 1),
                 ])
                 finishUploadingUI()
                 self.showError(self.userFacingShareError(error))

--- a/MezonSharing/ShareViewController.swift
+++ b/MezonSharing/ShareViewController.swift
@@ -6,7 +6,6 @@ class ShareViewController: UIViewController {
 
     private let shareProtocol = "mezon.mobile.sharing"
     private let sharedKey = "mezon.mobile.sharing"
-    private let appGroupIdentifier = "group.mezon.mobile"
 
     private var sharedMedia: [SharedMediaFile] = []
     private var sharedText: [String] = []
@@ -263,7 +262,7 @@ class ShareViewController: UIViewController {
 
     private func saveAndRedirect() {
 
-        guard let userDefaults = UserDefaults(suiteName: appGroupIdentifier) else {
+        guard let userDefaults = UserDefaults(suiteName: ExistingVideoSharePayload.appGroupIdentifier) else {
             dismissWithError(message: "Cannot access shared storage")
             return
         }
@@ -309,7 +308,9 @@ class ShareViewController: UIViewController {
     }
 
     private func sharedContainerURL() -> URL? {
-        let url = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier)
+        let url = FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: ExistingVideoSharePayload.appGroupIdentifier
+        )
         return url
     }
 
@@ -318,7 +319,7 @@ class ShareViewController: UIViewController {
               let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               let token = components.queryItems?.first(where: { $0.name == "token" })?.value,
               UUID(uuidString: token) != nil,
-              let defaults = UserDefaults(suiteName: appGroupIdentifier)
+              let defaults = UserDefaults(suiteName: ExistingVideoSharePayload.appGroupIdentifier)
         else { return nil }
 
         let key = ExistingVideoSharePayload.tokenKeyPrefix + token.lowercased()
@@ -478,26 +479,6 @@ struct SharedMediaFile: Codable {
     var type: SharedMediaType
     var width: CGFloat?
     var height: CGFloat?
-}
-
-struct ExistingVideoSharePayload: Codable {
-    static let internalScheme = "mezon-video-share"
-    static let tokenKeyPrefix = "mezon.video-share.token."
-    static let tokenLifetime: TimeInterval = 10 * 60
-
-    var url: String
-    var thumbnail: String
-    var filename: String
-    var filetype: String
-    var size: Int64
-    var width: Int
-    var height: Int
-    var durationSeconds: Int
-}
-
-private struct ExistingVideoShareTokenRecord: Codable {
-    let createdAt: TimeInterval
-    let payload: ExistingVideoSharePayload
 }
 
 enum SharedMediaType: Int, Codable {

--- a/MezonSharing/ShareViewController.swift
+++ b/MezonSharing/ShareViewController.swift
@@ -10,6 +10,7 @@ class ShareViewController: UIViewController {
 
     private var sharedMedia: [SharedMediaFile] = []
     private var sharedText: [String] = []
+    private var existingVideo: ExistingVideoSharePayload?
     private var pendingItems = 0
     private var processedItems = 0
 
@@ -128,6 +129,12 @@ class ShareViewController: UIViewController {
                 return
             }
 
+            if let payload = self.decodeExistingVideo(from: url) {
+                self.existingVideo = payload
+                self.itemProcessed()
+                return
+            }
+
             let fileExtension = self.getExtension(from: url, type: .video)
             let newName = UUID().uuidString
             guard let newPath = self.sharedContainerURL()?.appendingPathComponent("\(newName).\(fileExtension)") else {
@@ -236,7 +243,11 @@ class ShareViewController: UIViewController {
                 return
             }
 
-            self.sharedText.append(url.absoluteString)
+            if let payload = self.decodeExistingVideo(from: url) {
+                self.existingVideo = payload
+            } else {
+                self.sharedText.append(url.absoluteString)
+            }
             self.itemProcessed()
         }
     }
@@ -257,7 +268,12 @@ class ShareViewController: UIViewController {
             return
         }
 
-        if !sharedMedia.isEmpty {
+        if let existingVideo {
+            let encodedData = try? JSONEncoder().encode(existingVideo)
+            userDefaults.set(encodedData, forKey: sharedKey)
+            userDefaults.synchronize()
+            redirectToHostApp(type: .existingVideo)
+        } else if !sharedMedia.isEmpty {
             let encodedData = try? JSONEncoder().encode(sharedMedia)
             userDefaults.set(encodedData, forKey: sharedKey)
             userDefaults.synchronize()
@@ -295,6 +311,26 @@ class ShareViewController: UIViewController {
     private func sharedContainerURL() -> URL? {
         let url = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier)
         return url
+    }
+
+    private func decodeExistingVideo(from url: URL) -> ExistingVideoSharePayload? {
+        guard url.scheme?.lowercased() == ExistingVideoSharePayload.internalScheme,
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let token = components.queryItems?.first(where: { $0.name == "token" })?.value,
+              UUID(uuidString: token) != nil,
+              let defaults = UserDefaults(suiteName: appGroupIdentifier)
+        else { return nil }
+
+        let key = ExistingVideoSharePayload.tokenKeyPrefix + token.lowercased()
+        guard let data = defaults.data(forKey: key) else { return nil }
+        defaults.removeObject(forKey: key)
+        defaults.synchronize()
+
+        let now = Date().timeIntervalSince1970
+        guard let record = try? JSONDecoder().decode(ExistingVideoShareTokenRecord.self, from: data),
+              record.createdAt <= now,
+              now - record.createdAt <= ExistingVideoSharePayload.tokenLifetime else { return nil }
+        return record.payload
     }
 
     private func saveScreenshot(_ image: UIImage) -> URL? {
@@ -422,13 +458,14 @@ class ShareViewController: UIViewController {
     }
 
     enum RedirectType: CustomStringConvertible {
-        case media, text, file
+        case media, text, file, existingVideo
 
         var description: String {
             switch self {
             case .media: return "media"
             case .text: return "text"
             case .file: return "file"
+            case .existingVideo: return "existingVideo"
             }
         }
     }
@@ -441,6 +478,26 @@ struct SharedMediaFile: Codable {
     var type: SharedMediaType
     var width: CGFloat?
     var height: CGFloat?
+}
+
+struct ExistingVideoSharePayload: Codable {
+    static let internalScheme = "mezon-video-share"
+    static let tokenKeyPrefix = "mezon.video-share.token."
+    static let tokenLifetime: TimeInterval = 10 * 60
+
+    var url: String
+    var thumbnail: String
+    var filename: String
+    var filetype: String
+    var size: Int64
+    var width: Int
+    var height: Int
+    var durationSeconds: Int
+}
+
+private struct ExistingVideoShareTokenRecord: Codable {
+    let createdAt: TimeInterval
+    let payload: ExistingVideoSharePayload
 }
 
 enum SharedMediaType: Int, Codable {


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-275
Video Sharing:
Root Cause
The previous flow shared only the video CDN URL and did not distinguish between Mezon and external targets.
Solution
Added target-aware sharing that reuses the existing CDN attachment for Mezon and downloads a temporary local file only for external apps.

Video Viewer Crash:
Root Cause
AsyncDisplayKit attempted to tint zero-sized video control images, causing UIGraphicsBeginImageContext to abort the app.
Solution
Added image-size validation before applying the AsyncDisplayKit tint modification block.

Test Cases
Share a video from Mezon to Mezon and verify that the channel selection screen opens immediately.
Verify that the preparation popup does not appear when sharing to Mezon.
Send the shared video and verify that its preview size and duration are correct.
Share a video to another app and verify that the preparation popup displays progress.
Cancel video preparation and verify that the video viewer remains usable.
Complete sharing to another app and verify that the shared video can be played.
Select Save Video from the Share Sheet and verify that the video is saved successfully.
Verify that Copy is not displayed in the video Share Sheet.
Share several large videos and verify that the app continues working normally.
Open an image and verify that the image viewer’s save, copy, swipe, and share functions still work.