### PR TITLE
260819-IOS-Handle badge event

### DIFF
--- a/MezonChat/Core/AccountContext/AccountContextImpl.swift
+++ b/MezonChat/Core/AccountContext/AccountContextImpl.swift
@@ -1395,6 +1395,16 @@ final class AccountContextImpl: AccountContext {
         case .userClanRemoved(let ev):
             engine.clanData.applyClanUserRemovedFromSocket(ev)
 
+        case .clanEventCreated(let event):
+            let statusApplied = engine.clanData.applyClanEventStatusUpdate(event)
+            if !statusApplied || event.eventStatus == ClanEventStatusValue.completed {
+                Task { @MainActor [weak self] in
+                    guard let self,
+                          let token = await self.getToken() else { return }
+                    await self.engine.clanData.refetchEvents(clanId: event.clanID, token: token)
+                }
+            }
+
         case .clanUpdated(let ev):
             account.postbox.write { tx in
                 guard let existingClan = tx.getClan(id: ev.clanID) else { return }

--- a/MezonChat/Core/MezonEngine/MezonEngine+ClanData.swift
+++ b/MezonChat/Core/MezonEngine/MezonEngine+ClanData.swift
@@ -1,6 +1,12 @@
 import Foundation
 import SwiftProtobuf
 
+enum ClanEventStatusValue {
+    static let upcoming: Int32 = 1
+    static let ongoing: Int32 = 2
+    static let completed: Int32 = 3
+}
+
 enum ChannelPreferenceListCodec {
     static func decode(_ data: Data) -> [Mezon_Api_ChannelDescription] {
         guard data.count >= 4 else { return [] }
@@ -130,6 +136,10 @@ extension MezonEngine {
         private var clanUsersMemoByClanId: [Int64: (list: Mezon_Api_ClanUserList?, at: Date)] = [:]
         private let clanUsersMemoTTL: TimeInterval = 2
         private let clanUsersMemoMaxEntries = 4
+        private var clanEventSocketVersionsByClanId: [Int64: Int] = [:]
+        private var inflightEventFetchesByClanId: [Int64: Task<Void, Never>] = [:]
+        private var clanEventFetchIdsByClanId: [Int64: UUID] = [:]
+        private var pendingForcedEventFetchIdsByClanId: [Int64: UUID] = [:]
 
         init(engine: MezonEngine) { self.engine = engine }
 
@@ -146,6 +156,13 @@ extension MezonEngine {
             lastPresenceMemberRefreshAtByClanId.removeAll()
             attemptedMemberRefreshUserIdsByClanId.removeAll()
             clanUsersMemoByClanId.removeAll()
+            for (_, task) in inflightEventFetchesByClanId {
+                task.cancel()
+            }
+            inflightEventFetchesByClanId.removeAll()
+            clanEventFetchIdsByClanId.removeAll()
+            pendingForcedEventFetchIdsByClanId.removeAll()
+            clanEventSocketVersionsByClanId.removeAll()
         }
 
         func cancelFetchAllClanData(exceptClanId: Int64) {
@@ -293,7 +310,72 @@ extension MezonEngine {
         }
 
         func refetchEvents(clanId: Int64, token: String) async {
-            await fetchEvents(clanId: clanId, token: token)
+            await fetchEvents(clanId: clanId, token: token, force: true)
+        }
+
+        func channelEventStatuses(clanId: Int64) -> [Int64: Int32] {
+            var statuses: [Int64: Int32] = [:]
+            for event in getClanEvents(clanId: clanId)?.events ?? [] where event.channelID != 0 {
+                switch event.eventStatus {
+                case ClanEventStatusValue.ongoing:
+                    statuses[event.channelID] = ClanEventStatusValue.ongoing
+                case ClanEventStatusValue.upcoming:
+                    if statuses[event.channelID] != ClanEventStatusValue.ongoing {
+                        statuses[event.channelID] = ClanEventStatusValue.upcoming
+                    }
+                default:
+                    break
+                }
+            }
+            return statuses
+        }
+
+        @discardableResult
+        func applyClanEventStatusUpdate(_ update: Mezon_Api_CreateEventRequest) -> Bool {
+            let validStatuses: Set<Int32> = [
+                ClanEventStatusValue.upcoming,
+                ClanEventStatusValue.ongoing,
+                ClanEventStatusValue.completed,
+            ]
+            guard update.clanID != 0 else {
+                return false
+            }
+            markClanEventSocketUpdate(clanId: update.clanID)
+            guard update.action == 0,
+                  validStatuses.contains(update.eventStatus) else {
+                return false
+            }
+
+            guard var list = getClanEvents(clanId: update.clanID) else {
+                return false
+            }
+            guard let index = list.events.firstIndex(where: { $0.id == update.eventID }) else {
+                return false
+            }
+
+            var event = list.events[index]
+            let updatedStartTime = update.eventStatus == ClanEventStatusValue.completed
+                && update.startTimeSeconds != 0
+                ? update.startTimeSeconds
+                : event.startTimeSeconds
+            guard event.eventStatus != update.eventStatus || event.startTimeSeconds != updatedStartTime else {
+                return true
+            }
+
+            event.eventStatus = update.eventStatus
+            event.startTimeSeconds = updatedStartTime
+            list.events[index] = event
+            guard let data = try? list.serializedData() else { return false }
+            postbox.setPreferenceDataSync(
+                key: PreferencesKeys.clanEvents(clanId: update.clanID),
+                value: data
+            )
+            clanEventsUpdated.putNext(update.clanID)
+            return true
+        }
+
+        private func markClanEventSocketUpdate(clanId: Int64) {
+            clanEventSocketVersionsByClanId[clanId, default: 0] += 1
         }
 
         func setUserEventInterest(
@@ -320,7 +402,7 @@ extension MezonEngine {
                     try await network.deleteUserEvent(request: req, token: token)
                 }
             } catch {
-                await fetchEvents(clanId: clanId, token: token)
+                await refetchEvents(clanId: clanId, token: token)
             }
         }
 
@@ -347,15 +429,60 @@ extension MezonEngine {
             postbox.setPreferenceDataSync(key: PreferencesKeys.clanEvents(clanId: clanId), value: data)
         }
 
-        private func fetchEvents(clanId: Int64, token: String) async {
-            do {
-                let response = try await network.listEvents(clanId: clanId, token: token)
-                if let data = try? response.serializedData() {
-                    postbox.setPreferenceDataSync(key: PreferencesKeys.clanEvents(clanId: clanId), value: data)
+        private func fetchEvents(clanId: Int64, token: String, force: Bool = false) async {
+            guard clanId != 0 else { return }
+            if let existing = inflightEventFetchesByClanId[clanId] {
+                if force, let fetchId = clanEventFetchIdsByClanId[clanId] {
+                    pendingForcedEventFetchIdsByClanId[clanId] = fetchId
                 }
-                clanEventsUpdated.putNext(clanId)
-            } catch {
+                await existing.value
+                return
             }
+
+            let fetchId = UUID()
+            clanEventFetchIdsByClanId[clanId] = fetchId
+            let task = Task { @MainActor [weak self] in
+                guard let self else { return }
+                defer {
+                    if self.clanEventFetchIdsByClanId[clanId] == fetchId {
+                        self.inflightEventFetchesByClanId[clanId] = nil
+                        self.clanEventFetchIdsByClanId[clanId] = nil
+                        self.pendingForcedEventFetchIdsByClanId[clanId] = nil
+                    }
+                }
+
+                var shouldFetch = true
+                while shouldFetch, !Task.isCancelled {
+                    let socketVersion = self.clanEventSocketVersionsByClanId[clanId] ?? 0
+                    var appliedCurrentResponse = false
+                    do {
+                        let response = try await self.network.listEvents(clanId: clanId, token: token)
+                        guard !Task.isCancelled,
+                              self.clanEventFetchIdsByClanId[clanId] == fetchId else {
+                            return
+                        }
+                        if self.clanEventSocketVersionsByClanId[clanId, default: 0] == socketVersion {
+                            if let data = try? response.serializedData() {
+                                self.postbox.setPreferenceDataSync(
+                                    key: PreferencesKeys.clanEvents(clanId: clanId),
+                                    value: data
+                                )
+                            }
+                            self.clanEventsUpdated.putNext(clanId)
+                            appliedCurrentResponse = true
+                        }
+                    } catch {
+                    }
+
+                    let hasPendingForce = self.pendingForcedEventFetchIdsByClanId[clanId] == fetchId
+                    if hasPendingForce {
+                        self.pendingForcedEventFetchIdsByClanId[clanId] = nil
+                    }
+                    shouldFetch = hasPendingForce && !appliedCurrentResponse
+                }
+            }
+            inflightEventFetchesByClanId[clanId] = task
+            await task.value
         }
 
         private func fetchUserPermissions(clanId: Int64, token: String) async {

--- a/MezonChat/Features/ChannelList/ChannelItemCellNode.swift
+++ b/MezonChat/Features/ChannelList/ChannelItemCellNode.swift
@@ -1,10 +1,113 @@
 import AsyncDisplayKit
 import UIKit
 
+enum ChannelEventIcon {
+    private static let upcomingImage = makeImage(
+        tintColor: UIColor(red: 168 / 255, green: 85 / 255, blue: 247 / 255, alpha: 1)
+    )
+    private static let ongoingImage = makeImage(
+        tintColor: UIColor(red: 34 / 255, green: 197 / 255, blue: 94 / 255, alpha: 1)
+    )
+
+    static func normalizedStatus(_ status: Int32?) -> Int32? {
+        switch status {
+        case ClanEventStatusValue.upcoming, ClanEventStatusValue.ongoing:
+            return status
+        default:
+            return nil
+        }
+    }
+
+    static func image(for status: Int32?) -> UIImage? {
+        switch normalizedStatus(status) {
+        case ClanEventStatusValue.upcoming:
+            return upcomingImage
+        case ClanEventStatusValue.ongoing:
+            return ongoingImage
+        default:
+            return nil
+        }
+    }
+
+    private static func makeImage(tintColor: UIColor) -> UIImage? {
+        guard let source = UIImage(named: "Channel/Event"),
+              let sourceImage = source.cgImage else {
+            return nil
+        }
+
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        guard tintColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else {
+            return source
+        }
+
+        let width = sourceImage.width
+        let height = sourceImage.height
+        let bytesPerRow = width * 4
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGBitmapInfo.byteOrder32Big.rawValue
+            | CGImageAlphaInfo.premultipliedLast.rawValue
+        var pixels = [UInt8](repeating: 0, count: height * bytesPerRow)
+        let outputImage: CGImage? = pixels.withUnsafeMutableBytes { buffer in
+            guard let context = CGContext(
+                data: buffer.baseAddress,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: bytesPerRow,
+                space: colorSpace,
+                bitmapInfo: bitmapInfo
+            ) else {
+                return nil
+            }
+            context.draw(sourceImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+            let bytes = buffer.bindMemory(to: UInt8.self)
+            let targetRed = red * 255
+            let targetGreen = green * 255
+            let targetBlue = blue * 255
+            let whiteThreshold: CGFloat = 120
+            for offset in stride(from: 0, to: bytes.count, by: 4) {
+                let pixelAlpha = CGFloat(bytes[offset + 3])
+                guard pixelAlpha > 0 else { continue }
+                let unpremultiply = 255 / pixelAlpha
+                let sourceRed = min(255, CGFloat(bytes[offset]) * unpremultiply)
+                let sourceGreen = min(255, CGFloat(bytes[offset + 1]) * unpremultiply)
+                let sourceBlue = min(255, CGFloat(bytes[offset + 2]) * unpremultiply)
+                let sourceWhite = min(sourceRed, sourceGreen, sourceBlue)
+                let whiteMix = min(
+                    1,
+                    max(0, (sourceWhite - whiteThreshold) / (255 - whiteThreshold))
+                )
+                let premultiply = pixelAlpha / 255
+                bytes[offset] = UInt8(
+                    ((targetRed * (1 - whiteMix) + 255 * whiteMix) * premultiply).rounded()
+                )
+                bytes[offset + 1] = UInt8(
+                    ((targetGreen * (1 - whiteMix) + 255 * whiteMix) * premultiply).rounded()
+                )
+                bytes[offset + 2] = UInt8(
+                    ((targetBlue * (1 - whiteMix) + 255 * whiteMix) * premultiply).rounded()
+                )
+            }
+            return context.makeImage()
+        }
+        guard let outputImage else { return source }
+        return UIImage(
+            cgImage: outputImage,
+            scale: source.scale,
+            orientation: source.imageOrientation
+        )
+    }
+}
+
 final class ChannelItemCellNode: ASCellNode {
 
     private let iconNode = ASTextNode2()
     private let iconImgNode = ASImageNode()
+    private let eventIconNode = ASImageNode()
     private let nameNode = ASTextNode2()
     private let badgeNode = ASTextNode2()
     private let badgeBackground = ASDisplayNode()
@@ -15,11 +118,20 @@ final class ChannelItemCellNode: ASCellNode {
     private let channel: Mezon_Api_ChannelDescription
     private let cellSelected: Bool
     private let isVoiceActive: Bool
+    private var eventStatus: Int32?
+    let channelId: Int64
 
-    init(channel: Mezon_Api_ChannelDescription, isSelected: Bool, isVoiceActive: Bool = false) {
+    init(
+        channel: Mezon_Api_ChannelDescription,
+        isSelected: Bool,
+        isVoiceActive: Bool = false,
+        eventStatus: Int32? = nil
+    ) {
         self.channel = channel
         self.cellSelected = isSelected
         self.isVoiceActive = isVoiceActive
+        self.eventStatus = ChannelEventIcon.normalizedStatus(eventStatus)
+        self.channelId = channel.channelID
         super.init()
         automaticallyManagesSubnodes = true
         neverShowPlaceholders = true
@@ -81,6 +193,10 @@ final class ChannelItemCellNode: ASCellNode {
             iconImgNode.isHidden = true
         }
 
+        eventIconNode.image = ChannelEventIcon.image(for: eventStatus)
+        eventIconNode.contentMode = .scaleAspectFit
+        eventIconNode.isHidden = eventIconNode.image == nil
+
         let nameStr = channel.channelLabel.isEmpty ? "channel" : channel.channelLabel
         let nameColor =
             isUnread ? t.channelUnread : t.channelNormal
@@ -131,6 +247,15 @@ final class ChannelItemCellNode: ASCellNode {
         isUserInteractionEnabled = true
     }
 
+    func applyEventStatus(_ status: Int32?) {
+        let normalized = ChannelEventIcon.normalizedStatus(status)
+        guard eventStatus != normalized else { return }
+        eventStatus = normalized
+        eventIconNode.image = ChannelEventIcon.image(for: normalized)
+        eventIconNode.isHidden = eventIconNode.image == nil
+        setNeedsLayout()
+    }
+
     func applyListSelectionState(selected: Bool) {
         let t = UIColor.theme
         let isVoiceType = Self.voiceTypes.contains(channel.type)
@@ -172,6 +297,23 @@ final class ChannelItemCellNode: ASCellNode {
         iconNode.style.preferredSize = CGSize(width: 14.swh, height: 14.swh)
         iconImgNode.style.preferredSize = CGSize(width: 12.swh, height: 12.swh)
         let iconChild: ASLayoutElement = iconNode.isHidden ? iconImgNode : iconNode
+        eventIconNode.style.preferredSize = CGSize(width: 16.swh, height: 16.swh)
+
+        let leadingChild: ASLayoutElement
+        let contentSpacing: CGFloat
+        if eventIconNode.isHidden {
+            leadingChild = iconChild
+            contentSpacing = 10.sw
+        } else {
+            leadingChild = ASStackLayoutSpec(
+                direction: .horizontal,
+                spacing: 6.sw,
+                justifyContent: .start,
+                alignItems: .center,
+                children: [iconChild, eventIconNode]
+            )
+            contentSpacing = 8.sw
+        }
 
         let badgeInset = ASInsetLayoutSpec(
             insets: UIEdgeInsets(top: 2.swh, left: 6.swh, bottom: 2.swh, right: 6.swh),
@@ -186,13 +328,13 @@ final class ChannelItemCellNode: ASCellNode {
         nameNode.style.flexShrink = 1
         nameNode.style.flexGrow = 0
 
-        var children: [ASLayoutElement] = [iconChild, nameNode]
+        var children: [ASLayoutElement] = [leadingChild, nameNode]
         if !badgeNode.isHidden {
             children.append(contentsOf: [spacer, badge])
         }
 
         let row = ASStackLayoutSpec(
-            direction: .horizontal, spacing: 10.sw, justifyContent: .start, alignItems: .center,
+            direction: .horizontal, spacing: contentSpacing, justifyContent: .start, alignItems: .center,
             children: children)
 
         let inset = ASInsetLayoutSpec(

--- a/MezonChat/Features/ChannelList/ChannelListContainerNode.swift
+++ b/MezonChat/Features/ChannelList/ChannelListContainerNode.swift
@@ -71,6 +71,7 @@ final class ChannelListContainerNode: ASDisplayNode {
 
     private var state: ChannelListState = .empty
     private var threadLookup: [Int64: [Mezon_Api_ChannelDescription]] = [:]
+    private var channelEventStatuses: [Int64: Int32] = [:]
 
     private var cachedRows: [Int: [ChannelListRow]] = [:]
 
@@ -1007,6 +1008,39 @@ final class ChannelListContainerNode: ASDisplayNode {
             }
         }
         CATransaction.commit()
+    }
+
+    func updateChannelEventStatuses(_ statuses: [Int64: Int32]) {
+        guard channelEventStatuses != statuses else { return }
+        let previous = channelEventStatuses
+        let changedChannelIds = Set(previous.keys).union(statuses.keys).filter {
+            previous[$0] != statuses[$0]
+        }
+        channelEventStatuses = statuses
+
+        guard isNodeLoaded, !changedChannelIds.isEmpty else { return }
+        let sectionOffset = leadingTableSectionsCount
+        for categoryIndex in state.categories.indices {
+            let section = categoryIndex + sectionOffset
+            guard section < tableNode.numberOfSections else { continue }
+            let rows = rowsForSection(categoryIndex)
+            guard tableNode.numberOfRows(inSection: section) == rows.count else { continue }
+            for (rowIndex, row) in rows.enumerated() {
+                let channelId = row.channelDesc.channelID
+                guard changedChannelIds.contains(channelId),
+                      let node = tableNode.nodeForRow(at: IndexPath(row: rowIndex, section: section)) else {
+                    continue
+                }
+                switch row {
+                case .channel:
+                    (node as? ChannelItemCellNode)?.applyEventStatus(statuses[channelId])
+                case .thread:
+                    (node as? ThreadItemCellNode)?.applyEventStatus(statuses[channelId])
+                default:
+                    break
+                }
+            }
+        }
     }
 
     private func channelListRowVisuallyChanged(
@@ -2310,16 +2344,28 @@ extension ChannelListContainerNode: ASTableDataSource {
         case .channel(let ch, let inFav):
             let hasVoiceMembers = Self.voiceChannelTypes.contains(ch.type)
                 && !(state.voiceUsersByChannel[ch.channelID] ?? []).isEmpty
+            let eventStatus = channelEventStatuses[ch.channelID]
             return {
-                let node = ChannelItemCellNode(channel: ch, isSelected: isSelected, isVoiceActive: hasVoiceMembers)
+                let node = ChannelItemCellNode(
+                    channel: ch,
+                    isSelected: isSelected,
+                    isVoiceActive: hasVoiceMembers,
+                    eventStatus: eventStatus
+                )
                 node.onLongPress = { [weak self] in
                     self?.interaction.onLongPressChannel(ch)
                 }
                 return node
             }
         case .thread(let ch, let isLast, let inFav):
+            let eventStatus = channelEventStatuses[ch.channelID]
             return {
-                let node = ThreadItemCellNode(channel: ch, isSelected: isSelected, isLast: isLast)
+                let node = ThreadItemCellNode(
+                    channel: ch,
+                    isSelected: isSelected,
+                    isLast: isLast,
+                    eventStatus: eventStatus
+                )
                 node.onLongPress = { [weak self] in
                     self?.interaction.onLongPressChannel(ch)
                 }
@@ -2399,6 +2445,11 @@ extension ChannelListContainerNode: ASTableDataSource {
 extension ChannelListContainerNode: ASTableDelegate {
 
     func tableNode(_ tableNode: ASTableNode, willDisplayRowWith node: ASCellNode) {
+        if let channelNode = node as? ChannelItemCellNode {
+            channelNode.applyEventStatus(channelEventStatuses[channelNode.channelId])
+        } else if let threadNode = node as? ThreadItemCellNode {
+            threadNode.applyEventStatus(channelEventStatuses[threadNode.channelId])
+        }
         guard node.isNodeLoaded else { return }
         var current: UIView? = node.view
         while let v = current, !(v is UITableViewCell) {

--- a/MezonChat/Features/ChannelList/ChannelListViewController.swift
+++ b/MezonChat/Features/ChannelList/ChannelListViewController.swift
@@ -717,6 +717,7 @@ final class ChannelListViewController: ViewController {
     private let fetchDisposable = MetaDisposable()
     private let dataDisposable = MetaDisposable()
     private let clanUsersDisposable = MetaDisposable()
+    private let clanEventsDisposable = MetaDisposable()
     private var processedBadgeKeys = Set<String>()
     private var pendingMentionUnreadFloorByClanId: [Int64: [Int64: Int32]] = [:]
 
@@ -908,6 +909,7 @@ final class ChannelListViewController: ViewController {
         fetchDisposable.dispose()
         dataDisposable.dispose()
         clanUsersDisposable.dispose()
+        clanEventsDisposable.dispose()
         NotificationCenter.default.removeObserver(self)
     }
 
@@ -1046,6 +1048,7 @@ final class ChannelListViewController: ViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         refreshShowEmptyCategoriesPreferenceFromCache()
+        refreshChannelEventStatuses()
         reconcileChannelListDataIfNeeded()
     }
 
@@ -1094,6 +1097,20 @@ final class ChannelListViewController: ViewController {
                 self.scheduleCoalescedClanUsersReload()
             })
         )
+        clanEventsDisposable.set(
+            (context.engine.clanData.clanEventsUpdated.signal() |> deliverOnMainQueue).start(next: { [weak self] updatedClanId in
+                guard let self, self.clanId != 0, updatedClanId == self.clanId else { return }
+                self.refreshChannelEventStatuses()
+            })
+        )
+        refreshChannelEventStatuses()
+    }
+
+    private func refreshChannelEventStatuses() {
+        let statuses = clanId == 0
+            ? [:]
+            : context.engine.clanData.channelEventStatuses(clanId: clanId)
+        channelListNode.updateChannelEventStatuses(statuses)
     }
 
     @objc private func handleAccountCurrentUserDidChangeForOnboarding(_ notification: Notification) {
@@ -1282,6 +1299,7 @@ final class ChannelListViewController: ViewController {
     @objc private func handleSocketStatusForChannelBadges(_ notification: Notification) {
         guard let connected = notification.userInfo?["isConnected"] as? Bool, connected else { return }
         guard clanId != 0 else { return }
+        refetchChannelEventsAfterConnectivityRestored()
         refreshChannelListAfterConnectivityRestored()
     }
 
@@ -1296,6 +1314,17 @@ final class ChannelListViewController: ViewController {
         Task { @MainActor [weak self] in
             guard let self, self.clanId != 0 else { return }
             await self.applyChannelBadgeCounts(clanId: self.clanId)
+        }
+    }
+
+    private func refetchChannelEventsAfterConnectivityRestored() {
+        let clanId = self.clanId
+        guard clanId != 0 else { return }
+        Task { @MainActor [weak self] in
+            guard let self, self.clanId == clanId else { return }
+            guard let token = await self.context.getTokenPreferringCachedSkipSessionReadyWait() else { return }
+            guard self.clanId == clanId else { return }
+            await self.context.engine.clanData.refetchEvents(clanId: clanId, token: token)
         }
     }
 
@@ -2799,6 +2828,7 @@ final class ChannelListViewController: ViewController {
         }
         self.clanId = clanId
         self.clanName = clanName
+        refreshChannelEventStatuses()
         emptyChannelRetryCountByClanId[clanId] = 0
         self.showEmptyCategoriesEnabled = loadShowEmptyCategoriesPreference(clanId: clanId)
         errorMessage = nil

--- a/MezonChat/Features/ChannelList/Event/EventViewerBottomSheetViewController.swift
+++ b/MezonChat/Features/ChannelList/Event/EventViewerBottomSheetViewController.swift
@@ -450,6 +450,10 @@ final class EventViewerBottomSheetViewController: UIViewController {
             }
         }
 
+        updateLoadingState()
+    }
+
+    private func updateLoadingState() {
         loadingRow.isHidden = !isFetching
         loadingIndicator.isHidden = !isFetching
         if isFetching {
@@ -527,22 +531,11 @@ final class EventViewerBottomSheetViewController: UIViewController {
             guard let self else { return }
             defer {
                 self.isFetching = false
-                self.reloadEvents()
+                self.updateLoadingState()
             }
             guard let token = await self.context.getToken() else { return }
-            do {
-                let response = try await MezonHTTPClient.shared.listEvents(clanId: self.clanId, token: token)
-                self.loadedEvents = response.events
-                if let data = try? response.serializedData() {
-                    self.context.account.postbox.setPreferenceDataSync(
-                        key: PreferencesKeys.clanEvents(clanId: self.clanId),
-                        value: data
-                    )
-                }
-            } catch {
-                await self.context.engine.clanData.refetchEvents(clanId: self.clanId, token: token)
-                self.loadedEvents = self.context.engine.clanData.getClanEvents(clanId: self.clanId)?.events ?? []
-            }
+            await self.context.engine.clanData.refetchEvents(clanId: self.clanId, token: token)
+            self.loadedEvents = self.context.engine.clanData.getClanEvents(clanId: self.clanId)?.events ?? []
         }
     }
 }

--- a/MezonChat/Features/ChannelList/ThreadItemCellNode.swift
+++ b/MezonChat/Features/ChannelList/ThreadItemCellNode.swift
@@ -4,15 +4,25 @@ import UIKit
 final class ThreadItemCellNode: ASCellNode {
 
     private let connectorNode = ASImageNode()
+    private let eventIconNode = ASImageNode()
     private let nameNode = ASTextNode2()
     private let badgeNode = ASTextNode2()
     private let badgeBackground = ASDisplayNode()
     private let selectionNode = ASDisplayNode()
     var onLongPress: (() -> Void)?
     private let isLast: Bool
+    private var eventStatus: Int32?
+    let channelId: Int64
 
-    init(channel: Mezon_Api_ChannelDescription, isSelected: Bool, isLast: Bool) {
+    init(
+        channel: Mezon_Api_ChannelDescription,
+        isSelected: Bool,
+        isLast: Bool,
+        eventStatus: Int32? = nil
+    ) {
         self.isLast = isLast
+        self.eventStatus = ChannelEventIcon.normalizedStatus(eventStatus)
+        self.channelId = channel.channelID
         super.init()
         automaticallyManagesSubnodes = true
         neverShowPlaceholders = true
@@ -31,6 +41,10 @@ final class ThreadItemCellNode: ASCellNode {
         connectorNode.image = UIImage(named: connectorName)
         connectorNode.tintColor = t.channelNormal.withAlphaComponent(0.6)
         connectorNode.contentMode = .scaleAspectFit
+
+        eventIconNode.image = ChannelEventIcon.image(for: eventStatus)
+        eventIconNode.contentMode = .scaleAspectFit
+        eventIconNode.isHidden = eventIconNode.image == nil
 
         let nameColor =
             isUnread ? t.channelUnread : t.channelNormal
@@ -77,6 +91,15 @@ final class ThreadItemCellNode: ASCellNode {
         isUserInteractionEnabled = true
     }
 
+    func applyEventStatus(_ status: Int32?) {
+        let normalized = ChannelEventIcon.normalizedStatus(status)
+        guard eventStatus != normalized else { return }
+        eventStatus = normalized
+        eventIconNode.image = ChannelEventIcon.image(for: normalized)
+        eventIconNode.isHidden = eventIconNode.image == nil
+        setNeedsLayout()
+    }
+
     func applyListSelectionState(selected: Bool) {
         let t = UIColor.theme
         selectionNode.isHidden = !selected
@@ -119,6 +142,7 @@ final class ThreadItemCellNode: ASCellNode {
         badge.style.minSize = CGSize(width: 20.swh, height: 20.swh)
 
         nameNode.style.flexShrink = 1
+        eventIconNode.style.preferredSize = CGSize(width: 16.swh, height: 16.swh)
         let spacer = ASLayoutSpec()
         spacer.style.flexGrow = 1
 
@@ -128,7 +152,11 @@ final class ThreadItemCellNode: ASCellNode {
             insets: UIEdgeInsets(top: topInset, left: leftInset, bottom: 0, right: 0),
             child: connectorNode)
 
-        var contentChildren: [ASLayoutElement] = [nameNode]
+        var contentChildren: [ASLayoutElement] = []
+        if !eventIconNode.isHidden {
+            contentChildren.append(eventIconNode)
+        }
+        contentChildren.append(nameNode)
         if !badgeNode.isHidden {
             contentChildren.append(contentsOf: [spacer, badge])
         }

--- a/MezonChat/Networking/MezonSocket.swift
+++ b/MezonChat/Networking/MezonSocket.swift
@@ -29,6 +29,7 @@ enum SocketEvent {
     case clanDeleted(Mezon_Realtime_ClanDeletedEvent)
     case userClanRemoved(Mezon_Realtime_UserClanRemoved)
     case userClanAdded(Mezon_Realtime_AddClanUserEvent)
+    case clanEventCreated(Mezon_Api_CreateEventRequest)
 
     case voiceJoined(Mezon_Realtime_VoiceJoinedEvent)
     case voiceLeaved(Mezon_Realtime_VoiceLeavedEvent)
@@ -804,6 +805,8 @@ final class MezonSocket: NSObject {
             eventPipe.putNext(.userClanRemoved(m))
         case .addClanUserEvent(let m):
             eventPipe.putNext(.userClanAdded(m))
+        case .clanEventCreated(let m):
+            eventPipe.putNext(.clanEventCreated(m))
         case .voiceJoinedEvent(let m):
             eventPipe.putNext(.voiceJoined(m))
         case .voiceLeavedEvent(let m):


### PR DESCRIPTION
task: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-290
Root Cause
Channel rows did not receive event status updates, so they could not show whether an event was upcoming or ongoing.
Solution
Added event status synchronization and updated only the affected channel or thread to show a purple icon before the event and a green icon during the event.

Test Cases
Verify that a channel with an upcoming event shows a purple event icon.
Verify that a channel with an ongoing event shows a green event icon.
Verify that the event icon disappears after the event ends.
Verify that no event icon appears on channels without an upcoming or ongoing event.
Verify that a thread with an upcoming or ongoing event shows the correct event icon.
Verify that the icon updates without reopening the channel list when the event starts or ends.

