### PR TITLE
260819-IOS-Fix bug in topic tab

### DIFF
--- a/MezonChat/Features/Notifications/NotificationsContainerNode.swift
+++ b/MezonChat/Features/Notifications/NotificationsContainerNode.swift
@@ -2,6 +2,10 @@ import AsyncDisplayKit
 import Combine
 import UIKit
 
+enum NotificationTabCategory {
+    static let topic: Int32 = 4
+}
+
 enum NotificationItem {
     case notification(NotificationRecord)
     case topic(TopicRecord)
@@ -578,7 +582,7 @@ final class NotificationsContainerNode: ASDisplayNode {
     private let tabs: [TabInfo] = [
         TabInfo(title: L(L10n.Notifications.mentions), tag: 1, iconName: "Notifications/mentions"),
         TabInfo(title: L(L10n.Notifications.messages), tag: 2, iconName: "Notifications/messages"),
-        TabInfo(title: L(L10n.Notifications.topic), tag: 4, iconName: "Notifications/topic"),
+        TabInfo(title: L(L10n.Notifications.topic), tag: NotificationTabCategory.topic, iconName: "Notifications/topic"),
         TabInfo(title: L(L10n.Notifications.forYou), tag: 3, iconName: "Notifications/forYou"),
     ]
     private var selectedTabIndex: Int = 0

--- a/MezonChat/Features/Notifications/NotificationsViewController.swift
+++ b/MezonChat/Features/Notifications/NotificationsViewController.swift
@@ -67,7 +67,7 @@ final class NotificationsViewController: ViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         notificationsNode.applyTheme()
-        let clanId = context.currentClanId
+        let clanId = currentCategory == NotificationTabCategory.topic ? resolvedTopicClanId() : context.currentClanId
         if items.isEmpty || clanId != lastLoadedClanId {
             loadedCategories.removeAll()
             Task { await fetchNotifications(category: currentCategory) }
@@ -101,15 +101,22 @@ final class NotificationsViewController: ViewController {
         }
 
         let token = await context.getToken()
-        let clanId = context.currentClanId
+        let clanId = category == NotificationTabCategory.topic ? resolvedTopicClanId() : context.currentClanId
 
         if isLoadMore, token == nil {
             setIsLoadingMore(false)
             return
         }
 
-        if category == 4 {
+        if category == NotificationTabCategory.topic {
             dataDisposable?.dispose()
+            defer { setIsLoading(false) }
+            guard clanId != 0 else {
+                loadedCategories.insert(category)
+                lastLoadedClanId = clanId
+                setItems([])
+                return
+            }
             dataDisposable =
                 (context.engine.data.subscribe(
                     MezonEngine.EngineData.Item.TopicList(clanId: clanId)
@@ -118,7 +125,6 @@ final class NotificationsViewController: ViewController {
                     self.setItems(self.enrichTopicItems(topics))
                 })
 
-            defer { setIsLoading(false) }
             guard let token else { return }
             do {
                 try await context.engine.topicDiscussion.listTopics(
@@ -162,6 +168,21 @@ final class NotificationsViewController: ViewController {
             lastLoadedClanId = clanId
         } catch {
         }
+    }
+
+    private func resolvedTopicClanId() -> Int64 {
+        if context.currentClanId != 0 {
+            return context.currentClanId
+        }
+        let storedClanId = UserDefaults.standard.integer(forKey: "mezon_selectedClanId")
+        if storedClanId != 0 {
+            return Int64(storedClanId)
+        }
+        if let data = context.account.postbox.getPreferenceData(key: PreferencesKeys.selectedClanId),
+           data.count >= 8 {
+            return data.withUnsafeBytes { $0.loadUnaligned(as: Int64.self).littleEndian }
+        }
+        return 0
     }
 
     deinit {


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-286
Root Cause
Opening a DM resets the active clan ID to 0, causing the Topic tab to load data without the currently selected clan.
Solution
Use the currently selected clan when opening the Topic tab from a DM, and do not load topics when no clan is selected.

Test Cases
Open a DM, go to Notifications > Topics, and verify topics from the currently selected clan are displayed.
Switch to another clan, open a DM, and verify the Topics tab displays topics from the newly selected clan.
Open the Topics tab while viewing a clan channel and verify the correct clan topics are displayed.
Verify the Topics tab is empty when the user has no clan.
Verify the Mentions, Messages, and For You tabs continue to work normally.