### PR TITLE
260821-IOS-Update type attachment

### DIFF
--- a/MezonChat/Core/Localization/L10n.swift
+++ b/MezonChat/Core/Localization/L10n.swift
@@ -1200,7 +1200,11 @@ enum L10n {
     enum ChannelDetail {
         static let members = "channelDetail.members"
         static let media   = "channelDetail.media"
+        static let images  = "channelDetail.images"
+        static let videos  = "channelDetail.videos"
         static let files   = "channelDetail.files"
+        static let docs    = "channelDetail.docs"
+        static let audios  = "channelDetail.audios"
         static let pins    = "channelDetail.pins"
         static let canvas  = "channelDetail.canvas"
         static let online  = "channelDetail.online"
@@ -2483,7 +2487,11 @@ extension L10n {
 
         "channelDetail.members": "Members",
         "channelDetail.media":   "Media",
+        "channelDetail.images":  "Images",
+        "channelDetail.videos":  "Videos",
         "channelDetail.files":   "Files",
+        "channelDetail.docs":    "Docs",
+        "channelDetail.audios":  "Audios",
         "channelDetail.pins":    "Pins",
         "channelDetail.canvas":  "Canvas",
         "channelDetail.online":  "Online",
@@ -3734,7 +3742,11 @@ extension L10n {
 
         "channelDetail.members": "Thành viên",
         "channelDetail.media":   "Phương tiện",
+        "channelDetail.images":  "Hình ảnh",
+        "channelDetail.videos":  "Video",
         "channelDetail.files":   "Tệp",
+        "channelDetail.docs":    "Tài liệu",
+        "channelDetail.audios":  "Âm thanh",
         "channelDetail.pins":    "Ghim",
         "channelDetail.canvas":  "Canvas",
         "channelDetail.online":  "Trực tuyến",

--- a/MezonChat/Core/UI/ImgproxyURL.swift
+++ b/MezonChat/Core/UI/ImgproxyURL.swift
@@ -51,14 +51,15 @@ enum ImgproxyURL {
         from sourceURL: String,
         width: Int,
         height: Int,
-        resizeType: String = "fit"
+        resizeType: String = "fit",
+        forceProxy: Bool = false
     ) -> String {
         let resolvedSourceURL = secureURLString(from: sourceURL)
         guard !resolvedSourceURL.isEmpty else { return resolvedSourceURL }
         guard cdnHosts.contains(where: { resolvedSourceURL.contains($0) }) else {
             return resolvedSourceURL
         }
-        if shouldSkipProxy(resolvedSourceURL) {
+        if !forceProxy && shouldSkipProxy(resolvedSourceURL) {
             return resolvedSourceURL
         }
         let w = max(1, width)

--- a/MezonChat/Features/ChannelDetail/Tabs/FileListNode.swift
+++ b/MezonChat/Features/ChannelDetail/Tabs/FileListNode.swift
@@ -9,6 +9,20 @@ private struct FileDaySection {
     let items: [Mezon_Api_ChannelAttachment]
 }
 
+private enum ChannelFilesType: String, CaseIterable {
+    case doc
+    case audio
+}
+
+private struct ChannelFilesState {
+    var attachments: [Mezon_Api_ChannelAttachment] = []
+    var didLoad = false
+    var isFetching = false
+    var refreshPending = false
+    var showsLoading = false
+    var loadFailed = false
+}
+
 @MainActor
 final class FileListNode: ASDisplayNode {
 
@@ -17,13 +31,13 @@ final class FileListNode: ASDisplayNode {
     private let channelId: Int64
     private let channelType: Int32
 
-    private var rawAttachments: [Mezon_Api_ChannelAttachment] = []
+    private var filesStateByType: [ChannelFilesType: ChannelFilesState] = [:]
+    private var selectedFilesType: ChannelFilesType = .doc
     private var sections: [FileDaySection] = []
     private var searchQuery: String = ""
-    private var isLoading = false
-    private var loadFailed = false
-    private var filesTabActivated = false
 
+    private let filesTypeControl: UISegmentedControl
+    private let filesTypeControlNode: ASDisplayNode
     private let tableNode = ASTableNode()
     private let loadingNode: ASDisplayNode
 
@@ -33,6 +47,12 @@ final class FileListNode: ASDisplayNode {
         self.channelId = channelId
         self.channelType = channelType
 
+        let filesTypeControl = UISegmentedControl(items: [
+            L(L10n.ChannelDetail.docs),
+            L(L10n.ChannelDetail.audios),
+        ])
+        self.filesTypeControl = filesTypeControl
+        self.filesTypeControlNode = ASDisplayNode(viewBlock: { filesTypeControl })
         self.loadingNode = ASDisplayNode(viewBlock: {
             let v = UIActivityIndicatorView(style: .large)
             v.color = UIColor.theme.text
@@ -42,6 +62,18 @@ final class FileListNode: ASDisplayNode {
 
         super.init()
         automaticallyManagesSubnodes = true
+
+        filesTypeControl.selectedSegmentIndex = 0
+        filesTypeControl.addTarget(
+            self, action: #selector(filesTypeChanged(_:)), for: .valueChanged)
+        filesTypeControl.selectedSegmentTintColor = UIColor.theme.bgViolet
+        filesTypeControl.backgroundColor = UIColor.theme.secondary
+        let segmentFont = UIFont.systemFont(ofSize: 14.sf, weight: .semibold)
+        filesTypeControl.setTitleTextAttributes(
+            [.font: segmentFont, .foregroundColor: UIColor.theme.text], for: .normal)
+        filesTypeControl.setTitleTextAttributes(
+            [.font: segmentFont, .foregroundColor: UIColor.white], for: .selected)
+        filesTypeControlNode.style.height = ASDimension(unit: .points, value: 40.sf)
 
         tableNode.dataSource = self
         tableNode.delegate = self
@@ -84,15 +116,13 @@ final class FileListNode: ASDisplayNode {
         
         if notiChannelId == self.channelId || (notiTopicId != 0 && notiTopicId == self.channelId) {
             DispatchQueue.main.async {
-                self.fetchFiles(showLoading: false)
+                self.refreshFilesAfterMessageChange()
             }
         }
     }
 
     func loadTabDataIfNeeded() {
-        guard !filesTabActivated else { return }
-        filesTabActivated = true
-        fetchFiles()
+        loadFilesIfNeeded(for: selectedFilesType)
     }
 
     override func didLoad() {
@@ -115,6 +145,16 @@ final class FileListNode: ASDisplayNode {
     @objc private func searchFieldChanged(_ field: UITextField) {
         searchQuery = field.text ?? ""
         rebuildSectionsAndReload()
+    }
+
+    @objc private func filesTypeChanged(_ control: UISegmentedControl) {
+        let filesType: ChannelFilesType = control.selectedSegmentIndex == 1 ? .audio : .doc
+        guard filesType != selectedFilesType else { return }
+        selectedFilesType = filesType
+        tableNode.view.setContentOffset(.zero, animated: false)
+        rebuildSectionsAndReload()
+        loadFilesIfNeeded(for: filesType)
+        setNeedsLayout()
     }
 
     private func installSearchHeader() {
@@ -164,20 +204,59 @@ final class FileListNode: ASDisplayNode {
         tableNode.view.tableHeaderView = header
     }
 
-    private static func isDocumentAttachment(_ att: Mezon_Api_ChannelAttachment) -> Bool {
-        let ft = att.filetype.lowercased()
-        if ft == "sticker" { return false }
-        if ft.hasPrefix("image/") { return false }
-        if ft.hasPrefix("video/") { return false }
-        return true
+    private func filesState(for filesType: ChannelFilesType) -> ChannelFilesState {
+        filesStateByType[filesType] ?? ChannelFilesState()
     }
 
-    private func fetchFiles(showLoading: Bool = true) {
-        if showLoading {
-            isLoading = true
+    private static func isAttachment(
+        _ att: Mezon_Api_ChannelAttachment, matching filesType: ChannelFilesType
+    ) -> Bool {
+        if AttachmentTypeClassifier.isSticker(att.filetype) { return false }
+        if AttachmentTypeClassifier.isImage(att.filetype) { return false }
+        if AttachmentTypeClassifier.isVideo(att.filetype) { return false }
+        switch filesType {
+        case .doc: return !AttachmentTypeClassifier.isAudio(att.filetype)
+        case .audio: return AttachmentTypeClassifier.isAudio(att.filetype)
+        }
+    }
+
+    private func loadFilesIfNeeded(for filesType: ChannelFilesType) {
+        let state = filesState(for: filesType)
+        guard !state.didLoad, !state.isFetching else { return }
+        fetchFiles(for: filesType)
+    }
+
+    private func refreshFilesAfterMessageChange() {
+        for filesType in ChannelFilesType.allCases where filesType != selectedFilesType {
+            var state = filesState(for: filesType)
+            if state.isFetching {
+                state.refreshPending = true
+                filesStateByType[filesType] = state
+            } else if state.didLoad {
+                state.didLoad = false
+                filesStateByType[filesType] = state
+            }
+        }
+        var selectedState = filesState(for: selectedFilesType)
+        if selectedState.isFetching {
+            selectedState.refreshPending = true
+            filesStateByType[selectedFilesType] = selectedState
+            return
+        }
+        guard selectedState.didLoad else { return }
+        fetchFiles(for: selectedFilesType, showLoading: false)
+    }
+
+    private func fetchFiles(for filesType: ChannelFilesType, showLoading: Bool = true) {
+        var state = filesState(for: filesType)
+        guard !state.isFetching else { return }
+        state.isFetching = true
+        state.showsLoading = showLoading
+        state.loadFailed = false
+        filesStateByType[filesType] = state
+        if selectedFilesType == filesType, showLoading {
             setNeedsLayout()
         }
-        loadFailed = false
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
@@ -189,31 +268,52 @@ final class FileListNode: ASDisplayNode {
                 let res = try await self.context.account.network.listChannelAttachments(
                     clanId: targetClanId,
                     channelId: self.channelId,
-                    fileType: "all",
+                    fileType: filesType.rawValue,
                     limit: 100,
                     token: token
                 )
-                let docs = res.attachments.filter { Self.isDocumentAttachment($0) }
-                self.rawAttachments = docs
-                self.rebuildSectionsAndReload()
+                var state = self.filesState(for: filesType)
+                state.attachments = res.attachments.filter {
+                    Self.isAttachment($0, matching: filesType)
+                }
+                state.didLoad = true
+                state.loadFailed = false
+                state.isFetching = false
+                state.showsLoading = false
+                self.filesStateByType[filesType] = state
             } catch {
-                self.loadFailed = true
-                self.rawAttachments = []
-                self.sections = []
-                await self.tableNode.reloadData()
+                var state = self.filesState(for: filesType)
+                state.attachments = []
+                state.didLoad = true
+                state.loadFailed = true
+                state.isFetching = false
+                state.showsLoading = false
+                self.filesStateByType[filesType] = state
             }
-            self.isLoading = false
-            self.setNeedsLayout()
+            var state = self.filesState(for: filesType)
+            let shouldRefresh = state.refreshPending
+            if shouldRefresh {
+                state.refreshPending = false
+                self.filesStateByType[filesType] = state
+            }
+            if self.selectedFilesType == filesType {
+                self.rebuildSectionsAndReload()
+                self.setNeedsLayout()
+            }
+            if shouldRefresh {
+                self.fetchFiles(for: filesType, showLoading: false)
+            }
         }
     }
 
     private func rebuildSectionsAndReload() {
         let q = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let attachments = filesState(for: selectedFilesType).attachments
         let filtered: [Mezon_Api_ChannelAttachment]
         if q.isEmpty {
-            filtered = rawAttachments
+            filtered = attachments
         } else {
-            filtered = rawAttachments.filter { $0.filename.lowercased().contains(q) }
+            filtered = attachments.filter { $0.filename.lowercased().contains(q) }
         }
         sections = Self.groupByYearDay(items: filtered)
         tableNode.reloadData()
@@ -223,14 +323,15 @@ final class FileListNode: ASDisplayNode {
     private func updateEmptyFooter() {
         let t = UIColor.theme
         let w = max(tableNode.bounds.width, 280)
-        if filesTabActivated, !isLoading, sections.isEmpty {
+        let state = filesState(for: selectedFilesType)
+        if state.didLoad, !state.showsLoading, sections.isEmpty {
             let footer = UILabel()
             footer.textAlignment = .center
             footer.font = .systemFont(ofSize: 15.sf, weight: .medium)
             footer.textColor = t.textDisabled
             footer.numberOfLines = 0
             footer.text =
-                loadFailed
+                state.loadFailed
                 ? L(L10n.Error.somethingWentWrong)
                 : L(L10n.ChannelDetail.noFilesYet)
             footer.frame = CGRect(x: 0, y: 0, width: w, height: 72)
@@ -308,13 +409,30 @@ final class FileListNode: ASDisplayNode {
         )
         loadingCentered.style.flexGrow = 1
 
-        if isLoading {
-            return ASOverlayLayoutSpec(
+        let state = filesState(for: selectedFilesType)
+        let contentSpec: ASLayoutSpec
+        if state.showsLoading {
+            contentSpec = ASOverlayLayoutSpec(
                 child: ASWrapperLayoutSpec(layoutElement: tableNode),
                 overlay: loadingCentered
             )
+        } else {
+            contentSpec = ASWrapperLayoutSpec(layoutElement: tableNode)
         }
-        return ASWrapperLayoutSpec(layoutElement: tableNode)
+        contentSpec.style.flexGrow = 1
+        contentSpec.style.flexShrink = 1
+
+        let filesTypeInset = ASInsetLayoutSpec(
+            insets: UIEdgeInsets(top: 8.sf, left: 8.sw, bottom: 8.sf, right: 8.sw),
+            child: filesTypeControlNode
+        )
+        return ASStackLayoutSpec(
+            direction: .vertical,
+            spacing: 0,
+            justifyContent: .start,
+            alignItems: .stretch,
+            children: [filesTypeInset, contentSpec]
+        )
     }
 }
 

--- a/MezonChat/Features/ChannelDetail/Tabs/MediaGalleryNode.swift
+++ b/MezonChat/Features/ChannelDetail/Tabs/MediaGalleryNode.swift
@@ -1,6 +1,19 @@
 import AsyncDisplayKit
 import UIKit
 
+private enum ChannelMediaType: String {
+    case image
+    case video
+}
+
+private struct ChannelMediaState {
+    var attachments: [Mezon_Api_ChannelAttachment] = []
+    var didLoad = false
+    var fetchCompleted = false
+    var isLoadingMore = false
+    var hasMore = true
+}
+
 @MainActor
 final class MediaGalleryNode: ASDisplayNode {
 
@@ -8,13 +21,12 @@ final class MediaGalleryNode: ASDisplayNode {
     private let clanId: Int64
     private let channelId: Int64
     private let channelType: Int32
-    private var attachments: [Mezon_Api_ChannelAttachment] = []
-    private var didLoadMedia = false
-    private var mediaFetchCompleted = false
-    private var isLoadingMore = false
-    private var hasMoreMedia = true
+    private var mediaStateByType: [ChannelMediaType: ChannelMediaState] = [:]
+    private var selectedMediaType: ChannelMediaType = .image
     private let mediaPageLimit: Int32 = 50
 
+    private let mediaTypeControl: UISegmentedControl
+    private let mediaTypeControlNode: ASDisplayNode
     private let collectionNode: ASCollectionNode
     private let loadingHostNode: ASDisplayNode
     private let emptyStateNode: MediaEmptyStateNode
@@ -36,6 +48,12 @@ final class MediaGalleryNode: ASDisplayNode {
         layout.itemSize = CGSize(width: provisionalSide, height: provisionalSide)
         self.flowLayout = layout
 
+        let mediaTypeControl = UISegmentedControl(items: [
+            L(L10n.ChannelDetail.images),
+            L(L10n.ChannelDetail.videos),
+        ])
+        self.mediaTypeControl = mediaTypeControl
+        self.mediaTypeControlNode = ASDisplayNode(viewBlock: { mediaTypeControl })
         self.collectionNode = ASCollectionNode(collectionViewLayout: layout)
 
         self.loadingHostNode = ASDisplayNode(viewBlock: {
@@ -51,6 +69,17 @@ final class MediaGalleryNode: ASDisplayNode {
         super.init()
         self.automaticallyManagesSubnodes = true
 
+        mediaTypeControl.selectedSegmentIndex = 0
+        mediaTypeControl.addTarget(
+            self, action: #selector(mediaTypeChanged(_:)), for: .valueChanged)
+        mediaTypeControl.selectedSegmentTintColor = UIColor.theme.bgViolet
+        mediaTypeControl.backgroundColor = UIColor.theme.secondary
+        let segmentFont = UIFont.systemFont(ofSize: 14.sf, weight: .semibold)
+        mediaTypeControl.setTitleTextAttributes(
+            [.font: segmentFont, .foregroundColor: UIColor.theme.text], for: .normal)
+        mediaTypeControl.setTitleTextAttributes(
+            [.font: segmentFont, .foregroundColor: UIColor.white], for: .selected)
+        mediaTypeControlNode.style.height = ASDimension(unit: .points, value: 40.sf)
         loadingHostNode.style.preferredSize = CGSize(width: 44, height: 44)
         overlayBackdropNode.style.flexGrow = 1
 
@@ -61,35 +90,63 @@ final class MediaGalleryNode: ASDisplayNode {
     }
 
     func loadTabDataIfNeeded() {
-        guard !didLoadMedia else { return }
-        didLoadMedia = true
-        fetchMedia()
+        loadMediaIfNeeded(for: .image)
     }
 
-    private func fetchMedia() {
+    private var attachments: [Mezon_Api_ChannelAttachment] {
+        mediaState(for: selectedMediaType).attachments
+    }
+
+    private func mediaState(for mediaType: ChannelMediaType) -> ChannelMediaState {
+        mediaStateByType[mediaType] ?? ChannelMediaState()
+    }
+
+    private func loadMediaIfNeeded(for mediaType: ChannelMediaType) {
+        var state = mediaState(for: mediaType)
+        guard !state.didLoad else { return }
+        state.didLoad = true
+        state.fetchCompleted = false
+        mediaStateByType[mediaType] = state
+        if selectedMediaType == mediaType {
+            setNeedsLayout()
+        }
+        fetchMedia(mediaType)
+    }
+
+    private func fetchMedia(_ mediaType: ChannelMediaType) {
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
                 let token = await context.getToken() ?? ""
-                let res = try await self.requestAttachments(before: 0, token: token)
+                let res = try await self.requestAttachments(
+                    before: 0, token: token, mediaType: mediaType)
                 let raw = res.attachments
-                self.hasMoreMedia = raw.count >= Int(self.mediaPageLimit)
-                let visual = raw
-                    .filter { Self.isVisualAttachment($0) }
+                var state = self.mediaState(for: mediaType)
+                state.hasMore = raw.count >= Int(self.mediaPageLimit)
+                state.attachments = raw
+                    .filter { Self.isAttachment($0, matching: mediaType) }
                     .sorted { $0.createTimeSeconds > $1.createTimeSeconds }
-                self.attachments = visual
+                state.fetchCompleted = true
+                self.mediaStateByType[mediaType] = state
 
-                await self.collectionNode.reloadData()
-                self.mediaFetchCompleted = true
-                self.setNeedsLayout()
+                if self.selectedMediaType == mediaType {
+                    await self.collectionNode.reloadData()
+                    self.setNeedsLayout()
+                }
             } catch {
-                self.mediaFetchCompleted = true
-                self.setNeedsLayout()
+                var state = self.mediaState(for: mediaType)
+                state.fetchCompleted = true
+                self.mediaStateByType[mediaType] = state
+                if self.selectedMediaType == mediaType {
+                    self.setNeedsLayout()
+                }
             }
         }
     }
 
-    private func requestAttachments(before: UInt32, token: String) async throws
+    private func requestAttachments(
+        before: UInt32, token: String, mediaType: ChannelMediaType
+    ) async throws
         -> Mezon_Api_ChannelAttachmentList
     {
         let targetClanId =
@@ -98,7 +155,7 @@ final class MediaGalleryNode: ASDisplayNode {
         return try await context.account.network.listChannelAttachments(
             clanId: targetClanId,
             channelId: channelId,
-            fileType: "image",
+            fileType: mediaType.rawValue,
             limit: mediaPageLimit,
             before: before,
             token: token
@@ -106,31 +163,43 @@ final class MediaGalleryNode: ASDisplayNode {
     }
 
     private func loadMoreMediaIfNeeded() {
-        guard mediaFetchCompleted, hasMoreMedia, !isLoadingMore,
-            let oldest = attachments.last, oldest.createTimeSeconds > 0
+        let mediaType = selectedMediaType
+        var state = mediaState(for: mediaType)
+        guard state.fetchCompleted, state.hasMore, !state.isLoadingMore,
+            let oldest = state.attachments.last, oldest.createTimeSeconds > 0
         else { return }
-        isLoadingMore = true
+        state.isLoadingMore = true
+        mediaStateByType[mediaType] = state
         let before = oldest.createTimeSeconds
         Task { @MainActor [weak self] in
             guard let self else { return }
-            defer { self.isLoadingMore = false }
+            defer {
+                var state = self.mediaState(for: mediaType)
+                state.isLoadingMore = false
+                self.mediaStateByType[mediaType] = state
+            }
             do {
                 let token = await self.context.getToken() ?? ""
-                let res = try await self.requestAttachments(before: before, token: token)
+                let res = try await self.requestAttachments(
+                    before: before, token: token, mediaType: mediaType)
                 let raw = res.attachments
-                self.hasMoreMedia = raw.count >= Int(self.mediaPageLimit)
-                let existingKeys = Set(self.attachments.map { Self.dedupKey($0) })
+                var state = self.mediaState(for: mediaType)
+                state.hasMore = raw.count >= Int(self.mediaPageLimit)
+                let existingKeys = Set(state.attachments.map { Self.dedupKey($0) })
                 let newItems = raw
-                    .filter { Self.isVisualAttachment($0) }
+                    .filter { Self.isAttachment($0, matching: mediaType) }
                     .filter { !existingKeys.contains(Self.dedupKey($0)) }
                     .sorted { $0.createTimeSeconds > $1.createTimeSeconds }
                 guard !newItems.isEmpty else {
-                    self.hasMoreMedia = false
+                    state.hasMore = false
+                    self.mediaStateByType[mediaType] = state
                     return
                 }
-                let startIndex = self.attachments.count
-                self.attachments.append(contentsOf: newItems)
-                let indexPaths = (startIndex..<self.attachments.count).map {
+                let startIndex = state.attachments.count
+                state.attachments.append(contentsOf: newItems)
+                self.mediaStateByType[mediaType] = state
+                guard self.selectedMediaType == mediaType else { return }
+                let indexPaths = (startIndex..<state.attachments.count).map {
                     IndexPath(item: $0, section: 0)
                 }
                 self.collectionNode.performBatch(
@@ -147,25 +216,19 @@ final class MediaGalleryNode: ASDisplayNode {
         att.id != 0 ? "id:\(att.id)" : "url:\(att.url)"
     }
 
-    private static func isVisualAttachment(_ att: Mezon_Api_ChannelAttachment) -> Bool {
-        let ft = att.filetype.lowercased()
-        if ft.contains("audio") || ft.hasPrefix("audio/") { return false }
-        if ft.hasPrefix("image/") || ft.hasPrefix("video/") { return true }
-        if ft.isEmpty {
-            let ext = (att.filename as NSString).pathExtension.lowercased()
-            if ["mp3", "m4a", "wav", "aac", "ogg", "flac"].contains(ext) { return false }
-            return true
+    private static func isAttachment(
+        _ att: Mezon_Api_ChannelAttachment, matching mediaType: ChannelMediaType
+    ) -> Bool {
+        let url = att.url.trimmingCharacters(in: .whitespacesAndNewlines)
+        if url.isEmpty || url.lowercased().contains("/stickers") { return false }
+        switch mediaType {
+        case .image: return AttachmentTypeClassifier.isImage(att.filetype)
+        case .video: return AttachmentTypeClassifier.isVideo(att.filetype)
         }
-        return false
     }
 
     private static func isVideo(_ att: Mezon_Api_ChannelAttachment) -> Bool {
-        let filetype = att.filetype.lowercased()
-        if filetype.hasPrefix("video/") { return true }
-        let filenameExtension = (att.filename as NSString).pathExtension.lowercased()
-        let urlExtension = URL(string: att.url)?.pathExtension.lowercased() ?? ""
-        return ["mp4", "mov", "m4v", "webm"].contains(filenameExtension)
-            || ["mp4", "mov", "m4v", "webm"].contains(urlExtension)
+        AttachmentTypeClassifier.isVideo(att.filetype)
     }
 
     private func gridItemSide(collectionWidth: CGFloat) -> CGFloat {
@@ -173,6 +236,16 @@ final class MediaGalleryNode: ASDisplayNode {
         let spacing = flowLayout.minimumInteritemSpacing
         let inner = max(0, collectionWidth - spacing * (columns - 1))
         return max(1, floor(inner / columns))
+    }
+
+    @objc private func mediaTypeChanged(_ control: UISegmentedControl) {
+        let mediaType: ChannelMediaType = control.selectedSegmentIndex == 1 ? .video : .image
+        guard mediaType != selectedMediaType else { return }
+        selectedMediaType = mediaType
+        collectionNode.view.setContentOffset(.zero, animated: false)
+        collectionNode.reloadData()
+        setNeedsLayout()
+        loadMediaIfNeeded(for: mediaType)
     }
 
     override func layout() {
@@ -261,21 +334,37 @@ final class MediaGalleryNode: ASDisplayNode {
         collectionNode.style.flexGrow = 1
         collectionNode.style.flexShrink = 1
 
-        let showLoading = didLoadMedia && !mediaFetchCompleted
-        let showEmpty = mediaFetchCompleted && attachments.isEmpty
+        let state = mediaState(for: selectedMediaType)
+        let showLoading = state.didLoad && !state.fetchCompleted
+        let showEmpty = state.fetchCompleted && state.attachments.isEmpty
+        let contentSpec: ASLayoutSpec
         if showLoading {
-            return ASOverlayLayoutSpec(
+            contentSpec = ASOverlayLayoutSpec(
                 child: collectionNode,
                 overlay: mediaOverlaySpec(centering: loadingHostNode)
             )
-        }
-        if showEmpty {
-            return ASOverlayLayoutSpec(
+        } else if showEmpty {
+            contentSpec = ASOverlayLayoutSpec(
                 child: collectionNode,
                 overlay: mediaOverlaySpec(centering: emptyStateNode)
             )
+        } else {
+            contentSpec = ASWrapperLayoutSpec(layoutElement: collectionNode)
         }
-        return ASWrapperLayoutSpec(layoutElement: collectionNode)
+        contentSpec.style.flexGrow = 1
+        contentSpec.style.flexShrink = 1
+
+        let mediaTypeInset = ASInsetLayoutSpec(
+            insets: UIEdgeInsets(top: 8.sf, left: 8.sw, bottom: 8.sf, right: 8.sw),
+            child: mediaTypeControlNode
+        )
+        return ASStackLayoutSpec(
+            direction: .vertical,
+            spacing: 0,
+            justifyContent: .start,
+            alignItems: .stretch,
+            children: [mediaTypeInset, contentSpec]
+        )
     }
 
     private func mediaOverlaySpec(centering content: ASLayoutElement) -> ASLayoutSpec {

--- a/MezonChat/Features/Chat/Cells/MessageBubbleNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageBubbleNode.swift
@@ -1209,6 +1209,9 @@ final class MessageBubbleNode: ASDisplayNode {
             interaction.onMediaRetryTapped?(index, display)
             return
         }
+        if index >= 0, index < media.count, media[index].isSticker {
+            return
+        }
         if let onMediaTapped = interaction.onMediaTapped {
             let previewImage = mediaContentNode?.displayImage(at: index)
             onMediaTapped(index, media, display, previewImage)

--- a/MezonChat/Features/Chat/Cells/MessageMediaContentNode.swift
+++ b/MezonChat/Features/Chat/Cells/MessageMediaContentNode.swift
@@ -679,6 +679,7 @@ final class MessageMediaContentNode: ASDisplayNode {
 
     private static func isAnimatedImageAttachment(_ attachment: ParsedAttachment) -> Bool {
         if isGifImageAttachment(attachment) { return true }
+        if attachment.isSticker { return true }
         let filetype = attachment.filetype
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
@@ -702,7 +703,16 @@ final class MessageMediaContentNode: ASDisplayNode {
 
     private func loadStickerImage(media: ParsedAttachment, into node: ASDisplayNode) {
         guard !media.isPresignPending else { return }
-        let url = ImgproxyURL.secureURLString(from: media.url)
+        let sourceURL = ImgproxyURL.secureURLString(from: media.url)
+        let url = media.isSticker
+            ? ImgproxyURL.attachmentURL(
+                from: sourceURL,
+                width: 400,
+                height: 400,
+                resizeType: "fit",
+                forceProxy: true
+            )
+            : sourceURL
         guard let imageURL = URL(string: url), !url.isEmpty else { return }
         let isAnimatedImage = Self.isAnimatedImageAttachment(media)
 

--- a/MezonChat/Features/Chat/ChatViewController.swift
+++ b/MezonChat/Features/Chat/ChatViewController.swift
@@ -31,23 +31,23 @@ struct ParsedAttachment: Equatable {
     var uploadShowsPercent: Bool = false
 
     var isImage: Bool {
-        filetype.hasPrefix("image/") || filetype == "sticker"
+        AttachmentTypeClassifier.isImage(filetype) || AttachmentTypeClassifier.isSticker(filetype)
             || ["jpg", "jpeg", "png", "gif", "webp", "heic"].contains(fileExtension)
             || ["jpg", "jpeg", "png", "gif", "webp", "heic"].contains(urlExtension)
     }
 
     var isVideo: Bool {
-        filetype.hasPrefix("video/") 
+        AttachmentTypeClassifier.isVideo(filetype)
             || ["mp4", "mov", "m4v", "webm", "mkv", "avi", "flv", "wmv", "ogv", "ogg", "3gp", "3g2", "mpg", "mpeg", "ts", "vob"].contains(fileExtension)
             || ["mp4", "mov", "m4v", "webm", "mkv", "avi", "flv", "wmv", "ogv", "ogg", "3gp", "3g2", "mpg", "mpeg", "ts", "vob"].contains(urlExtension)
     }
 
-    var isSticker: Bool { filetype == "sticker" }
+    var isSticker: Bool { AttachmentTypeClassifier.isSticker(filetype) }
 
     var isMedia: Bool { isImage || isVideo }
 
     var isAudio: Bool {
-        if filetype.hasPrefix("audio/") { return true }
+        if AttachmentTypeClassifier.isAudio(filetype) { return true }
         return ["mp3", "m4a", "aac", "wav", "ogg", "flac", "opus"].contains(fileExtension)
             || ["mp3", "m4a", "aac", "wav", "ogg", "flac", "opus"].contains(urlExtension)
     }
@@ -6408,9 +6408,9 @@ final class ChatViewController: ViewController {
     }
 
     private static func isVisualChannelAttachment(_ attachment: Mezon_Api_ChannelAttachment) -> Bool {
-        let filetype = attachment.filetype.lowercased()
-        if filetype == "sticker" || attachment.url.contains("/stickers") { return false }
-        if filetype.hasPrefix("image/") || filetype.hasPrefix("video/") { return true }
+        if AttachmentTypeClassifier.isSticker(attachment.filetype) || attachment.url.contains("/stickers") { return false }
+        if AttachmentTypeClassifier.isImage(attachment.filetype)
+            || AttachmentTypeClassifier.isVideo(attachment.filetype) { return true }
         let filenameExtension = (attachment.filename as NSString).pathExtension.lowercased()
         let urlExtension = URL(string: attachment.url)?.pathExtension.lowercased() ?? ""
         let imageExtensions: Set<String> = ["jpg", "jpeg", "png", "gif", "webp", "heic"]
@@ -6422,8 +6422,7 @@ final class ChatViewController: ViewController {
     }
 
     private static func isVideoChannelAttachment(_ attachment: Mezon_Api_ChannelAttachment) -> Bool {
-        let filetype = attachment.filetype.lowercased()
-        if filetype.hasPrefix("video/") { return true }
+        if AttachmentTypeClassifier.isVideo(attachment.filetype) { return true }
         let filenameExtension = (attachment.filename as NSString).pathExtension.lowercased()
         let urlExtension = URL(string: attachment.url)?.pathExtension.lowercased() ?? ""
         return ["mp4", "mov", "m4v", "webm"].contains(filenameExtension)

--- a/MezonChat/Features/SendMessageInput/AttachmentUploadCoordinator.swift
+++ b/MezonChat/Features/SendMessageInput/AttachmentUploadCoordinator.swift
@@ -984,7 +984,7 @@ final class AttachmentUploadCoordinator {
                 var att = Mezon_Api_MessageAttachment()
                 att.filename = file.filename
                 att.url = cdnURL
-                att.filetype = file.filetype
+                att.filetype = AttachmentTypeClassifier.uploadType(for: file.filetype)
                 att.size = Int32(size)
                 session.fileTracks.append(FileUploadTrack(
                     file: file, presignKey: presignKey, attachment: att, pending: pending))
@@ -1043,7 +1043,7 @@ final class AttachmentUploadCoordinator {
         do {
             var att = Mezon_Api_MessageAttachment()
             att.filename = originalFilename
-            att.filetype = filetype
+            att.filetype = AttachmentTypeClassifier.uploadType(for: filetype)
             att.width = Int32(width)
             att.height = Int32(height)
             var pendingUploads: [PendingMinIOUpload] = []
@@ -1076,7 +1076,7 @@ final class AttachmentUploadCoordinator {
                     width: width, height: height, token: token)
                 let cdnURL = "\(MezonConfig.baseImgURL)/\(uploadInfo.filename)"
                 att.filename = payload.filename
-                att.filetype = payload.filetype
+                att.filetype = AttachmentTypeClassifier.uploadType(for: payload.filetype)
                 att.url = cdnURL
                 att.size = Int32(payload.data.count)
                 pendingUploads.append(PendingMinIOUpload(

--- a/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
+++ b/MezonChat/Features/SendMessageInput/SendMessageInputViewController.swift
@@ -1965,7 +1965,7 @@ final class SendMessageInputViewController: UIViewController {
             || srcLower.hasSuffix(".mp3")
             || srcLower.hasSuffix(".wav")
             || srcLower.hasSuffix(".m4a")
-        att.filetype = isAudio ? "audio/mpeg" : "image/gif"
+        att.filetype = isAudio ? "audio/mpeg" : "sticker"
         att.filename = "\(sticker.id)"
 
         sendChannelMessageWithAttachments(text: "", attachments: [att])
@@ -1979,7 +1979,7 @@ final class SendMessageInputViewController: UIViewController {
         }
         var att = Mezon_Api_MessageAttachment()
         att.url = url
-        att.filetype = "image/gif"
+        att.filetype = "sticker"
         sendChannelMessageWithAttachments(text: "", attachments: [att])
     }
 
@@ -5495,7 +5495,7 @@ final class SendMessageInputViewController: UIViewController {
                 var att = Mezon_Api_MessageAttachment()
                 att.filename = originalFilename
                 att.url = uploaded.cdnURL
-                att.filetype = filetype
+                att.filetype = AttachmentTypeClassifier.uploadType(for: filetype)
                 att.size = Int32(size)
                 att.width = Int32(width)
                 att.height = Int32(height)
@@ -5529,7 +5529,7 @@ final class SendMessageInputViewController: UIViewController {
             var att = Mezon_Api_MessageAttachment()
             att.filename = originalFilename
             att.url = cdnURL
-            att.filetype = filetype
+            att.filetype = AttachmentTypeClassifier.uploadType(for: filetype)
             att.size = Int32(fileData.count)
             att.width = Int32(width)
             att.height = Int32(height)
@@ -5567,7 +5567,7 @@ final class SendMessageInputViewController: UIViewController {
             var att = Mezon_Api_MessageAttachment()
             att.filename = file.filename
             att.url = uploaded.cdnURL
-            att.filetype = file.filetype
+            att.filetype = AttachmentTypeClassifier.uploadType(for: file.filetype)
             att.size = Int32(size)
             attachments.append(att)
 

--- a/MezonChat/Features/Sharing/SharingViewController.swift
+++ b/MezonChat/Features/Sharing/SharingViewController.swift
@@ -1539,7 +1539,7 @@ final class SharingViewController: UIViewController {
                     var att = Mezon_Api_MessageAttachment()
                     att.filename = filename
                     att.url = uploaded.cdnURL
-                    att.filetype = filetype
+                    att.filetype = AttachmentTypeClassifier.uploadType(for: filetype)
                     att.size = Int32(fileSize)
                     if width > 0 { att.width = Int32(width) }
                     if height > 0 { att.height = Int32(height) }

--- a/MezonChat/Networking/AttachmentUploader.swift
+++ b/MezonChat/Networking/AttachmentUploader.swift
@@ -1,5 +1,39 @@
 import Foundation
 
+enum AttachmentTypeClassifier {
+    static func uploadType(for filetype: String) -> String {
+        let type = normalized(filetype)
+        if type == "image" || type.hasPrefix("image/") { return "image" }
+        if type == "video" || type.hasPrefix("video/") { return "video" }
+        if type == "audio" || type.hasPrefix("audio/") { return "audio" }
+        return "doc"
+    }
+
+    static func isImage(_ filetype: String) -> Bool {
+        let type = normalized(filetype)
+        return type == "image" || type.hasPrefix("image/")
+    }
+
+    static func isVideo(_ filetype: String) -> Bool {
+        let type = normalized(filetype)
+        return type == "video" || type.hasPrefix("video/")
+    }
+
+    static func isAudio(_ filetype: String) -> Bool {
+        let type = normalized(filetype)
+        return type == "audio" || type.hasPrefix("audio/")
+    }
+
+    static func isSticker(_ filetype: String) -> Bool {
+        normalized(filetype) == "sticker"
+    }
+
+    private static func normalized(_ filetype: String) -> String {
+        let mime = filetype.split(separator: ";", maxSplits: 1).first.map(String.init) ?? filetype
+        return mime.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}
+
 struct UploadedAttachmentFile {
     let serverFilename: String
     let cdnURL: String

--- a/MezonChat/Networking/MezonHTTPClient.swift
+++ b/MezonChat/Networking/MezonHTTPClient.swift
@@ -1687,9 +1687,10 @@ final class MezonHTTPClient {
         token: String,
         preferHTTPFirst: Bool = false
     ) async throws -> Mezon_Api_UploadAttachment {
+        let uploadType = AttachmentTypeClassifier.uploadType(for: filetype)
         var req = Mezon_Api_UploadAttachmentRequest()
         req.filename = filename
-        req.filetype = filetype
+        req.filetype = uploadType
         req.size = Int32(size)
         req.width = Int32(width)
         req.height = Int32(height)
@@ -1728,9 +1729,10 @@ final class MezonHTTPClient {
         token: String,
         preferHTTPFirst: Bool = false
     ) async throws -> Mezon_Api_MultipartUploadAttachment {
+        let uploadType = AttachmentTypeClassifier.uploadType(for: filetype)
         var req = Mezon_Api_UploadAttachmentRequest()
         req.filename = filename
-        req.filetype = filetype
+        req.filetype = uploadType
         req.size = Int32(size)
         req.width = Int32(width)
         req.height = Int32(height)


### PR DESCRIPTION
Root Cause: Media and Files showed different attachment types in a single list without separate loading states.
Solution: Added Images/Videos and Docs/Audios sub-tabs, with Images and Docs selected by default and each tab loading its own data safely.

Test Cases:
1. Open Media and verify Images is selected by default and only images are displayed.
2. Select Videos and verify only videos are displayed.
3. Scroll to the bottom of Images and Videos and verify older items load without duplicates.
4. Open Files and verify Docs is selected by default and only documents are displayed.
5. Select Audios and verify only audio files are displayed.
6. Switch between sub-tabs and verify previously loaded content remains correct.
7. Add or delete an attachment while Files is loading and verify the list updates correctly.
8. Verify loading, empty, and error states are shown correctly for each sub-tab.
9. Verify files with older MIME formats appear in the correct sub-tab when returned by the server.
10. Open Media and Files in channels, direct messages, and group messages and verify they work normally.