### PR TITLE
260821-IOS-Implement sound sticker of clan setting

### DIFF
--- a/MezonChat/Core/Localization/L10n.swift
+++ b/MezonChat/Core/Localization/L10n.swift
@@ -634,6 +634,31 @@ enum L10n {
             static let previewTypeSticker = "clan.setting.stickers.previewTypeSticker"
         }
 
+        enum SoundStickers {
+            static let duplicateName = "clan.setting.soundStickers.duplicateName"
+            static let updateSuccess = "clan.setting.soundStickers.updateSuccess"
+            static let deleteConfirmTitle = "clan.setting.soundStickers.deleteConfirmTitle"
+            static let deleteConfirmDesc = "clan.setting.soundStickers.deleteConfirmDesc"
+            static let deleteSuccess = "clan.setting.soundStickers.deleteSuccess"
+            static let empty = "clan.setting.soundStickers.empty"
+            static let createSuccess = "clan.setting.soundStickers.createSuccess"
+            static let validateName = "clan.setting.soundStickers.validateName"
+            static let errorUpdating = "clan.setting.soundStickers.errorUpdating"
+            static let uploadButton = "clan.setting.soundStickers.uploadButton"
+            static let uploadRequirementsTitle = "clan.setting.soundStickers.uploadRequirementsTitle"
+            static let uploadRequirement1 = "clan.setting.soundStickers.uploadRequirement1"
+            static let uploadRequirement2 = "clan.setting.soundStickers.uploadRequirement2"
+            static let uploadRequirement3 = "clan.setting.soundStickers.uploadRequirement3"
+            static let uploadFileTooLarge = "clan.setting.soundStickers.uploadFileTooLarge"
+            static let invalidFileType = "clan.setting.soundStickers.invalidFileType"
+            static let durationTooLong = "clan.setting.soundStickers.durationTooLong"
+            static let previewTitle = "clan.setting.soundStickers.previewTitle"
+            static let previewNameLabel = "clan.setting.soundStickers.previewNameLabel"
+            static let previewUpload = "clan.setting.soundStickers.previewUpload"
+            static let previewLengthError = "clan.setting.soundStickers.previewLengthError"
+            static let previewTypeSound = "clan.setting.soundStickers.previewTypeSound"
+        }
+
         enum Overview {
             static let title = "clan.setting.overview.title"
             static let save = "clan.setting.overview.save"
@@ -1820,6 +1845,28 @@ extension L10n {
         "clan.setting.stickers.previewUpload": "Upload",
         "clan.setting.stickers.previewLengthError": "%@ name must be between %d and %d characters, only letters, numbers, _ and - are allowed.",
         "clan.setting.stickers.previewTypeSticker": "Sticker",
+        "clan.setting.soundStickers.duplicateName": "Sound effect name already exists",
+        "clan.setting.soundStickers.updateSuccess": "Sound effect updated successfully",
+        "clan.setting.soundStickers.deleteConfirmTitle": "Delete Sound Effect",
+        "clan.setting.soundStickers.deleteConfirmDesc": "Are you sure you want to delete this sound effect?",
+        "clan.setting.soundStickers.deleteSuccess": "Sound effect deleted successfully",
+        "clan.setting.soundStickers.empty": "No sound effects available",
+        "clan.setting.soundStickers.createSuccess": "Sound effect created successfully",
+        "clan.setting.soundStickers.validateName": "Length must be %d - %d characters. Only letters, numbers, _ and - are allowed.",
+        "clan.setting.soundStickers.errorUpdating": "Failed to update sound effect. Please try again.",
+        "clan.setting.soundStickers.uploadButton": "Upload Sound Effect",
+        "clan.setting.soundStickers.uploadRequirementsTitle": "Upload Requirements",
+        "clan.setting.soundStickers.uploadRequirement1": "Only accepts .mp3, .wav files, maximum 1MB.",
+        "clan.setting.soundStickers.uploadRequirement2": "Use memorable names for sound effects.",
+        "clan.setting.soundStickers.uploadRequirement3": "Sound effects will be used in clan notifications or events.",
+        "clan.setting.soundStickers.uploadFileTooLarge": "Audio must not be larger than 1MB.",
+        "clan.setting.soundStickers.invalidFileType": "Only MP3, MPEG, and WAV audio files are supported.",
+        "clan.setting.soundStickers.durationTooLong": "Audio must not be longer than 10 seconds.",
+        "clan.setting.soundStickers.previewTitle": "Sound Effect Preview",
+        "clan.setting.soundStickers.previewNameLabel": "Sound Effect Name",
+        "clan.setting.soundStickers.previewUpload": "Upload",
+        "clan.setting.soundStickers.previewLengthError": "%@ name must be between %d and %d characters, only letters, numbers, _ and - are allowed.",
+        "clan.setting.soundStickers.previewTypeSound": "Sound effect",
         "clan.setting.emojis.duplicateName": "Emoji name already exists",
         "clan.setting.emojis.updateSuccess": "Emoji updated successfully",
         "clan.setting.emojis.deleteConfirmTitle": "Delete Emoji",
@@ -3073,6 +3120,28 @@ extension L10n {
         "clan.setting.stickers.previewUpload": "Tải lên",
         "clan.setting.stickers.previewLengthError": "Tên %@ phải từ %d đến %d kí tự, chỉ bao gồm chữ cái, chữ số, _ và -.",
         "clan.setting.stickers.previewTypeSticker": "nhãn dán",
+        "clan.setting.soundStickers.duplicateName": "Tên hiệu ứng âm thanh đã tồn tại",
+        "clan.setting.soundStickers.updateSuccess": "Cập nhật hiệu ứng âm thanh thành công",
+        "clan.setting.soundStickers.deleteConfirmTitle": "Xoá hiệu ứng âm thanh",
+        "clan.setting.soundStickers.deleteConfirmDesc": "Bạn có chắc muốn xoá hiệu ứng âm thanh này?",
+        "clan.setting.soundStickers.deleteSuccess": "Đã xoá hiệu ứng âm thanh thành công",
+        "clan.setting.soundStickers.empty": "Chưa có hiệu ứng âm thanh nào",
+        "clan.setting.soundStickers.createSuccess": "Tạo hiệu ứng âm thanh thành công",
+        "clan.setting.soundStickers.validateName": "Độ dài phải từ %d - %d ký tự. Chỉ cho phép chữ, số, _ và -.",
+        "clan.setting.soundStickers.errorUpdating": "Cập nhật hiệu ứng âm thanh thất bại. Vui lòng thử lại.",
+        "clan.setting.soundStickers.uploadButton": "Tải lên hiệu ứng âm thanh",
+        "clan.setting.soundStickers.uploadRequirementsTitle": "Yêu cầu tải lên",
+        "clan.setting.soundStickers.uploadRequirement1": "Chỉ chấp nhận tệp .mp3, .wav, dung lượng tối đa 1MB.",
+        "clan.setting.soundStickers.uploadRequirement2": "Hãy sử dụng tên dễ nhớ cho hiệu ứng âm thanh.",
+        "clan.setting.soundStickers.uploadRequirement3": "Hiệu ứng âm thanh sẽ được dùng trong thông báo hoặc sự kiện của clan.",
+        "clan.setting.soundStickers.uploadFileTooLarge": "Tệp âm thanh không được lớn hơn 1MB.",
+        "clan.setting.soundStickers.invalidFileType": "Chỉ hỗ trợ tệp âm thanh MP3, MPEG và WAV.",
+        "clan.setting.soundStickers.durationTooLong": "Tệp âm thanh không được dài quá 10 giây.",
+        "clan.setting.soundStickers.previewTitle": "Xem trước hiệu ứng âm thanh",
+        "clan.setting.soundStickers.previewNameLabel": "Tên hiệu ứng âm thanh",
+        "clan.setting.soundStickers.previewUpload": "Tải lên",
+        "clan.setting.soundStickers.previewLengthError": "Tên %@ phải từ %d đến %d kí tự, chỉ bao gồm chữ cái, chữ số, _ và -.",
+        "clan.setting.soundStickers.previewTypeSound": "hiệu ứng âm thanh",
         "clan.setting.emojis.duplicateName": "Tên biểu cảm đã tồn tại",
         "clan.setting.emojis.updateSuccess": "Cập nhật biểu cảm thành công",
         "clan.setting.emojis.deleteConfirmTitle": "Xoá biểu cảm",

--- a/MezonChat/Features/ClanSettings/ClanSettingsContainerNode.swift
+++ b/MezonChat/Features/ClanSettings/ClanSettingsContainerNode.swift
@@ -9,6 +9,7 @@ final class ClanSettingsContainerNode: ASDisplayNode {
     var onSelectAuditLog: (() -> Void)?
     var onSelectIntegrations: (() -> Void)?
     var onSelectStickers: (() -> Void)?
+    var onSelectSoundStickers: (() -> Void)?
     var onSelectEmojis: (() -> Void)?
     var onSelectInvites: (() -> Void)?
     var onSelectMembers: (() -> Void)?
@@ -120,7 +121,7 @@ final class ClanSettingsContainerNode: ASDisplayNode {
         settingsActions.append(contentsOf: [
             .init(title: L(L10n.ClanSetting.emoji), icon: "ClanSetting/emoji", navigate: .emojis),
             .init(title: L(L10n.ClanSetting.sticker), icon: "ClanSetting/StickerIcon", navigate: .stickers),
-            .init(title: L(L10n.ClanSetting.soundEffect), icon: "ClanSetting/SoundEffectIcon"),
+            .init(title: L(L10n.ClanSetting.soundEffect), icon: "ClanSetting/SoundEffectIcon", navigate: .soundStickers),
             .init(title: L(L10n.ClanSetting.enableCommunity), icon: "ClanSetting/EnableCommunityIcon")
         ])
         
@@ -462,6 +463,8 @@ final class ClanSettingsContainerNode: ASDisplayNode {
             onSelectIntegrations?()
         case .stickers:
             onSelectStickers?()
+        case .soundStickers:
+            onSelectSoundStickers?()
         case .emojis:
             onSelectEmojis?()
         case .invites:
@@ -485,6 +488,7 @@ private enum ClanSettingsNavigateAction: Int {
     case invites = 5
     case members = 6
     case auditLog = 7
+    case soundStickers = 8
 }
 
 private struct SettingAction {

--- a/MezonChat/Features/ClanSettings/ClanSettingsViewController.swift
+++ b/MezonChat/Features/ClanSettings/ClanSettingsViewController.swift
@@ -69,6 +69,15 @@ final class ClanSettingsViewController: BaseViewController {
             let vc = ClanStickersViewController(context: self.context, clanId: self.clanId)
             self.navigationController?.pushViewController(vc, animated: true)
         }
+        node.onSelectSoundStickers = { [weak self] in
+            guard let self else { return }
+            let vc = ClanStickersViewController(
+                context: self.context,
+                clanId: self.clanId,
+                mediaType: .audio
+            )
+            self.navigationController?.pushViewController(vc, animated: true)
+        }
         node.onSelectEmojis = { [weak self] in
             guard let self else { return }
             let vc = ClanEmojisViewController(context: self.context, clanId: self.clanId)

--- a/MezonChat/Features/ClanSettings/ClanStickerPreviewViewController.swift
+++ b/MezonChat/Features/ClanSettings/ClanStickerPreviewViewController.swift
@@ -1,10 +1,17 @@
 import UIKit
+import AVFoundation
 
-final class ClanStickerPreviewViewController: UIViewController {
+final class ClanStickerPreviewViewController: UIViewController, AVAudioPlayerDelegate {
 
     var onConfirm: ((String, Bool) -> Void)?
 
     private let previewImage: UIImage
+    private let soundData: Data?
+    private var audioPlayer: AVAudioPlayer?
+
+    private var isSoundSticker: Bool {
+        soundData != nil
+    }
 
     private lazy var backdropView: UIView = {
         let view = UIView()
@@ -27,7 +34,9 @@ final class ClanStickerPreviewViewController: UIViewController {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = .systemFont(ofSize: 15.sf, weight: .bold)
-        label.text = L(L10n.ClanSetting.Stickers.previewTitle)
+        label.text = isSoundSticker
+            ? L(L10n.ClanSetting.SoundStickers.previewTitle)
+            : L(L10n.ClanSetting.Stickers.previewTitle)
         return label
     }()
 
@@ -36,6 +45,12 @@ final class ClanStickerPreviewViewController: UIViewController {
         view.translatesAutoresizingMaskIntoConstraints = false
         view.contentMode = .scaleAspectFit
         view.clipsToBounds = true
+        if isSoundSticker {
+            view.image = UIImage(systemName: "play.fill")
+            view.isUserInteractionEnabled = true
+            view.layer.cornerRadius = 20.swh
+            view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handlePlayTapped)))
+        }
         return view
     }()
 
@@ -43,7 +58,9 @@ final class ClanStickerPreviewViewController: UIViewController {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = .systemFont(ofSize: 15.sf, weight: .bold)
-        label.text = L(L10n.ClanSetting.Stickers.previewNameLabel)
+        label.text = isSoundSticker
+            ? L(L10n.ClanSetting.SoundStickers.previewNameLabel)
+            : L(L10n.ClanSetting.Stickers.previewNameLabel)
         return label
     }()
 
@@ -88,7 +105,12 @@ final class ClanStickerPreviewViewController: UIViewController {
     private lazy var uploadButton: UIButton = {
         let button = UIButton(type: .system)
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.setTitle(L(L10n.ClanSetting.Stickers.previewUpload), for: .normal)
+        button.setTitle(
+            isSoundSticker
+                ? L(L10n.ClanSetting.SoundStickers.previewUpload)
+                : L(L10n.ClanSetting.Stickers.previewUpload),
+            for: .normal
+        )
         button.titleLabel?.font = .systemFont(ofSize: 15.sf, weight: .semibold)
         button.setTitleColor(.white, for: .normal)
         button.layer.cornerRadius = 30.sh
@@ -99,6 +121,15 @@ final class ClanStickerPreviewViewController: UIViewController {
 
     init(image: UIImage) {
         self.previewImage = image
+        self.soundData = nil
+        super.init(nibName: nil, bundle: nil)
+        modalPresentationStyle = .overFullScreen
+        modalTransitionStyle = .crossDissolve
+    }
+
+    init(soundData: Data) {
+        self.previewImage = UIImage(systemName: "play.fill") ?? UIImage()
+        self.soundData = soundData
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .overFullScreen
         modalTransitionStyle = .crossDissolve
@@ -108,7 +139,8 @@ final class ClanStickerPreviewViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        nameTextField.text = "sticker_\(Int(Date().timeIntervalSince1970 * 1000))"
+        let prefix = isSoundSticker ? "sound" : "sticker"
+        nameTextField.text = "\(prefix)_\(Int(Date().timeIntervalSince1970 * 1000))"
         setupLayout()
         applyTheme()
     }
@@ -123,11 +155,16 @@ final class ClanStickerPreviewViewController: UIViewController {
         forSaleRow.alignment = .center
         forSaleRow.spacing = 10.sw
 
-        [titleLabel, imagePreviewView, nameTitleLabel, nameTextField, errorLabel, forSaleRow, uploadButton].forEach {
+        var contentViews: [UIView] = [titleLabel, imagePreviewView, nameTitleLabel, nameTextField, errorLabel]
+        if !isSoundSticker {
+            contentViews.append(forSaleRow)
+        }
+        contentViews.append(uploadButton)
+        contentViews.forEach {
             containerView.addSubview($0)
         }
 
-        NSLayoutConstraint.activate([
+        var constraints = [
             backdropView.topAnchor.constraint(equalTo: view.topAnchor),
             backdropView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             backdropView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
@@ -158,16 +195,21 @@ final class ClanStickerPreviewViewController: UIViewController {
             errorLabel.topAnchor.constraint(equalTo: nameTextField.bottomAnchor, constant: 6.sh),
             errorLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor, constant: 4.sw),
             errorLabel.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
-
-            forSaleRow.topAnchor.constraint(equalTo: errorLabel.bottomAnchor, constant: 14.sh),
-            forSaleRow.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
-
-            uploadButton.topAnchor.constraint(equalTo: forSaleRow.bottomAnchor, constant: 16.sh),
             uploadButton.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 20.sw),
             uploadButton.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -20.sw),
             uploadButton.heightAnchor.constraint(equalToConstant: 44.sh),
             uploadButton.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -20.sh)
-        ])
+        ]
+        if isSoundSticker {
+            constraints.append(uploadButton.topAnchor.constraint(equalTo: errorLabel.bottomAnchor, constant: 16.sh))
+        } else {
+            constraints.append(contentsOf: [
+                forSaleRow.topAnchor.constraint(equalTo: errorLabel.bottomAnchor, constant: 14.sh),
+                forSaleRow.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+                uploadButton.topAnchor.constraint(equalTo: forSaleRow.bottomAnchor, constant: 16.sh)
+            ])
+        }
+        NSLayoutConstraint.activate(constraints)
     }
 
     private func applyTheme() {
@@ -181,10 +223,44 @@ final class ClanStickerPreviewViewController: UIViewController {
         errorLabel.textColor = .systemRed
         uploadButton.backgroundColor = theme.bgViolet
         forSaleSwitch.onTintColor = theme.bgViolet
+        if isSoundSticker {
+            imagePreviewView.tintColor = theme.bgViolet
+            imagePreviewView.backgroundColor = theme.primary
+        }
     }
 
     @objc private func handleDismiss() {
+        audioPlayer?.stop()
         dismiss(animated: true)
+    }
+
+    @objc private func handlePlayTapped() {
+        guard let soundData else { return }
+        if audioPlayer?.isPlaying == true {
+            audioPlayer?.pause()
+            updateSoundPreviewIcon(isPlaying: false)
+            return
+        }
+        do {
+            if audioPlayer == nil {
+                audioPlayer = try AVAudioPlayer(data: soundData)
+                audioPlayer?.delegate = self
+            }
+            try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [.mixWithOthers])
+            try? AVAudioSession.sharedInstance().setActive(true)
+            audioPlayer?.play()
+            updateSoundPreviewIcon(isPlaying: true)
+        } catch {
+            updateSoundPreviewIcon(isPlaying: false)
+        }
+    }
+
+    private func updateSoundPreviewIcon(isPlaying: Bool) {
+        imagePreviewView.image = UIImage(systemName: isPlaying ? "pause.fill" : "play.fill")
+    }
+
+    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        updateSoundPreviewIcon(isPlaying: false)
     }
 
     @objc private func nameTextChanged() {
@@ -195,8 +271,16 @@ final class ClanStickerPreviewViewController: UIViewController {
         let name = ClanStickerNameValidator.normalized(nameTextField.text ?? "")
         guard ClanStickerNameValidator.isValidForPreview(name) else {
             errorLabel.text = String(
-                format: L(L10n.ClanSetting.Stickers.previewLengthError),
-                L(L10n.ClanSetting.Stickers.previewTypeSticker),
+                format: L(
+                    isSoundSticker
+                        ? L10n.ClanSetting.SoundStickers.previewLengthError
+                        : L10n.ClanSetting.Stickers.previewLengthError
+                ),
+                L(
+                    isSoundSticker
+                        ? L10n.ClanSetting.SoundStickers.previewTypeSound
+                        : L10n.ClanSetting.Stickers.previewTypeSticker
+                ),
                 ClanStickerNameValidator.minLength,
                 ClanStickerNameValidator.previewMaxLength
             )
@@ -204,6 +288,10 @@ final class ClanStickerPreviewViewController: UIViewController {
             return
         }
         errorLabel.isHidden = true
-        onConfirm?(name, forSaleSwitch.isOn)
+        if isSoundSticker {
+            audioPlayer?.stop()
+            updateSoundPreviewIcon(isPlaying: false)
+        }
+        onConfirm?(name, !isSoundSticker && forSaleSwitch.isOn)
     }
 }

--- a/MezonChat/Features/ClanSettings/ClanStickersViewController.swift
+++ b/MezonChat/Features/ClanSettings/ClanStickersViewController.swift
@@ -1,19 +1,55 @@
 import UIKit
+import AVFoundation
+
+private actor SoundStickerSnowflakeGenerator {
+    static let shared = SoundStickerSnowflakeGenerator()
+
+    private static let sequenceMask: Int64 = 0xFFF
+    private var lastTimestamp: Int64 = -1
+    private var sequence: Int64 = 0
+
+    func generate() -> Int64 {
+        var timestamp = Int64(Date().timeIntervalSince1970 * 1_000)
+        timestamp = max(timestamp, lastTimestamp)
+
+        if timestamp == lastTimestamp {
+            sequence = (sequence + 1) & Self.sequenceMask
+            if sequence == 0 {
+                timestamp += 1
+            }
+        } else {
+            sequence = 0
+        }
+
+        lastTimestamp = timestamp
+        return (timestamp << 22) | sequence
+    }
+}
 
 final class ClanStickersViewController: BaseViewController {
 
     private let context: AccountContext
     private let clanId: Int64
+    private let mediaType: StickerMediaType
     private let repository: StickersRepository
 
     private var stickers: [CachedClanStickerRecord] = []
     private var clanMembers: [Int64: ClanMemberRecord] = [:]
     private weak var openSwipeCell: StickerItemCell?
     private var isSwipeInteractionActive = false
+    private var audioPlayer: AVPlayer?
+    private var audioPlaybackEndObserver: NSObjectProtocol?
+    private var playingStickerId: Int64?
 
     private static let listHorizontalInset: CGFloat = 16
     private static let maxUploadFileSize = 512 * 1024
+    private static let maxSoundUploadFileSize = 1024 * 1024
+    private static let maxSoundDuration: TimeInterval = 10
     private static let uploadSectionSpacing: CGFloat = 20.sh
+
+    private var isSoundStickerMode: Bool {
+        mediaType == .audio
+    }
 
     private lazy var tableView: UITableView = {
         let t = UITableView(frame: .zero, style: .plain)
@@ -64,7 +100,14 @@ final class ClanStickersViewController: BaseViewController {
 
     private func setupTableHeader() {
         tableHeaderContainer.backgroundColor = UIColor.theme.primary
-        uploadButton.setTitle(L(L10n.ClanSetting.Stickers.uploadButton), for: .normal)
+        uploadButton.setTitle(
+            L(
+                isSoundStickerMode
+                    ? L10n.ClanSetting.SoundStickers.uploadButton
+                    : L10n.ClanSetting.Stickers.uploadButton
+            ),
+            for: .normal
+        )
         uploadButton.titleLabel?.font = .systemFont(ofSize: 15.sf, weight: .semibold)
         uploadButton.setTitleColor(.white, for: .normal)
         uploadButton.backgroundColor = UIColor.theme.bgViolet
@@ -72,7 +115,11 @@ final class ClanStickersViewController: BaseViewController {
         uploadButton.clipsToBounds = true
         uploadButton.addTarget(self, action: #selector(addStickerTapped), for: .touchUpInside)
 
-        requirementsTitleLabel.text = L(L10n.ClanSetting.Stickers.uploadRequirementsTitle).uppercased()
+        requirementsTitleLabel.text = L(
+            isSoundStickerMode
+                ? L10n.ClanSetting.SoundStickers.uploadRequirementsTitle
+                : L10n.ClanSetting.Stickers.uploadRequirementsTitle
+        ).uppercased()
         requirementsTitleLabel.font = .systemFont(ofSize: 13.sf, weight: .bold)
         requirementsTitleLabel.textColor = UIColor.theme.textStrong
 
@@ -80,11 +127,18 @@ final class ClanStickersViewController: BaseViewController {
         requirementsStack.spacing = 10.sh
         requirementsStack.alignment = .fill
         requirementsStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
-        [
-            L(L10n.ClanSetting.Stickers.uploadRequirement1),
-            L(L10n.ClanSetting.Stickers.uploadRequirement2),
-            L(L10n.ClanSetting.Stickers.uploadRequirement3)
-        ].forEach { requirementsStack.addArrangedSubview(makeRequirementRow(text: $0)) }
+        let requirements = isSoundStickerMode
+            ? [
+                L(L10n.ClanSetting.SoundStickers.uploadRequirement1),
+                L(L10n.ClanSetting.SoundStickers.uploadRequirement2),
+                L(L10n.ClanSetting.SoundStickers.uploadRequirement3)
+            ]
+            : [
+                L(L10n.ClanSetting.Stickers.uploadRequirement1),
+                L(L10n.ClanSetting.Stickers.uploadRequirement2),
+                L(L10n.ClanSetting.Stickers.uploadRequirement3)
+            ]
+        requirements.forEach { requirementsStack.addArrangedSubview(makeRequirementRow(text: $0)) }
 
         [uploadButton, requirementsTitleLabel, requirementsStack].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
@@ -143,10 +197,15 @@ final class ClanStickersViewController: BaseViewController {
         tableHeaderContainer.frame.size.height = tableHeaderHeight
     }
 
-    init(context: AccountContext, clanId: Int64) {
+    init(
+        context: AccountContext,
+        clanId: Int64,
+        mediaType: StickerMediaType = .sticker
+    ) {
         self.context = context
         self.clanId = clanId
-        self.repository = StickersRepository(context: context)
+        self.mediaType = mediaType
+        self.repository = StickersRepository(context: context, mediaType: mediaType)
         super.init(navigationBarPresentationData: nil)
     }
 
@@ -156,6 +215,9 @@ final class ClanStickersViewController: BaseViewController {
 
     deinit {
         NotificationCenter.default.removeObserver(self)
+        if let audioPlaybackEndObserver {
+            NotificationCenter.default.removeObserver(audioPlaybackEndObserver)
+        }
     }
 
     override func setupUI() {
@@ -178,7 +240,11 @@ final class ClanStickersViewController: BaseViewController {
         backButton.tintColor = UIColor.theme.textStrong
         backButton.addTarget(self, action: #selector(backTapped), for: .touchUpInside)
 
-        headerTitleLabel.text = L(L10n.ClanSetting.sticker)
+        headerTitleLabel.text = L(
+            isSoundStickerMode
+                ? L10n.ClanSetting.soundEffect
+                : L10n.ClanSetting.sticker
+        )
         headerTitleLabel.font = .systemFont(ofSize: 16.sf, weight: .bold)
         headerTitleLabel.textColor = .mezonTextPrimary
         headerTitleLabel.textAlignment = .center
@@ -226,6 +292,13 @@ final class ClanStickersViewController: BaseViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(true, animated: animated)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        guard isSoundStickerMode, let playingStickerId else { return }
+        stopSoundPlayback()
+        reloadSoundStickerRows(ids: [playingStickerId])
     }
 
     override func containerLayoutUpdated(_ layout: ContainerViewLayout, transition: ContainedViewLayoutTransition) {
@@ -323,7 +396,11 @@ final class ClanStickersViewController: BaseViewController {
     }
 
     private func canEdit(_ sticker: CachedClanStickerRecord) -> Bool {
-        hasClanStickerAdminPermission || (currentUserId != 0 && currentUserId == sticker.creatorID)
+        let isCreator = currentUserId != 0 && currentUserId == sticker.creatorID
+        if isSoundStickerMode {
+            return context.rolePermissions.isClanOwner(clanId: clanId) || isCreator
+        }
+        return hasClanStickerAdminPermission || isCreator
     }
 
     private func resolvedCreatorInfo(for creatorId: Int64) -> (avatar: String?, name: String) {
@@ -356,9 +433,21 @@ final class ClanStickersViewController: BaseViewController {
 
     @objc private func handleStickersChanged() {
         reloadData()
+        guard isSoundStickerMode,
+              let playingStickerId,
+              !stickers.contains(where: { $0.id == playingStickerId })
+        else { return }
+        stopSoundPlayback()
     }
 
     @objc private func addStickerTapped() {
+        if isSoundStickerMode {
+            let picker = UIDocumentPickerViewController(documentTypes: ["public.audio"], in: .import)
+            picker.delegate = self
+            picker.allowsMultipleSelection = false
+            present(picker, animated: true)
+            return
+        }
         let picker = UIImagePickerController()
         picker.delegate = self
         picker.sourceType = .photoLibrary
@@ -403,14 +492,22 @@ final class ClanStickersViewController: BaseViewController {
         let trimmed = ClanStickerNameValidator.normalized(name)
         guard ClanStickerNameValidator.isValid(trimmed) else {
             Toast.error(String(
-                format: L(L10n.ClanSetting.Stickers.validateName),
+                format: L(
+                    isSoundStickerMode
+                        ? L10n.ClanSetting.SoundStickers.validateName
+                        : L10n.ClanSetting.Stickers.validateName
+                ),
                 ClanStickerNameValidator.minLength,
                 ClanStickerNameValidator.maxLength
             ))
             return false
         }
         guard !stickers.contains(where: { $0.shortname == trimmed && $0.id != excludingId }) else {
-            Toast.error(L(L10n.ClanSetting.Stickers.duplicateName))
+            Toast.error(L(
+                isSoundStickerMode
+                    ? L10n.ClanSetting.SoundStickers.duplicateName
+                    : L10n.ClanSetting.Stickers.duplicateName
+            ))
             return false
         }
         return true
@@ -440,13 +537,21 @@ final class ClanStickersViewController: BaseViewController {
                     category: sticker.category
                 )
                 await MainActor.run {
-                    Toast.success(L(L10n.ClanSetting.Stickers.updateSuccess))
+                    Toast.success(L(
+                        isSoundStickerMode
+                            ? L10n.ClanSetting.SoundStickers.updateSuccess
+                            : L10n.ClanSetting.Stickers.updateSuccess
+                    ))
                     completion(true)
                     reloadData()
                 }
             } catch {
                 await MainActor.run {
-                    Toast.error(L(L10n.ClanSetting.Stickers.errorUpdating))
+                    Toast.error(L(
+                        isSoundStickerMode
+                            ? L10n.ClanSetting.SoundStickers.errorUpdating
+                            : L10n.ClanSetting.Stickers.errorUpdating
+                    ))
                     completion(false)
                 }
             }
@@ -457,8 +562,16 @@ final class ClanStickersViewController: BaseViewController {
         guard canEdit(sticker) else { return }
         MezonConfirm.present(
             from: self,
-            title: L(L10n.ClanSetting.Stickers.deleteConfirmTitle),
-            content: L(L10n.ClanSetting.Stickers.deleteConfirmDesc),
+            title: L(
+                isSoundStickerMode
+                    ? L10n.ClanSetting.SoundStickers.deleteConfirmTitle
+                    : L10n.ClanSetting.Stickers.deleteConfirmTitle
+            ),
+            content: L(
+                isSoundStickerMode
+                    ? L10n.ClanSetting.SoundStickers.deleteConfirmDesc
+                    : L10n.ClanSetting.Stickers.deleteConfirmDesc
+            ),
             confirmTitle: L(L10n.Common.delete),
             isDanger: true
         ) { [weak self] in
@@ -470,11 +583,104 @@ final class ClanStickersViewController: BaseViewController {
                         clanId: self.clanId,
                         shortname: sticker.shortname
                     )
-                    Toast.success(L(L10n.ClanSetting.Stickers.deleteSuccess))
+                    if self.playingStickerId == sticker.id {
+                        self.stopSoundPlayback()
+                    }
+                    Toast.success(L(
+                        self.isSoundStickerMode
+                            ? L10n.ClanSetting.SoundStickers.deleteSuccess
+                            : L10n.ClanSetting.Stickers.deleteSuccess
+                    ))
                 } catch {
-                    Toast.error(L(L10n.ClanSetting.Stickers.errorUpdating))
+                    Toast.error(L(
+                        self.isSoundStickerMode
+                            ? L10n.ClanSetting.SoundStickers.errorUpdating
+                            : L10n.ClanSetting.Stickers.errorUpdating
+                    ))
                 }
             }
+        }
+    }
+
+    private func toggleSoundPlayback(_ sticker: CachedClanStickerRecord) {
+        guard let url = soundURL(for: sticker) else { return }
+        if playingStickerId == sticker.id, let audioPlayer {
+            if audioPlayer.rate > 0 {
+                audioPlayer.pause()
+            } else {
+                activatePlaybackAudioSession()
+                audioPlayer.play()
+            }
+            reloadSoundStickerRows(ids: [sticker.id])
+            return
+        }
+
+        let previousId = playingStickerId
+        stopSoundPlayback()
+        activatePlaybackAudioSession()
+        let player = AVPlayer(url: url)
+        audioPlayer = player
+        playingStickerId = sticker.id
+        audioPlaybackEndObserver = NotificationCenter.default.addObserver(
+            forName: .AVPlayerItemDidPlayToEndTime,
+            object: player.currentItem,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            let finishedId = self.playingStickerId
+            self.stopSoundPlayback()
+            if let finishedId {
+                self.reloadSoundStickerRows(ids: [finishedId])
+            }
+        }
+        player.play()
+        reloadSoundStickerRows(ids: [previousId, sticker.id].compactMap { $0 })
+    }
+
+    private func activatePlaybackAudioSession() {
+        try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [.mixWithOthers])
+        try? AVAudioSession.sharedInstance().setActive(true)
+    }
+
+    private func stopSoundPlayback() {
+        audioPlayer?.pause()
+        audioPlayer = nil
+        playingStickerId = nil
+        if let audioPlaybackEndObserver {
+            NotificationCenter.default.removeObserver(audioPlaybackEndObserver)
+            self.audioPlaybackEndObserver = nil
+        }
+    }
+
+    private func soundURL(for sticker: CachedClanStickerRecord) -> URL? {
+        let source = sticker.source.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !source.isEmpty else { return nil }
+        let resolved: String
+        if URL(string: source)?.scheme != nil {
+            resolved = source
+        } else if source.hasPrefix("//") {
+            resolved = "https:\(source)"
+        } else if source.hasPrefix("/") {
+            resolved = "\(MezonConfig.baseImgURL)\(source)"
+        } else {
+            resolved = "\(MezonConfig.baseImgURL)/\(source)"
+        }
+        guard let url = URL(string: resolved),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private func reloadSoundStickerRows(ids: [Int64]) {
+        let indexPaths = Set(ids).compactMap { id in
+            stickers.firstIndex(where: { $0.id == id }).map { IndexPath(row: $0, section: 0) }
+        }
+        guard !indexPaths.isEmpty else { return }
+        UIView.performWithoutAnimation {
+            tableView.reloadRows(at: indexPaths, with: .none)
         }
     }
 }
@@ -502,7 +708,11 @@ extension ClanStickersViewController: UITableViewDataSource, UITableViewDelegate
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: StickerItemCell.reuseId, for: indexPath) as! StickerItemCell
         if stickers.isEmpty {
-            cell.configureEmpty(text: L(L10n.ClanSetting.Stickers.empty))
+            cell.configureEmpty(text: L(
+                isSoundStickerMode
+                    ? L10n.ClanSetting.SoundStickers.empty
+                    : L10n.ClanSetting.Stickers.empty
+            ))
             return cell
         }
         let rowCount = stickers.count
@@ -515,8 +725,13 @@ extension ClanStickersViewController: UITableViewDataSource, UITableViewDelegate
             creatorAvatar: creatorInfo.avatar,
             creatorName: creatorInfo.name,
             isEditable: editable,
-            isLast: isLast
+            isLast: isLast,
+            isSoundSticker: isSoundStickerMode,
+            isPlaying: playingStickerId == sticker.id && (audioPlayer?.rate ?? 0) > 0
         )
+        cell.onPlay = isSoundStickerMode ? { [weak self] in
+            self?.toggleSoundPlayback(sticker)
+        } : nil
         cell.onShortnameCommit = { [weak self] newName, done in
             guard let self,
                   let current = self.stickers.first(where: { $0.id == sticker.id })
@@ -558,7 +773,113 @@ extension ClanStickersViewController: UITableViewDataSource, UITableViewDelegate
 
 }
 
-extension ClanStickersViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+extension ClanStickersViewController: UIImagePickerControllerDelegate, UIDocumentPickerDelegate, UINavigationControllerDelegate {
+    func documentPicker(
+        _ controller: UIDocumentPickerViewController,
+        didPickDocumentsAt urls: [URL]
+    ) {
+        guard isSoundStickerMode, let url = urls.first else { return }
+        let didAccess = url.startAccessingSecurityScopedResource()
+        defer {
+            if didAccess {
+                url.stopAccessingSecurityScopedResource()
+            }
+        }
+
+        let fileExtension = url.pathExtension.lowercased()
+        guard ["mp3", "mpeg", "wav"].contains(fileExtension) else {
+            Toast.error(L(L10n.ClanSetting.SoundStickers.invalidFileType))
+            return
+        }
+
+        do {
+            let resourceValues = try url.resourceValues(forKeys: [.fileSizeKey])
+            guard let fileSize = resourceValues.fileSize,
+                  fileSize <= Self.maxSoundUploadFileSize
+            else {
+                Toast.error(L(L10n.ClanSetting.SoundStickers.uploadFileTooLarge))
+                return
+            }
+            let data = try Data(contentsOf: url, options: .mappedIfSafe)
+            guard data.count <= Self.maxSoundUploadFileSize else {
+                Toast.error(L(L10n.ClanSetting.SoundStickers.uploadFileTooLarge))
+                return
+            }
+            let player = try AVAudioPlayer(data: data)
+            guard player.duration <= Self.maxSoundDuration else {
+                Toast.error(L(L10n.ClanSetting.SoundStickers.durationTooLong))
+                return
+            }
+            let picked = PickedSound(
+                data: data,
+                contentType: Self.soundMimeType(for: fileExtension),
+                fileExtension: fileExtension
+            )
+            presentSoundPreview(picked: picked)
+        } catch {
+            Toast.error(L(L10n.ClanSetting.SoundStickers.invalidFileType))
+        }
+    }
+
+    private func presentSoundPreview(picked: PickedSound) {
+        let preview = ClanStickerPreviewViewController(soundData: picked.data)
+        var isSubmitting = false
+        preview.onConfirm = { [weak self, weak preview] shortname, _ in
+            guard let self, !isSubmitting else { return }
+            let trimmed = ClanStickerNameValidator.normalized(shortname)
+            guard self.validateShortname(trimmed) else { return }
+            isSubmitting = true
+            preview?.dismiss(animated: true) {
+                Task {
+                    await self.uploadSoundSticker(picked: picked, shortname: trimmed)
+                }
+            }
+        }
+        present(preview, animated: true)
+    }
+
+    private func uploadSoundSticker(picked: PickedSound, shortname: String) async {
+        guard !repository.isAtUploadLimit(clanId: clanId) else { return }
+        let uploadId = await SoundStickerSnowflakeGenerator.shared.generate()
+        let filename = "sounds/\(uploadId).\(picked.fileExtension)"
+        do {
+            guard let token = await context.getToken() else { return }
+            let upload = try await context.account.network.uploadAttachmentFile(
+                filename: filename,
+                filetype: picked.contentType,
+                size: picked.data.count,
+                token: token
+            )
+            try await context.account.network.uploadToMinIO(
+                url: upload.url,
+                data: picked.data,
+                contentType: picked.contentType
+            )
+            let cdnURL = "\(MezonConfig.baseImgURL)/\(upload.filename)"
+            let requestId = Self.stickerId(fromUploadFilename: upload.filename) ?? uploadId
+            try await repository.addSticker(
+                clanId: clanId,
+                source: cdnURL,
+                shortname: shortname,
+                category: "Among Us",
+                id: requestId
+            )
+            Toast.success(L(L10n.ClanSetting.SoundStickers.createSuccess))
+        } catch {
+            Toast.error(L(L10n.ClanSetting.SoundStickers.errorUpdating))
+        }
+    }
+
+    private struct PickedSound {
+        let data: Data
+        let contentType: String
+        let fileExtension: String
+    }
+
+    private static func soundMimeType(for fileExtension: String) -> String {
+        fileExtension == "wav" ? "audio/wav" : "audio/mpeg"
+    }
+
     func imagePickerController(
         _ picker: UIImagePickerController,
         didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]

--- a/MezonChat/Features/ClanSettings/StickerItemCell.swift
+++ b/MezonChat/Features/ClanSettings/StickerItemCell.swift
@@ -15,6 +15,7 @@ final class StickerItemCell: UITableViewCell {
 
     var onShortnameCommit: ((String, @escaping (Bool) -> Void) -> Void)?
     var onDelete: (() -> Void)?
+    var onPlay: (() -> Void)?
     var onSwipeOpened: (() -> Void)?
     var onSwipeClosed: (() -> Void)?
     var onSwipeInteractionChanged: ((Bool) -> Void)?
@@ -24,6 +25,7 @@ final class StickerItemCell: UITableViewCell {
     private let deleteButton = UIButton(type: .system)
     private let iconContainerView = UIView()
     private let iconView = UIImageView()
+    private let soundPlayButton = UIButton(type: .system)
     private let forSaleBadgeHost = UIView()
     private let forSaleBadgeView = UIImageView()
     private let nameTextField = UITextField()
@@ -87,6 +89,13 @@ final class StickerItemCell: UITableViewCell {
         iconView.clipsToBounds = true
         iconView.layer.cornerRadius = 6.swh
 
+        soundPlayButton.tintColor = UIColor.theme.bgViolet
+        soundPlayButton.backgroundColor = UIColor.theme.secondaryLight
+        soundPlayButton.layer.cornerRadius = Self.iconSize / 2
+        soundPlayButton.clipsToBounds = true
+        soundPlayButton.isHidden = true
+        soundPlayButton.addTarget(self, action: #selector(playTapped), for: .touchUpInside)
+
         forSaleBadgeHost.backgroundColor = UIColor.theme.secondary
         forSaleBadgeHost.layer.cornerRadius = 3.swh
         forSaleBadgeHost.clipsToBounds = true
@@ -130,11 +139,12 @@ final class StickerItemCell: UITableViewCell {
             $0.translatesAutoresizingMaskIntoConstraints = false
             contentView.addSubview($0)
         }
-        [deleteButton, iconContainerView, iconView, forSaleBadgeHost, forSaleBadgeView, nameTextField, emptyStateLabel, creatorTextAvatar, creatorNameLabel].forEach {
+        [deleteButton, iconContainerView, iconView, soundPlayButton, forSaleBadgeHost, forSaleBadgeView, nameTextField, emptyStateLabel, creatorTextAvatar, creatorNameLabel].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
         deleteActionView.addSubview(deleteButton)
         iconContainerView.addSubview(iconView)
+        iconContainerView.addSubview(soundPlayButton)
         forSaleBadgeHost.addSubview(forSaleBadgeView)
         creatorTextAvatar.addSubview(creatorAvatarImageView)
         creatorAvatarImageView.translatesAutoresizingMaskIntoConstraints = false
@@ -178,6 +188,11 @@ final class StickerItemCell: UITableViewCell {
             iconView.leadingAnchor.constraint(equalTo: iconContainerView.leadingAnchor),
             iconView.trailingAnchor.constraint(equalTo: iconContainerView.trailingAnchor),
             iconView.bottomAnchor.constraint(equalTo: iconContainerView.bottomAnchor),
+
+            soundPlayButton.topAnchor.constraint(equalTo: iconContainerView.topAnchor),
+            soundPlayButton.leadingAnchor.constraint(equalTo: iconContainerView.leadingAnchor),
+            soundPlayButton.trailingAnchor.constraint(equalTo: iconContainerView.trailingAnchor),
+            soundPlayButton.bottomAnchor.constraint(equalTo: iconContainerView.bottomAnchor),
 
             forSaleBadgeHost.topAnchor.constraint(
                 equalTo: iconContainerView.topAnchor,
@@ -231,7 +246,7 @@ final class StickerItemCell: UITableViewCell {
         creatorNameLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         nameTextField.setContentHuggingPriority(.defaultLow, for: .horizontal)
         creatorNameLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        [iconContainerView, iconView, forSaleBadgeHost, forSaleBadgeView].forEach {
+        [iconContainerView, iconView, soundPlayButton, forSaleBadgeHost, forSaleBadgeView].forEach {
             $0.setContentCompressionResistancePriority(.required, for: .horizontal)
             $0.setContentCompressionResistancePriority(.required, for: .vertical)
             $0.setContentHuggingPriority(.required, for: .horizontal)
@@ -255,6 +270,8 @@ final class StickerItemCell: UITableViewCell {
         nameTextField.textColor = .mezonTextPrimary
         emptyStateLabel.textColor = UIColor.theme.textDisabled
         creatorNameLabel.textColor = UIColor.theme.textStrong
+        soundPlayButton.tintColor = UIColor.theme.bgViolet
+        soundPlayButton.backgroundColor = UIColor.theme.secondaryLight
         selectedBackgroundView?.backgroundColor = contentBackground.withAlphaComponent(isEmpty ? 0 : 0.6)
         applySwipeOffset(currentSwipeOffset, animated: false)
     }
@@ -298,7 +315,9 @@ final class StickerItemCell: UITableViewCell {
         creatorAvatar: String?,
         creatorName: String,
         isEditable: Bool,
-        isLast: Bool
+        isLast: Bool,
+        isSoundSticker: Bool = false,
+        isPlaying: Bool = false
     ) {
         closeSwipe(animated: false)
         isSwipeDeletable = isEditable
@@ -317,13 +336,21 @@ final class StickerItemCell: UITableViewCell {
         creatorNameLabel.alpha = 1
         creatorTextAvatar.isHidden = false
         creatorTextAvatar.alpha = 1
-        iconView.isHidden = false
-        forSaleBadgeHost.isHidden = !sticker.isForSale
+        iconView.isHidden = isSoundSticker
+        soundPlayButton.isHidden = !isSoundSticker
+        if isSoundSticker {
+            let configuration = UIImage.SymbolConfiguration(pointSize: 14.sf, weight: .semibold)
+            let imageName = isPlaying ? "pause.fill" : "play.fill"
+            soundPlayButton.setImage(UIImage(systemName: imageName, withConfiguration: configuration), for: .normal)
+        }
+        forSaleBadgeHost.isHidden = isSoundSticker || !sticker.isForSale
         isUserInteractionEnabled = true
         applyRowSeparator(isLast: isLast)
 
         loadCreatorAvatar(creatorAvatar, displayName: creatorName)
-        loadStickerIcon(sticker)
+        if !isSoundSticker {
+            loadStickerIcon(sticker)
+        }
     }
 
     func configureEmpty(text: String, isLast: Bool = true) {
@@ -335,6 +362,7 @@ final class StickerItemCell: UITableViewCell {
         creatorAvatarImageView.image = nil
         iconContainerView.isHidden = true
         iconView.isHidden = true
+        soundPlayButton.isHidden = true
         forSaleBadgeHost.isHidden = true
         creatorTextAvatar.isHidden = true
         creatorNameLabel.isHidden = true
@@ -374,8 +402,10 @@ final class StickerItemCell: UITableViewCell {
         iconTask = nil
         loadingIconURL = nil
         iconView.image = nil
+        soundPlayButton.setImage(nil, for: .normal)
         forSaleBadgeHost.isHidden = true
         iconContainerView.isHidden = false
+        soundPlayButton.isHidden = true
         nameTextField.isHidden = false
         emptyStateLabel.isHidden = true
         emptyStateLabel.text = nil
@@ -383,6 +413,7 @@ final class StickerItemCell: UITableViewCell {
         creatorTextAvatar.showImageMode()
         onShortnameCommit = nil
         onDelete = nil
+        onPlay = nil
         onSwipeOpened = nil
         onSwipeClosed = nil
         onSwipeInteractionChanged = nil
@@ -429,6 +460,10 @@ final class StickerItemCell: UITableViewCell {
     @objc private func deleteTapped() {
         closeSwipe(animated: true)
         onDelete?()
+    }
+
+    @objc private func playTapped() {
+        onPlay?()
     }
 
     private func commitEditing() {

--- a/MezonChat/Features/ClanSettings/StickersRepository.swift
+++ b/MezonChat/Features/ClanSettings/StickersRepository.swift
@@ -28,9 +28,11 @@ final class StickersRepository {
     static let maxSlots = 250
 
     private let context: AccountContext
+    private let mediaType: StickerMediaType
 
-    init(context: AccountContext) {
+    init(context: AccountContext, mediaType: StickerMediaType = .sticker) {
         self.context = context
+        self.mediaType = mediaType
     }
 
     func stickers(clanId: Int64) -> [CachedClanStickerRecord] {
@@ -38,7 +40,7 @@ final class StickersRepository {
             return []
         }
         return list.stickers
-            .filter { $0.clanID == clanId && $0.mediaType == StickerMediaType.sticker.rawValue }
+            .filter { $0.clanID == clanId && $0.mediaType == mediaType.rawValue }
             .sorted { $0.createTimeSeconds > $1.createTimeSeconds }
     }
 
@@ -124,7 +126,7 @@ final class StickersRepository {
         req.source = source
         req.shortname = shortname
         req.category = category
-        req.mediaType = StickerMediaType.sticker.rawValue
+        req.mediaType = mediaType.rawValue
         req.isForSale = isForSale
         req.id = id ?? Int64(Date().timeIntervalSince1970 * 1000)
         guard let token = await context.getToken() else {
@@ -143,6 +145,7 @@ final class StickersRepository {
             )
         } else {
             var parsed = created.toCachedRecord()
+            parsed.mediaType = mediaType.rawValue
             parsed.isForSale = isForSale
             record = parsed
         }
@@ -155,7 +158,9 @@ final class StickersRepository {
                     fallbackShortname: shortname
                 )
             } else if let idx = stickers.firstIndex(where: {
-                $0.shortname == shortname && $0.clanID == clanId
+                $0.shortname == shortname
+                    && $0.clanID == clanId
+                    && $0.mediaType == mediaType.rawValue
             }) {
                 stickers[idx] = Self.mergeStickerRecord(
                     existing: stickers[idx],


### PR DESCRIPTION
task: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-341
Root Cause
iOS Clan Settings did not support managing Sound Stickers, causing feature differences between iOS and Web.
Solution
Added Sound Sticker listing, upload, preview, playback, rename, deletion, permission checks, and automatic refresh while keeping the existing Sticker and Emoji flows unchanged.

Test Cases
1. Verify a valid MP3 or WAV file under 1 MB and 10 seconds can be uploaded successfully.
2. Verify invalid format, oversized, and over-duration files are rejected with the correct message.
3. Verify a Sound Sticker can be played, paused, renamed, and deleted successfully.
4. Verify only the Clan Owner or the sound creator can rename or delete a Sound Sticker.
5. Verify deleting a playing sound stops playback immediately.
6. Verify existing Sticker and Emoji flows continue working normally.