### PR TITLE
260826-IOS-Remove tab message in search global

### DIFF
--- a/MezonChat/Features/Search/SearchViewController.swift
+++ b/MezonChat/Features/Search/SearchViewController.swift
@@ -153,7 +153,7 @@ final class SearchViewController: ViewController {
     required init(coder aDecoder: NSCoder) { fatalError() }
 
     override func loadDisplayNode() {
-        var hiddenTabs: Set<SearchTab> = isChannelScoped ? [.channels] : []
+        var hiddenTabs: Set<SearchTab> = isChannelScoped ? [.channels] : [.messages]
         let isDM = clanId == 0
         if isDM {
             hiddenTabs.insert(.members)


### PR DESCRIPTION
https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-382
Root cause: The Messages tab was included in Global Search even though message search should only be available inside a conversation.
Solution: Hide Messages in Global Search while keeping message search available inside channels and direct messages.
Test cases:
- Open Global Search and confirm that only Members and Channels are shown.
- Search for a member in Global Search and confirm that matching members are displayed.
- Search for a channel in Global Search and confirm that matching channels are displayed.
- Open search inside a clan channel and confirm that Members and Messages remain available.
- Open search inside a direct message and confirm that message search still works.
- Enter a keyword from an existing direct message and confirm that matching messages are displayed.