### PR TITLE
260904-IOS-Improve jump to msg mentions

### DIFF
--- a/MezonChat/Features/Chat/ChatContainerNode.swift
+++ b/MezonChat/Features/Chat/ChatContainerNode.swift
@@ -99,6 +99,8 @@ final class ChatContainerNode: ASDisplayNode {
     private let isDM: Bool
     private let disposables = DisposableSet()
     var pendingJumpMessageId: String?
+    var onPendingJumpCompleted: ((String) -> Void)?
+    private var scheduledJumpMessageId: String?
     private(set) var didAutoScrollForNewMessages = false
     private var isLoadMoreGuardActive = false
     private var lastKnownDistanceFromBottom: CGFloat = 0
@@ -320,20 +322,31 @@ final class ChatContainerNode: ASDisplayNode {
         if hadZeroFrame && listView.bounds.width > 0 || needsReloadAfterLayout {
             needsReloadAfterLayout = false
             reloadAllItems()
+            triggerPendingJump()
         }
     }
 
     func triggerPendingJump() {
-        guard let jumpId = pendingJumpMessageId,
-              state.messages.contains(where: { $0.id == jumpId }) else { return }
-        pendingJumpMessageId = nil
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
-            self?.scrollToMessage(id: jumpId)
+        guard let jumpId = pendingJumpMessageId else { return }
+        guard state.messages.contains(where: { $0.id == jumpId }),
+              committedMessageIds.contains(jumpId),
+              scheduledJumpMessageId != jumpId else { return }
+        scheduledJumpMessageId = jumpId
+        listView.addAfterTransactionsCompleted { [weak self] in
+            guard let self else { return }
+            guard self.pendingJumpMessageId == jumpId else {
+                self.scheduledJumpMessageId = nil
+                return
+            }
+            if !self.scrollToMessage(id: jumpId) {
+                self.scheduledJumpMessageId = nil
+            }
         }
     }
 
-    func scrollToMessage(id: String) {
-        guard let row = committedMessageIds.firstIndex(of: id) else { return }
+    @discardableResult
+    func scrollToMessage(id: String) -> Bool {
+        guard let row = committedMessageIds.firstIndex(of: id) else { return false }
         listView.transaction(
             deleteIndices: [],
             insertIndicesAndItems: [],
@@ -341,7 +354,13 @@ final class ChatContainerNode: ASDisplayNode {
             options: [.Synchronous],
             scrollToItem: ListViewScrollToItem(index: row, position: .center(.top), animated: true, curve: .Default(duration: nil), directionHint: .Down),
             updateOpaqueState: nil,
-            completion: { _ in }
+            completion: { [weak self] _ in
+                guard let self else { return }
+                self.scheduledJumpMessageId = nil
+                guard self.pendingJumpMessageId == id else { return }
+                self.pendingJumpMessageId = nil
+                self.onPendingJumpCompleted?(id)
+            }
         )
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
@@ -355,6 +374,7 @@ final class ChatContainerNode: ASDisplayNode {
                 }
             }
         }
+        return true
     }
 
     func captureVisibleMessageAnchor() -> VisibleMessageAnchor? {

--- a/MezonChat/Features/Chat/ChatViewController.swift
+++ b/MezonChat/Features/Chat/ChatViewController.swift
@@ -600,7 +600,25 @@ final class ChatViewController: ViewController {
 
     private var messagesNode: ChatContainerNode { displayNode as! ChatContainerNode }
 
-    var pendingJumpToMessageId: String?
+    private var initialMessageJumpTargetId: String?
+    private var startupJumpTargetForInitialFetch: String?
+    var pendingJumpToMessageId: String? {
+        didSet {
+            if let target = pendingJumpToMessageId, !target.isEmpty {
+                initialMessageJumpTargetId = target
+            }
+        }
+    }
+
+    private func finishMessageJump(messageId: String) {
+        if let initialTarget = initialMessageJumpTargetId {
+            guard initialTarget == messageId else { return }
+            initialMessageJumpTargetId = nil
+            setIsLoading(false)
+        }
+        isJumping = false
+        readyToLoadMore = true
+    }
 
     init(
         clanId: Int64, channel: Mezon_Api_ChannelDescription, context: AccountContext,
@@ -994,11 +1012,15 @@ final class ChatViewController: ViewController {
             self.handleEmbedButtonClicked(button: button, messageId: messageId, display: display)
         }
         
-        displayNode = ChatContainerNode(
+        let containerNode = ChatContainerNode(
             signal: stateSignal(),
             interaction: interaction,
             isDM: channel.type == MezonConstants.ChannelType.dm.rawValue
         )
+        containerNode.onPendingJumpCompleted = { [weak self] messageId in
+            self?.finishMessageJump(messageId: messageId)
+        }
+        displayNode = containerNode
     }
 
     override func viewDidLoad() {
@@ -1081,8 +1103,7 @@ final class ChatViewController: ViewController {
                 self.setIsLoading(false)
                 return
             }
-            self.hasCompletedInitialFetch = true
-            self.fetchMessages(token: token)
+            self.performInitialMessageFetchIfNeeded(token: token)
         }
     }
     
@@ -1723,6 +1744,7 @@ final class ChatViewController: ViewController {
         markChannelAsReadOnEntryIfPossible()
 
         if let jumpId = pendingJumpToMessageId {
+            isJumping = true
             pendingJumpToMessageId = nil
             DispatchQueue.main.async { [weak self] in
                 self?.jumpToMessage(id: jumpId)
@@ -1808,7 +1830,20 @@ final class ChatViewController: ViewController {
         2_400_000_000
     ]
 
+    private func performInitialMessageFetchIfNeeded(token: String) {
+        guard !hasCompletedInitialFetch else { return }
+        hasCompletedInitialFetch = true
+        if startupJumpTargetForInitialFetch != nil {
+            startupJumpTargetForInitialFetch = nil
+            return
+        }
+        fetchMessages(token: token)
+    }
+
     func start() {
+        if let initialMessageJumpTargetId {
+            startupJumpTargetForInitialFetch = initialMessageJumpTargetId
+        }
         if topicId == 0 {
             context.currentClanId = clanId
             context.currentChannel = channel
@@ -1896,8 +1931,7 @@ final class ChatViewController: ViewController {
                 return nil
             }()
             if let immediateToken, !self.hasCompletedInitialFetch {
-                self.hasCompletedInitialFetch = true
-                self.fetchMessages(token: immediateToken)
+                self.performInitialMessageFetchIfNeeded(token: immediateToken)
             }
 
             var token = await self.context.getTokenPreferringCachedSkipSessionReadyWait()
@@ -1910,8 +1944,7 @@ final class ChatViewController: ViewController {
                 return
             }
             if !self.hasCompletedInitialFetch {
-                self.hasCompletedInitialFetch = true
-                self.fetchMessages(token: token)
+                self.performInitialMessageFetchIfNeeded(token: token)
             }
             await self.waitForSocketConnected()
             self.joinChat()
@@ -2444,7 +2477,7 @@ final class ChatViewController: ViewController {
     }
 
     func fetchMessages(token: String? = nil) {
-        if pendingJumpToMessageId != nil { return }
+        if initialMessageJumpTargetId != nil || pendingJumpToMessageId != nil { return }
         let hadCachedMessages = !messages.isEmpty
         let hadCachedInPostbox = hasCachedMessagesInPostbox()
         if shouldSkipRemoteFetchForEmptyTopic(
@@ -4620,14 +4653,11 @@ final class ChatViewController: ViewController {
         if messages.contains(where: { $0.id == messageId }) {
             messagesNode.pendingJumpMessageId = messageId
             messagesNode.triggerPendingJump()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-                self?.isJumping = false
-            }
             return
         }
 
         guard let msgId = Int64(messageId) else {
-            isJumping = false
+            finishMessageJump(messageId: messageId)
             return
         }
 
@@ -4640,12 +4670,12 @@ final class ChatViewController: ViewController {
         Task { @MainActor in
             defer {
                 self.setIsLoadingMessageContext(false)
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
-                    self?.isJumping = false
-                    self?.readyToLoadMore = true
-                }
             }
-            guard let token = await self.context.getTokenPreferringCachedSkipSessionReadyWait() else { return }
+            guard let token = await self.context.getTokenPreferringCachedSkipSessionReadyWait() else {
+                self.messagesNode.pendingJumpMessageId = nil
+                self.finishMessageJump(messageId: messageId)
+                return
+            }
             do {
                 let response = try await self.context.account.network.listChannelMessages(
                     clanId: self.clanId,
@@ -4656,8 +4686,9 @@ final class ChatViewController: ViewController {
                     topicId: self.topicId,
                     token: token
                 )
-                guard !response.messages.isEmpty else {
+                guard response.messages.contains(where: { $0.messageID == msgId }) else {
                     self.messagesNode.pendingJumpMessageId = nil
+                    self.finishMessageJump(messageId: messageId)
                     return
                 }
                 self.setHasMoreOlder(response.messages.count > 1)
@@ -4676,6 +4707,7 @@ final class ChatViewController: ViewController {
                     "anchorMessageId": msgId,
                 ])
                 self.messagesNode.pendingJumpMessageId = nil
+                self.finishMessageJump(messageId: messageId)
             }
         }
     }


### PR DESCRIPTION
task: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-429
Root Cause
The initial latest-message load could replace the target message’s history, while scrolling could run before the message list was ready, causing intermittent incorrect jumps.
Solution
Skip the initial latest-message load when opening a specific message, wait until the list is ready before scrolling, and clear the jump state only after scrolling completes or loading fails.
Test Cases
- Tap an old mention in a channel that has not been opened recently and verify the correct message appears.
- Return to Mentions, tap the same mention again, and verify it opens the correct message.
- Repeat both scenarios for direct messages.
- Scroll up and down after jumping and verify more messages load normally.

