### PR TITLE
260904-IOS-Implement share text

### DIFF
--- a/MezonChat/Core/Localization/L10n.swift
+++ b/MezonChat/Core/Localization/L10n.swift
@@ -1158,6 +1158,7 @@ enum L10n {
     enum MessageAction {
         static let reply            = "messageAction.reply"
         static let copyText         = "messageAction.copyText"
+        static let shareText        = "messageAction.shareText"
         static let saveImage        = "messageAction.saveImage"
         static let saveVideo        = "messageAction.saveVideo"
         static let copyImage        = "messageAction.copyImage"
@@ -2299,6 +2300,7 @@ extension L10n {
 
         "messageAction.reply": "Reply",
         "messageAction.copyText": "Copy Text",
+        "messageAction.shareText": "Share Text",
         "messageAction.saveImage": "Save Image",
         "messageAction.saveVideo": "Save Video",
         "messageAction.copyImage": "Copy Image",
@@ -3585,6 +3587,7 @@ extension L10n {
 
         "messageAction.reply": "Trả lời",
         "messageAction.copyText": "Sao chép văn bản",
+        "messageAction.shareText": "Chia sẻ văn bản",
         "messageAction.saveImage": "Lưu ảnh",
         "messageAction.saveVideo": "Lưu video",
         "messageAction.copyImage": "Sao chép ảnh",

--- a/MezonChat/Features/Chat/ChatViewController.swift
+++ b/MezonChat/Features/Chat/ChatViewController.swift
@@ -6461,6 +6461,18 @@ final class ChatViewController: ViewController {
         case restricted
     }
 
+    private func shareMessageText(display: ChatMessageDisplay) {
+        let text = display.parsedContent.text
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        let activity = UIActivityViewController(activityItems: [text], applicationActivities: nil)
+        if let popover = activity.popoverPresentationController {
+            popover.sourceView = view
+            popover.sourceRect = CGRect(x: view.bounds.midX, y: view.bounds.midY, width: 1, height: 1)
+            popover.permittedArrowDirections = []
+        }
+        present(activity, animated: true)
+    }
+
     private func saveSingleMessageImage(display: ChatMessageDisplay) {
         loadSingleMessageImage(display: display) { [weak self] image in
             guard let self else { return }
@@ -6645,6 +6657,8 @@ final class ChatViewController: ViewController {
         case .copyText:
             UIPasteboard.general.string = display.parsedContent.text
             Toast.success(L(L10n.MessageAction.copied))
+        case .shareText:
+            shareMessageText(display: display)
         case .saveImage:
             saveSingleMessageImage(display: display)
         case .copyImage:

--- a/MezonChat/Features/Chat/MessageActionSheet.swift
+++ b/MezonChat/Features/Chat/MessageActionSheet.swift
@@ -8,6 +8,7 @@ enum MessageAction: CaseIterable {
     case forwardAll
     case createThread
     case copyText
+    case shareText
     case saveImage
     case copyImage
     case markUnread
@@ -30,6 +31,7 @@ enum MessageAction: CaseIterable {
         case .forwardAll:       return L(L10n.MessageAction.forwardAll)
         case .createThread:     return L(L10n.MessageAction.createThread)
         case .copyText:         return L(L10n.MessageAction.copyText)
+        case .shareText:        return L(L10n.MessageAction.shareText)
         case .saveImage:        return L(L10n.MessageAction.saveImage)
         case .copyImage:        return L(L10n.MessageAction.copyImage)
         case .markUnread:       return L(L10n.MessageAction.markUnread)
@@ -54,6 +56,7 @@ enum MessageAction: CaseIterable {
         case .forwardAll:       return "Chat/IconForwardAll"
         case .createThread:     return nil
         case .copyText:         return "Chat/IconCopy"
+        case .shareText:        return nil
         case .saveImage:        return nil
         case .copyImage:        return "Chat/IconCopy"
         case .markUnread:       return "Chat/IconMarkUnread"
@@ -74,6 +77,7 @@ enum MessageAction: CaseIterable {
         switch self {
         case .createThread:     return "square.and.pencil"
         case .saveImage:        return "square.and.arrow.down"
+        case .shareText:        return "square.and.arrow.up"
         case .topicDiscussion:  return "text.bubble"
         case .quickMenu:       return "bolt.fill"
         case .unpinMessage:     return "pin.slash"
@@ -96,7 +100,7 @@ enum MessageAction: CaseIterable {
         switch self {
         case .giveACoffee, .reply, .forwardMessage, .forwardAll, .createThread, .resend, .editMessage, .forward:
             return .frequent
-        case .copyText, .saveImage, .copyImage, .markUnread, .topicDiscussion, .pinMessage, .unpinMessage, .markMessage, .quickMenu:
+        case .copyText, .shareText, .saveImage, .copyImage, .markUnread, .topicDiscussion, .pinMessage, .unpinMessage, .markMessage, .quickMenu:
             return .normal
         case .deleteMessage, .report:
             return .warning
@@ -259,6 +263,7 @@ final class MessageActionSheetController: ViewController {
 
         if hasText {
             actions.append(.copyText)
+            actions.append(.shareText)
         }
         if display.singleImageMediaAttachment != nil {
             actions.append(.saveImage)


### PR DESCRIPTION
task: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-443
Root cause: The message menu lacked a Share Text option to share message text with Mezon or other apps.
Solution: Added Share Text on Android and iOS using the system share sheet and existing text-sharing support.
Test cases:
- Verify that Share Text appears for messages containing text.
- Verify that Share Text does not appear for messages containing only images.
- Verify that tapping Share Text opens the system app chooser.
- Verify that sharing to another app sends the message text correctly.
- Verify that selecting Mezon allows sharing the text to a chat.
