### PR TITLE
260908-IOS-Handle invite channel

### DIFF
--- a/MezonChat/Features/ChannelDetail/Tabs/MemberListNode.swift
+++ b/MezonChat/Features/ChannelDetail/Tabs/MemberListNode.swift
@@ -737,19 +737,31 @@ extension MemberListNode: ASTableDataSource, ASTableDelegate {
 
     private func handleHeaderActionTapped(tableNode: ASTableNode) {
         guard let host = tableNode.view.findHostingViewController() else { return }
-        guard channelType == MezonConstants.ChannelType.group.rawValue else { return }
-        let memberSnapshot = currentGroupMemberSnapshot()
-        let vc = NewGroupDMViewController(
-            context: context,
-            existingGroupChannel: channelDescription,
-            existingMemberIds: memberSnapshot.ids,
-            existingMemberCount: memberSnapshot.count,
-            onMembersAdded: { [weak self] updated in
-                let expectedCount: Int? = updated.memberCount > 0 ? Int(updated.memberCount) : nil
-                self?.refreshGroupMembersAfterAdd(expectedMemberCount: expectedCount)
-            }
-        )
-        host.navigationController?.pushViewController(vc, animated: true)
+        if channelType == MezonConstants.ChannelType.group.rawValue {
+            let memberSnapshot = currentGroupMemberSnapshot()
+            let vc = NewGroupDMViewController(
+                context: context,
+                existingGroupChannel: channelDescription,
+                existingMemberIds: memberSnapshot.ids,
+                existingMemberCount: memberSnapshot.count,
+                onMembersAdded: { [weak self] updated in
+                    let expectedCount: Int? = updated.memberCount > 0 ? Int(updated.memberCount) : nil
+                    self?.refreshGroupMembersAfterAdd(expectedMemberCount: expectedCount)
+                }
+            )
+            host.navigationController?.pushViewController(vc, animated: true)
+            return
+        }
+
+        guard clanId != 0, channelType != MezonConstants.ChannelType.dm.rawValue else { return }
+        let vc = ClanInviteSheetViewController(context: context, clanId: clanId, channelId: channelId)
+        vc.modalPresentationStyle = .pageSheet
+        if #available(iOS 15.0, *), let sheet = vc.sheetPresentationController {
+            sheet.prefersGrabberVisible = true
+            sheet.detents = [.medium(), .large()]
+            sheet.selectedDetentIdentifier = .medium
+        }
+        host.present(vc, animated: true)
     }
 
     private func refreshGroupMembersAfterAdd(expectedMemberCount: Int?) {

--- a/MezonChat/Features/Clans/ClanInviteSheetViewController.swift
+++ b/MezonChat/Features/Clans/ClanInviteSheetViewController.swift
@@ -892,6 +892,7 @@ private final class ClanInviteFriendCellNode: ASCellNode {
 }
 
 private final class ClanInviteSheetContainerNode: ASDisplayNode {
+    private let showsQRCode: Bool
     let titleNode = ASTextNode()
     let shareButton: ClanInviteActionButtonNode
     let copyButton: ClanInviteActionButtonNode
@@ -904,7 +905,8 @@ private final class ClanInviteSheetContainerNode: ASDisplayNode {
     let loadingSpinner = UIActivityIndicatorView(style: .medium)
     let loadingLabel = UILabel()
 
-    override init() {
+    init(showsQRCode: Bool) {
+        self.showsQRCode = showsQRCode
         shareButton = ClanInviteActionButtonNode(
             iconAsset: "Invite/ShareIcon",
             fallbackSystemIcon: "square.and.arrow.up",
@@ -922,6 +924,7 @@ private final class ClanInviteSheetContainerNode: ASDisplayNode {
         )
 
         super.init()
+        qrButton.isHidden = !showsQRCode
         automaticallyManagesSubnodes = false
 
         titleNode.isLayerBacked = true
@@ -1022,9 +1025,15 @@ private final class ClanInviteSheetContainerNode: ASDisplayNode {
         let copyW = copySz.width
         let qrW = qrSz.width
 
-        shareButton.frame = CGRect(x: aLead, y: aTop, width: shareW, height: 62.sh)
-        copyButton.frame = CGRect(x: (w - copyW) / 2, y: aTop, width: copyW, height: 62.sh)
-        qrButton.frame = CGRect(x: w - aTrail - qrW, y: aTop, width: qrW, height: 62.sh)
+        if showsQRCode {
+            shareButton.frame = CGRect(x: aLead, y: aTop, width: shareW, height: 62.sh)
+            copyButton.frame = CGRect(x: (w - copyW) / 2, y: aTop, width: copyW, height: 62.sh)
+            qrButton.frame = CGRect(x: w - aTrail - qrW, y: aTop, width: qrW, height: 62.sh)
+        } else {
+            shareButton.frame = CGRect(x: w / 3 - shareW / 2, y: aTop, width: shareW, height: 62.sh)
+            copyButton.frame = CGRect(x: w * 2 / 3 - copyW / 2, y: aTop, width: copyW, height: 62.sh)
+            qrButton.frame = .zero
+        }
         dividerNode.frame = CGRect(
             x: 0,
             y: y + 94.sh - 1 / UIScreen.main.scale,
@@ -1068,6 +1077,7 @@ final class ClanInviteSheetViewController: ViewController {
 
     private let context: AccountContext
     private let clanId: Int64
+    private let channelId: Int64?
     private let nativeModalPresenter = UIViewController()
 
     private var inviteLink: String?
@@ -1083,9 +1093,10 @@ final class ClanInviteSheetViewController: ViewController {
 
     private var containerNode: ClanInviteSheetContainerNode { displayNode as! ClanInviteSheetContainerNode }
 
-    init(context: AccountContext, clanId: Int64) {
+    init(context: AccountContext, clanId: Int64, channelId: Int64? = nil) {
         self.context = context
         self.clanId = clanId
+        self.channelId = channelId
         super.init(navigationBarPresentationData: nil)
     }
 
@@ -1094,7 +1105,7 @@ final class ClanInviteSheetViewController: ViewController {
     }
 
     override func loadDisplayNode() {
-        let node = ClanInviteSheetContainerNode()
+        let node = ClanInviteSheetContainerNode(showsQRCode: channelId == nil)
         displayNode = node
 
         node.shareButton.onTap = { [weak self] in self?.shareInvite() }
@@ -1268,6 +1279,10 @@ final class ClanInviteSheetViewController: ViewController {
     }
 
     private func resolveInviteLink(token: String) async -> String? {
+        if let channelId {
+            return "\(MezonConfig.chatWebAppBaseURL)/chat/clans/\(clanId)/channels/\(channelId)"
+        }
+
         guard let inviteContext = await resolveInviteContext(token: token) else {
             return nil
         }


### PR DESCRIPTION
task: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-452
result:
<img width="402" height="558" alt="image" src="https://github.com/user-attachments/assets/ed266210-9805-464a-b142-01d645ac51d2" />
<img width="402" height="558" alt="image" src="https://github.com/user-attachments/assets/021eb605-46e4-4041-97b6-f7ccac85cb81" />

Root Cause: Invite Members did not open an invite sheet for channels and threads.
Solution: Reuse the clan invite sheet, hide the QR option, and use the correct channel or thread link.
Test Cases:
1. Open Invite Members in a channel and a thread, then verify Share and Copy Link are shown without the QR option.
2. Copy or share the link and verify it opens the correct channel or thread.
3. Verify clan invitations and group chat member invitations still work normally.