### PR TITLE
260909-IOS-Implement create, edit event

### DIFF
--- a/MezonChat/Core/AccountContext/AccountContextImpl.swift
+++ b/MezonChat/Core/AccountContext/AccountContextImpl.swift
@@ -1402,6 +1402,13 @@ final class AccountContextImpl: AccountContext {
         case .userClanRemoved(let ev):
             engine.clanData.applyClanUserRemovedFromSocket(ev)
 
+        case .clanEventCreated(let ev):
+            guard ev.clanID != 0 else { break }
+            Task { @MainActor [weak self] in
+                guard let self, let token = await self.getToken() else { return }
+                await self.engine.clanData.refetchEvents(clanId: ev.clanID, token: token)
+            }
+
         case .clanUpdated(let ev):
             account.postbox.write { tx in
                 guard let existingClan = tx.getClan(id: ev.clanID) else { return }

--- a/MezonChat/Core/AccountContext/AccountContextImpl.swift
+++ b/MezonChat/Core/AccountContext/AccountContextImpl.swift
@@ -1404,10 +1404,7 @@ final class AccountContextImpl: AccountContext {
 
         case .clanEventCreated(let ev):
             guard ev.clanID != 0 else { break }
-            Task { @MainActor [weak self] in
-                guard let self, let token = await self.getToken() else { return }
-                await self.engine.clanData.refetchEvents(clanId: ev.clanID, token: token)
-            }
+            engine.clanData.applyClanEventFromSocket(ev)
 
         case .clanUpdated(let ev):
             account.postbox.write { tx in

--- a/MezonChat/Core/Localization/L10n.swift
+++ b/MezonChat/Core/Localization/L10n.swift
@@ -850,9 +850,75 @@ enum L10n {
         static let unknownClan          = "clan.inviteSheet.unknownClan"
     }
 
+    enum EventEditor {
+        static let create = "eventEditor.create"
+        static let edit = "eventEditor.edit"
+        static let update = "eventEditor.update"
+        static let step = "eventEditor.step"
+        static let location = "eventEditor.location"
+        static let details = "eventEditor.details"
+        static let preview = "eventEditor.preview"
+        static let cancel = "eventEditor.cancel"
+        static let back = "eventEditor.back"
+        static let next = "eventEditor.next"
+        static let close = "eventEditor.close"
+        static let done = "eventEditor.done"
+        static let chooseType = "eventEditor.chooseType"
+        static let chooseTypeSubtitle = "eventEditor.chooseTypeSubtitle"
+        static let voice = "eventEditor.voice"
+        static let voiceSubtitle = "eventEditor.voiceSubtitle"
+        static let elsewhere = "eventEditor.elsewhere"
+        static let elsewhereSubtitle = "eventEditor.elsewhereSubtitle"
+        static let external = "eventEditor.external"
+        static let externalSubtitle = "eventEditor.externalSubtitle"
+        static let address = "eventEditor.address"
+        static let addressPlaceholder = "eventEditor.addressPlaceholder"
+        static let addressError = "eventEditor.addressError"
+        static let announcement = "eventEditor.announcement"
+        static let pickChannel = "eventEditor.pickChannel"
+        static let search = "eventEditor.search"
+        static let noChannels = "eventEditor.noChannels"
+        static let detailsTitle = "eventEditor.detailsTitle"
+        static let detailsSubtitle = "eventEditor.detailsSubtitle"
+        static let name = "eventEditor.name"
+        static let namePlaceholder = "eventEditor.namePlaceholder"
+        static let nameRequired = "eventEditor.nameRequired"
+        static let nameTooLong = "eventEditor.nameTooLong"
+        static let invalidName = "eventEditor.invalidName"
+        static let startDate = "eventEditor.startDate"
+        static let startTime = "eventEditor.startTime"
+        static let endDate = "eventEditor.endDate"
+        static let endTime = "eventEditor.endTime"
+        static let startError = "eventEditor.startError"
+        static let endError = "eventEditor.endError"
+        static let repeatLabel = "eventEditor.repeat"
+        static let repeatNone = "eventEditor.repeatNone"
+        static let repeatWeekly = "eventEditor.repeatWeekly"
+        static let repeatOther = "eventEditor.repeatOther"
+        static let repeatMonthly = "eventEditor.repeatMonthly"
+        static let repeatAnnually = "eventEditor.repeatAnnually"
+        static let repeatWeekday = "eventEditor.repeatWeekday"
+        static let description = "eventEditor.description"
+        static let descriptionPlaceholder = "eventEditor.descriptionPlaceholder"
+        static let cover = "eventEditor.cover"
+        static let addCover = "eventEditor.addCover"
+        static let removeCover = "eventEditor.removeCover"
+        static let coverTooLarge = "eventEditor.coverTooLarge"
+        static let coverFailed = "eventEditor.coverFailed"
+        static let previewTitle = "eventEditor.previewTitle"
+        static let previewVoice = "eventEditor.previewVoice"
+        static let previewLocation = "eventEditor.previewLocation"
+        static let previewExternal = "eventEditor.previewExternal"
+        static let previewEdit = "eventEditor.previewEdit"
+        static let created = "eventEditor.created"
+        static let updated = "eventEditor.updated"
+        static let sessionExpired = "eventEditor.sessionExpired"
+        static let permissionDenied = "eventEditor.permissionDenied"
+    }
+
     enum EventMenu {
-        static let title              = "eventMenu.dashboard.title"
-        static let eventOne           = "eventMenu.dashboard.event_one"
+        static let eventCountOne      = "eventMenu.dashboard.eventCountOne"
+        static let eventCountMany     = "eventMenu.dashboard.eventCountMany"
         static let noEvent            = "eventMenu.dashboard.noEvent"
         static let noEventDescription = "eventMenu.dashboard.noEventDescription"
         static let createButton       = "eventMenu.dashboard.createButton"
@@ -872,6 +938,13 @@ enum L10n {
         static let detailCreatedBy    = "eventMenu.detail.createdBy"
         static let itemInterested     = "eventMenu.item.interested"
         static let itemUninterested   = "eventMenu.item.uninterested"
+        static let actions           = "eventMenu.actions"
+        static let endEvent          = "eventMenu.endEvent"
+        static let deleteEvent       = "eventMenu.deleteEvent"
+        static let deleteTitle       = "eventMenu.deleteTitle"
+        static let deleteMessage     = "eventMenu.deleteMessage"
+        static let deleted           = "eventMenu.deleted"
+        static let openLink          = "eventMenu.openLink"
     }
 
     enum OnboardingClan {
@@ -1712,8 +1785,72 @@ extension L10n {
         "discover.detail.communityVerified": "Weekly events and updates.",
         "discover.detail.dateUnavailable": "—",
 
-        "eventMenu.dashboard.title":              "Events",
-        "eventMenu.dashboard.event_one":          "Event",
+        "eventEditor.create": "Create Event",
+        "eventEditor.edit": "Edit Event",
+        "eventEditor.update": "Update Event",
+        "eventEditor.step": "Step %d of 3",
+        "eventEditor.location": "Location",
+        "eventEditor.details": "Details",
+        "eventEditor.preview": "Preview",
+        "eventEditor.cancel": "Cancel",
+        "eventEditor.back": "Back",
+        "eventEditor.next": "Next",
+        "eventEditor.close": "Close",
+        "eventEditor.done": "Done",
+        "eventEditor.chooseType": "What type of event is this?",
+        "eventEditor.chooseTypeSubtitle": "Choose how members will join your event.",
+        "eventEditor.voice": "Voice Channel",
+        "eventEditor.voiceSubtitle": "Host the event in a voice channel",
+        "eventEditor.elsewhere": "Somewhere else",
+        "eventEditor.elsewhereSubtitle": "Meet at an offline location",
+        "eventEditor.external": "Create External Event",
+        "eventEditor.externalSubtitle": "Users can join the meeting by link without logging in.",
+        "eventEditor.address": "Address",
+        "eventEditor.addressPlaceholder": "Enter event location",
+        "eventEditor.addressError": "Location must be 100 characters or fewer",
+        "eventEditor.announcement": "Announcement channel (optional)",
+        "eventEditor.pickChannel": "Tap to select a channel",
+        "eventEditor.search": "Search",
+        "eventEditor.noChannels": "No channels available",
+        "eventEditor.detailsTitle": "Tell us about your event",
+        "eventEditor.detailsSubtitle": "Add a name, schedule, and optional cover image.",
+        "eventEditor.name": "Event name",
+        "eventEditor.namePlaceholder": "Enter event name",
+        "eventEditor.nameRequired": "Enter an event name",
+        "eventEditor.nameTooLong": "Event name must be %d characters or fewer",
+        "eventEditor.invalidName": "Event name contains invalid characters",
+        "eventEditor.startDate": "Start date",
+        "eventEditor.startTime": "Start time",
+        "eventEditor.endDate": "End date",
+        "eventEditor.endTime": "End time",
+        "eventEditor.startError": "Start time must be in the future",
+        "eventEditor.endError": "End time must be after start time",
+        "eventEditor.repeat": "Repeat",
+        "eventEditor.repeatNone": "Does not repeat",
+        "eventEditor.repeatWeekly": "Weekly on %@",
+        "eventEditor.repeatOther": "Every other %@",
+        "eventEditor.repeatMonthly": "Monthly on the %d %@",
+        "eventEditor.repeatAnnually": "Annually on %@ %d",
+        "eventEditor.repeatWeekday": "Every weekday",
+        "eventEditor.description": "Description",
+        "eventEditor.descriptionPlaceholder": "Describe your event (optional)",
+        "eventEditor.cover": "Cover image",
+        "eventEditor.addCover": "Add cover image (up to 1 MB)",
+        "eventEditor.removeCover": "Remove cover image",
+        "eventEditor.coverTooLarge": "Cover image must be 1 MB or smaller",
+        "eventEditor.coverFailed": "Could not upload cover image",
+        "eventEditor.previewTitle": "Looking good?",
+        "eventEditor.previewVoice": "Members will join via the selected voice channel.",
+        "eventEditor.previewLocation": "Review your event before creating it.",
+        "eventEditor.previewExternal": "Members can join using the meeting link.",
+        "eventEditor.previewEdit": "Review your changes before saving.",
+        "eventEditor.created": "Event created",
+        "eventEditor.updated": "Event updated",
+        "eventEditor.sessionExpired": "Your session has expired. Please sign in again.",
+        "eventEditor.permissionDenied": "You no longer have permission to edit this event.",
+
+        "eventMenu.dashboard.eventCountOne":      "1 Event",
+        "eventMenu.dashboard.eventCountMany":     "%d Events",
         "eventMenu.dashboard.noEvent":            "There are no upcoming events.",
         "eventMenu.dashboard.noEventDescription": "Feel free to invite other members to contribute their ideas for upcoming events.",
         "eventMenu.dashboard.createButton":     "Create",
@@ -1733,6 +1870,13 @@ extension L10n {
         "eventMenu.detail.createdBy":             "Created by ",
         "eventMenu.item.interested":              "Interested",
         "eventMenu.item.uninterested":            "Uninterested",
+        "eventMenu.actions":                      "Event actions",
+        "eventMenu.endEvent":                     "End Event",
+        "eventMenu.deleteEvent":                  "Delete Event",
+        "eventMenu.deleteTitle":                  "Delete event?",
+        "eventMenu.deleteMessage":                "Are you sure you want to delete \"%@\"?",
+        "eventMenu.deleted":                      "Event deleted",
+        "eventMenu.openLink":                     "Open Link",
 
         "clan.action.invite":               "Invite",
         "clan.action.markAsRead":           "Mark as Read",
@@ -2982,8 +3126,72 @@ extension L10n {
         "discover.detail.communityVerified": "Sự kiện và cập nhật hàng tuần.",
         "discover.detail.dateUnavailable": "—",
 
-        "eventMenu.dashboard.title":              "Sự kiện",
-        "eventMenu.dashboard.event_one":          "Sự kiện",
+        "eventEditor.create": "Tạo sự kiện",
+        "eventEditor.edit": "Chỉnh sửa sự kiện",
+        "eventEditor.update": "Cập nhật sự kiện",
+        "eventEditor.step": "Bước %d / 3",
+        "eventEditor.location": "Địa điểm",
+        "eventEditor.details": "Chi tiết",
+        "eventEditor.preview": "Xem trước",
+        "eventEditor.cancel": "Hủy",
+        "eventEditor.back": "Quay lại",
+        "eventEditor.next": "Tiếp theo",
+        "eventEditor.close": "Đóng",
+        "eventEditor.done": "Xong",
+        "eventEditor.chooseType": "Đây là loại sự kiện gì?",
+        "eventEditor.chooseTypeSubtitle": "Chọn cách thành viên tham gia sự kiện.",
+        "eventEditor.voice": "Kênh thoại",
+        "eventEditor.voiceSubtitle": "Tổ chức sự kiện trong kênh thoại",
+        "eventEditor.elsewhere": "Địa điểm khác",
+        "eventEditor.elsewhereSubtitle": "Gặp mặt tại một địa điểm trực tiếp",
+        "eventEditor.external": "Tạo sự kiện bên ngoài",
+        "eventEditor.externalSubtitle": "Người dùng có thể tham gia cuộc họp qua liên kết mà không cần đăng nhập.",
+        "eventEditor.address": "Địa chỉ",
+        "eventEditor.addressPlaceholder": "Nhập địa điểm sự kiện",
+        "eventEditor.addressError": "Địa điểm không được vượt quá 100 ký tự",
+        "eventEditor.announcement": "Kênh thông báo (không bắt buộc)",
+        "eventEditor.pickChannel": "Nhấn để chọn kênh",
+        "eventEditor.search": "Tìm kiếm",
+        "eventEditor.noChannels": "Không có kênh phù hợp",
+        "eventEditor.detailsTitle": "Giới thiệu về sự kiện của bạn",
+        "eventEditor.detailsSubtitle": "Thêm tên, lịch trình và ảnh bìa nếu muốn.",
+        "eventEditor.name": "Tên sự kiện",
+        "eventEditor.namePlaceholder": "Nhập tên sự kiện",
+        "eventEditor.nameRequired": "Vui lòng nhập tên sự kiện",
+        "eventEditor.nameTooLong": "Tên sự kiện không được vượt quá %d ký tự",
+        "eventEditor.invalidName": "Tên sự kiện chứa ký tự không hợp lệ",
+        "eventEditor.startDate": "Ngày bắt đầu",
+        "eventEditor.startTime": "Giờ bắt đầu",
+        "eventEditor.endDate": "Ngày kết thúc",
+        "eventEditor.endTime": "Giờ kết thúc",
+        "eventEditor.startError": "Thời gian bắt đầu phải ở tương lai",
+        "eventEditor.endError": "Thời gian kết thúc phải sau thời gian bắt đầu",
+        "eventEditor.repeat": "Lặp lại",
+        "eventEditor.repeatNone": "Không lặp lại",
+        "eventEditor.repeatWeekly": "Hàng tuần vào %@",
+        "eventEditor.repeatOther": "Cách tuần vào %@",
+        "eventEditor.repeatMonthly": "Hàng tháng vào lần thứ %d của %@",
+        "eventEditor.repeatAnnually": "Hàng năm vào %@ ngày %d",
+        "eventEditor.repeatWeekday": "Mỗi ngày trong tuần",
+        "eventEditor.description": "Mô tả",
+        "eventEditor.descriptionPlaceholder": "Mô tả sự kiện (không bắt buộc)",
+        "eventEditor.cover": "Ảnh bìa",
+        "eventEditor.addCover": "Thêm ảnh bìa (tối đa 1 MB)",
+        "eventEditor.removeCover": "Xóa ảnh bìa",
+        "eventEditor.coverTooLarge": "Ảnh bìa không được vượt quá 1 MB",
+        "eventEditor.coverFailed": "Không thể tải ảnh bìa lên",
+        "eventEditor.previewTitle": "Mọi thứ đã sẵn sàng?",
+        "eventEditor.previewVoice": "Thành viên sẽ tham gia qua kênh thoại đã chọn.",
+        "eventEditor.previewLocation": "Kiểm tra sự kiện trước khi tạo.",
+        "eventEditor.previewExternal": "Thành viên có thể tham gia bằng liên kết cuộc họp.",
+        "eventEditor.previewEdit": "Kiểm tra thay đổi trước khi lưu.",
+        "eventEditor.created": "Đã tạo sự kiện",
+        "eventEditor.updated": "Đã cập nhật sự kiện",
+        "eventEditor.sessionExpired": "Phiên đăng nhập đã hết hạn. Vui lòng đăng nhập lại.",
+        "eventEditor.permissionDenied": "Bạn không còn quyền chỉnh sửa sự kiện này.",
+
+        "eventMenu.dashboard.eventCountOne":      "1 sự kiện",
+        "eventMenu.dashboard.eventCountMany":     "%d sự kiện",
         "eventMenu.dashboard.noEvent":            "Không có sự kiện nào",
         "eventMenu.dashboard.noEventDescription": "Hãy thoải mái mời các thành viên khác tham gia đóng góp ý tưởng cho các sự kiện sắp tới.",
         "eventMenu.dashboard.createButton":     "Tạo",
@@ -3003,6 +3211,13 @@ extension L10n {
         "eventMenu.detail.createdBy":             "Tạo bởi ",
         "eventMenu.item.interested":              "Quan tâm",
         "eventMenu.item.uninterested":            "Bỏ quan tâm",
+        "eventMenu.actions":                      "Thao tác sự kiện",
+        "eventMenu.endEvent":                     "Kết thúc sự kiện",
+        "eventMenu.deleteEvent":                  "Xóa sự kiện",
+        "eventMenu.deleteTitle":                  "Xóa sự kiện?",
+        "eventMenu.deleteMessage":                "Bạn có chắc muốn xóa \"%@\" không?",
+        "eventMenu.deleted":                      "Đã xóa sự kiện",
+        "eventMenu.openLink":                     "Mở liên kết",
 
         "clan.action.invite":               "Mời",
         "clan.action.markAsRead":           "Đánh dấu là đã đọc",

--- a/MezonChat/Core/MezonEngine/MezonEngine+ClanData.swift
+++ b/MezonChat/Core/MezonEngine/MezonEngine+ClanData.swift
@@ -292,8 +292,43 @@ extension MezonEngine {
             }
         }
 
+        func createEvent(draft: EventEditorDraft, clanId: Int64, creatorId: Int64, token: String) async throws {
+            try await network.createEvent(request: draft.createRequest(clanId: clanId, creatorId: creatorId), token: token)
+            await fetchEvents(clanId: clanId, token: token)
+        }
+
+        func updateEvent(draft: EventEditorDraft, clanId: Int64, original: Mezon_Api_EventManagement, token: String) async throws {
+            try await network.updateEvent(request: draft.updateRequest(clanId: clanId, original: original), token: token)
+            // Keep the confirmed edit visible even if the subsequent list refresh fails.
+            if var list = getClanEvents(clanId: clanId), let index = list.events.firstIndex(where: { $0.id == original.id }) {
+                list.events[index] = draft.applying(to: list.events[index])
+                if let data = try? list.serializedData() {
+                    postbox.setPreferenceDataSync(key: PreferencesKeys.clanEvents(clanId: clanId), value: data)
+                }
+                clanEventsUpdated.putNext(clanId)
+            }
+            await fetchEvents(clanId: clanId, token: token)
+        }
+
         func refetchEvents(clanId: Int64, token: String) async {
             await fetchEvents(clanId: clanId, token: token)
+        }
+
+        func deleteEvent(_ event: Mezon_Api_EventManagement, clanId: Int64, token: String) async throws {
+            var request = Mezon_Api_DeleteEventRequest()
+            request.eventID = event.id
+            request.clanID = clanId
+            request.creatorID = event.creatorID
+            request.eventLabel = event.title
+            request.channelID = event.channelID
+            try await network.deleteEvent(request: request, token: token)
+            if var list = getClanEvents(clanId: clanId) {
+                list.events.removeAll { $0.id == event.id }
+                if let data = try? list.serializedData() {
+                    postbox.setPreferenceDataSync(key: PreferencesKeys.clanEvents(clanId: clanId), value: data)
+                }
+            }
+            clanEventsUpdated.putNext(clanId)
         }
 
         func setUserEventInterest(

--- a/MezonChat/Core/MezonEngine/MezonEngine+ClanData.swift
+++ b/MezonChat/Core/MezonEngine/MezonEngine+ClanData.swift
@@ -320,7 +320,6 @@ extension MezonEngine {
 
         func updateEvent(draft: EventEditorDraft, clanId: Int64, original: Mezon_Api_EventManagement, token: String) async throws {
             try await network.updateEvent(request: draft.updateRequest(clanId: clanId, original: original), token: token)
-            // Keep the confirmed edit visible even if the subsequent list refresh fails.
             if var list = getClanEvents(clanId: clanId), let index = list.events.firstIndex(where: { $0.id == original.id }) {
                 list.events[index] = draft.applying(to: list.events[index])
                 if let data = try? list.serializedData() {

--- a/MezonChat/Core/MezonEngine/MezonEngine+ClanData.swift
+++ b/MezonChat/Core/MezonEngine/MezonEngine+ClanData.swift
@@ -103,6 +103,20 @@ enum EStateFriend: Int32 {
     case block = 3
 }
 
+private enum ClanEventSocketAction {
+    static let created: Int32 = 1
+    static let update: Int32 = 2
+    static let delete: Int32 = 3
+    static let interested: Int32 = 4
+    static let uninterested: Int32 = 5
+}
+
+private enum ClanEventSocketStatus {
+    static let upcoming: Int32 = 1
+    static let ongoing: Int32 = 2
+    static let completed: Int32 = 3
+}
+
 extension MezonEngine {
 
     @MainActor
@@ -121,6 +135,8 @@ extension MezonEngine {
         let clanNotificationUpdated = ValuePipe<Int64>()
 
         private var inflightFetchAllByClanId: [Int64: Task<Void, Never>] = [:]
+        private var inflightEventFetchByClanId: [Int64: Task<Void, Never>] = [:]
+        private var pendingSocketEventsByClanId: [Int64: [Mezon_Api_CreateEventRequest]] = [:]
         private var lastFetchAllAtByClanId: [Int64: Date] = [:]
         private let clanDataCacheTTL: TimeInterval = 300
         private var inflightForceRefreshClanUsersByClanId: [Int64: Task<Void, Never>] = [:]
@@ -139,6 +155,11 @@ extension MezonEngine {
             }
             inflightFetchAllByClanId.removeAll()
             lastFetchAllAtByClanId.removeAll()
+            for (_, task) in inflightEventFetchByClanId {
+                task.cancel()
+            }
+            inflightEventFetchByClanId.removeAll()
+            pendingSocketEventsByClanId.removeAll()
             for (_, task) in inflightForceRefreshClanUsersByClanId {
                 task.cancel()
             }
@@ -314,6 +335,18 @@ extension MezonEngine {
             await fetchEvents(clanId: clanId, token: token)
         }
 
+        func applyClanEventFromSocket(_ update: Mezon_Api_CreateEventRequest) {
+            let clanId = update.clanID
+            guard clanId != 0, update.eventID != 0 else { return }
+            if inflightEventFetchByClanId[clanId] != nil {
+                pendingSocketEventsByClanId[clanId, default: []].append(update)
+            }
+            var list = getClanEvents(clanId: clanId) ?? Mezon_Api_EventList()
+            guard applySocketEvent(update, to: &list) else { return }
+            persistEvents(list, clanId: clanId)
+            clanEventsUpdated.putNext(clanId)
+        }
+
         func deleteEvent(_ event: Mezon_Api_EventManagement, clanId: Int64, token: String) async throws {
             var request = Mezon_Api_DeleteEventRequest()
             request.eventID = event.id
@@ -383,14 +416,132 @@ extension MezonEngine {
         }
 
         private func fetchEvents(clanId: Int64, token: String) async {
+            if let existing = inflightEventFetchByClanId[clanId] {
+                await existing.value
+                return
+            }
+            let task = Task<Void, Never> { @MainActor [weak self] in
+                guard let self else { return }
+                await self.performFetchEvents(clanId: clanId, token: token)
+            }
+            inflightEventFetchByClanId[clanId] = task
+            await task.value
+            inflightEventFetchByClanId[clanId] = nil
+            pendingSocketEventsByClanId[clanId] = nil
+        }
+
+        private func performFetchEvents(clanId: Int64, token: String) async {
             do {
-                let response = try await network.listEvents(clanId: clanId, token: token)
-                if let data = try? response.serializedData() {
-                    postbox.setPreferenceDataSync(key: PreferencesKeys.clanEvents(clanId: clanId), value: data)
+                var response = try await network.listEvents(clanId: clanId, token: token)
+                for update in pendingSocketEventsByClanId.removeValue(forKey: clanId) ?? [] {
+                    _ = applySocketEvent(update, to: &response)
                 }
+                persistEvents(response, clanId: clanId)
                 clanEventsUpdated.putNext(clanId)
             } catch {
             }
+        }
+
+        private func persistEvents(_ list: Mezon_Api_EventList, clanId: Int64) {
+            guard let data = try? list.serializedData() else { return }
+            postbox.setPreferenceDataSync(key: PreferencesKeys.clanEvents(clanId: clanId), value: data)
+        }
+
+        private func applySocketEvent(
+            _ update: Mezon_Api_CreateEventRequest,
+            to list: inout Mezon_Api_EventList
+        ) -> Bool {
+            let index = list.events.firstIndex { $0.id == update.eventID }
+            let existing = index.map { list.events[$0] }
+
+            if update.action == ClanEventSocketAction.created {
+                guard existing == nil else { return false }
+                list.events.append(eventFromSocket(update))
+                return true
+            }
+
+            if update.eventStatus == ClanEventSocketStatus.upcoming ||
+                update.eventStatus == ClanEventSocketStatus.ongoing {
+                guard var event = existing, let index else { return false }
+                event.eventStatus = update.eventStatus
+                list.events[index] = event
+                return true
+            }
+
+            if update.eventStatus == ClanEventSocketStatus.completed &&
+                update.repeatType != EventRepeatType.doesNotRepeat {
+                guard var event = existing, let index else { return false }
+                event.eventStatus = update.eventStatus
+                event.startTimeSeconds = update.startTimeSeconds
+                list.events[index] = event
+                return true
+            }
+
+            if update.action == ClanEventSocketAction.update {
+                let event = eventFromSocket(update, preserving: existing)
+                if let index {
+                    list.events[index] = event
+                } else {
+                    list.events.append(event)
+                }
+                return true
+            }
+
+            if (update.eventStatus == ClanEventSocketStatus.completed &&
+                    update.repeatType == EventRepeatType.doesNotRepeat) ||
+                update.action == ClanEventSocketAction.delete {
+                guard let index else { return false }
+                list.events.remove(at: index)
+                return true
+            }
+
+            if update.action == ClanEventSocketAction.interested ||
+                update.action == ClanEventSocketAction.uninterested {
+                guard var event = existing, let index, update.userID != 0 else { return false }
+                var userIds = event.userIds.filter { $0 != 0 }
+                if update.action == ClanEventSocketAction.interested {
+                    guard !userIds.contains(update.userID) else { return false }
+                    userIds.append(update.userID)
+                } else {
+                    guard userIds.contains(update.userID) else { return false }
+                    userIds.removeAll { $0 == update.userID }
+                }
+                event.userIds = userIds
+                list.events[index] = event
+                return true
+            }
+
+            return false
+        }
+
+        private func eventFromSocket(
+            _ update: Mezon_Api_CreateEventRequest,
+            preserving existing: Mezon_Api_EventManagement? = nil
+        ) -> Mezon_Api_EventManagement {
+            var event = existing ?? Mezon_Api_EventManagement()
+            event.id = update.eventID
+            event.title = update.title
+            event.logo = update.logo
+            event.description_p = update.description_p
+            event.clanID = update.clanID
+            event.channelVoiceID = update.channelVoiceID
+            event.address = update.address
+            event.startTimeSeconds = update.startTimeSeconds
+            event.endTimeSeconds = update.endTimeSeconds
+            event.channelID = update.channelID
+            event.repeatType = update.repeatType
+            event.isPrivate = update.isPrivate
+            if update.creatorID != 0 {
+                event.creatorID = update.creatorID
+            }
+            if update.hasMeetRoom {
+                event.meetRoom = update.meetRoom
+            }
+            if existing == nil {
+                event.eventStatus = update.eventStatus
+                event.userIds = update.creatorID == 0 ? [] : [update.creatorID]
+            }
+            return event
         }
 
         private func fetchUserPermissions(clanId: Int64, token: String) async {

--- a/MezonChat/Features/ChannelList/Event/EventDetailBottomSheetViewController.swift
+++ b/MezonChat/Features/ChannelList/Event/EventDetailBottomSheetViewController.swift
@@ -1,5 +1,37 @@
 import UIKit
 
+@MainActor
+enum EventDeleteConfirmation {
+    static func present(event: Mezon_Api_EventManagement, clanId: Int64, context: AccountContext, from presenter: UIViewController, onDeleted: (() -> Void)? = nil) {
+        guard EventEditorAccess.canEdit(event, context: context) else { return }
+        let alert = UIAlertController(title: L(L10n.EventMenu.deleteTitle), message: L(L10n.EventMenu.deleteMessage, event.title), preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: L(L10n.Common.cancel), style: .cancel))
+        alert.addAction(UIAlertAction(title: L(L10n.EventMenu.deleteEvent), style: .destructive) { [weak presenter] _ in
+            guard let presenter, EventEditorAccess.canEdit(event, context: context) else { return }
+            presenter.view.isUserInteractionEnabled = false
+            presenter.isModalInPresentation = true
+            Task { @MainActor in
+                defer {
+                    presenter.view.isUserInteractionEnabled = true
+                    presenter.isModalInPresentation = false
+                }
+                guard let token = await context.getToken() else {
+                    Toast.error(L(L10n.EventEditor.sessionExpired))
+                    return
+                }
+                do {
+                    try await context.engine.clanData.deleteEvent(event, clanId: clanId, token: token)
+                    Toast.success(L(L10n.EventMenu.deleted))
+                    onDeleted?()
+                } catch {
+                    Toast.error(error.localizedDescription)
+                }
+            }
+        })
+        presenter.present(alert, animated: true)
+    }
+}
+
 final class EventDetailBottomSheetViewController: UIViewController {
 
     private let context: AccountContext
@@ -15,6 +47,7 @@ final class EventDetailBottomSheetViewController: UIViewController {
     private let scrollView = UIScrollView()
     private let contentStack = UIStackView()
     private let interestButton = UIButton(type: .custom)
+    private var eventsDisposable: Disposable?
 
     init(
         context: AccountContext,
@@ -46,6 +79,20 @@ final class EventDetailBottomSheetViewController: UIViewController {
         buildContent()
         applyTheme()
         showTab(0)
+        eventsDisposable = context.engine.clanData.clanEventsUpdated.signal().start(next: { [weak self] updatedClanId in
+            guard let self, updatedClanId == self.clanId else { return }
+            DispatchQueue.main.async { [weak self] in
+                guard let self,
+                      let events = self.context.engine.clanData.getClanEvents(clanId: self.clanId)?.events else { return }
+                guard let updated = events.first(where: { $0.id == self.event.id }) else {
+                    self.dismissDetail()
+                    return
+                }
+                self.event = updated
+                self.updateInterestedSegmentTitle()
+                self.rebuildContent()
+            }
+        })
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(themeDidChange),
@@ -55,6 +102,7 @@ final class EventDetailBottomSheetViewController: UIViewController {
     }
 
     deinit {
+        eventsDisposable?.dispose()
         NotificationCenter.default.removeObserver(self)
     }
 
@@ -149,6 +197,83 @@ final class EventDetailBottomSheetViewController: UIViewController {
         }
     }
 
+    private func editEvent() {
+        guard EventEditorAccess.canEdit(event, context: context) else { return }
+        let editor = EventEditorViewController(context: context, clanId: clanId, channels: channels, event: event)
+        editor.onSaved = { [weak self] updated in
+            guard let self, let updated else { return }
+            self.event = updated
+            self.updateInterestedSegmentTitle()
+            self.rebuildContent()
+        }
+        present(editor, animated: true)
+    }
+
+    private var eventURL: URL? {
+        if event.isPrivate {
+            return MezonConfig.externalEventURL(event.meetRoom.externalLink)
+        }
+        let channelId = event.channelVoiceID != 0 ? event.channelVoiceID : event.channelID
+        return MezonConfig.eventShareURL(clanId: clanId, channelId: channelId)
+    }
+
+    private func showEventActions(from source: UIView) {
+        let menu = UIAlertController(title: event.title, message: nil, preferredStyle: .actionSheet)
+        if EventEditorAccess.canEdit(event, context: context) {
+            menu.addAction(UIAlertAction(title: L(L10n.EventEditor.edit), style: .default) { [weak self] _ in
+                self?.editEvent()
+            })
+            menu.addAction(UIAlertAction(title: L(L10n.EventMenu.deleteEvent), style: .destructive) { [weak self] _ in
+                self?.confirmDeleteEvent()
+            })
+        }
+        if eventURL != nil {
+            menu.addAction(UIAlertAction(title: L(L10n.ClanInviteSheet.copy), style: .default) { [weak self] _ in
+                self?.copyEventLink()
+            })
+        }
+        menu.addAction(UIAlertAction(title: L(L10n.Common.cancel), style: .cancel))
+        menu.popoverPresentationController?.sourceView = source
+        menu.popoverPresentationController?.sourceRect = source.bounds
+        present(menu, animated: true)
+    }
+
+    private func confirmDeleteEvent() {
+        EventDeleteConfirmation.present(event: event, clanId: clanId, context: context, from: self) { [weak self] in
+            self?.dismissDetail()
+        }
+    }
+
+    private func dismissDetail() {
+        guard !isBeingDismissed else { return }
+        presentingViewController?.dismiss(animated: true)
+    }
+
+    private func copyEventLink() {
+        guard let url = eventURL else { return }
+        UIPasteboard.general.string = url.absoluteString
+        Toast.success(L(L10n.ClanInviteSheet.linkCopied))
+    }
+
+    private func shareEvent(from source: UIView) {
+        guard let url = eventURL else { return }
+        let share = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        share.popoverPresentationController?.sourceView = source
+        share.popoverPresentationController?.sourceRect = source.bounds
+        present(share, animated: true)
+    }
+
+    private func inviteToEvent() {
+        guard event.isPrivate, let url = eventURL else { return }
+        let invite = ClanInviteSheetViewController(context: context, clanId: clanId, externalEventURL: url)
+        invite.modalPresentationStyle = .pageSheet
+        if #available(iOS 15.0, *) {
+            invite.sheetPresentationController?.prefersGrabberVisible = true
+            invite.sheetPresentationController?.detents = [.medium(), .large()]
+        }
+        present(invite, animated: true)
+    }
+
     private func rebuildContent() {
         showTab(segmentedControl.selectedSegmentIndex)
     }
@@ -178,6 +303,20 @@ final class EventDetailBottomSheetViewController: UIViewController {
             stack.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
             stack.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor),
         ])
+
+        let more = EventEditorButton()
+        more.setImage(UIImage(systemName: "ellipsis"), for: .normal)
+        more.tintColor = UIColor.theme.textStrong
+        more.accessibilityLabel = L(L10n.EventMenu.actions)
+        more.widthAnchor.constraint(equalToConstant: 44).isActive = true
+        more.heightAnchor.constraint(equalToConstant: 44).isActive = true
+        more.action = { [weak self, weak more] in
+            guard let more else { return }
+            self?.showEventActions(from: more)
+        }
+        let menuRow = UIStackView(arrangedSubviews: [UIView(), more])
+        stack.addArrangedSubview(menuRow)
+        menuRow.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
 
         if !event.logo.isEmpty {
             let cover = UIImageView()
@@ -233,6 +372,23 @@ final class EventDetailBottomSheetViewController: UIViewController {
         let actionsRow = makeActionsRow()
         stack.addArrangedSubview(actionsRow)
         actionsRow.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+
+        if event.isPrivate, eventURL != nil {
+            let externalActions = UIStackView()
+            externalActions.spacing = 8
+            externalActions.distribution = .fillEqually
+            externalActions.addArrangedSubview(actionButton(L(L10n.EventMenu.openLink), symbol: "arrow.up.right.square") { [weak self] in
+                self?.handleVoiceJoin()
+            })
+            externalActions.addArrangedSubview(actionButton(L(L10n.ClanInviteSheet.invite), symbol: "person.badge.plus") { [weak self] in
+                self?.inviteToEvent()
+            })
+            externalActions.addArrangedSubview(actionButton(L(L10n.ClanInviteSheet.copy), symbol: "link") { [weak self] in
+                self?.copyEventLink()
+            })
+            stack.addArrangedSubview(externalActions)
+            externalActions.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+        }
 
         if event.channelID != 0, let channel = channels.first(where: { $0.channelID == event.channelID }) {
             let audienceRow = makeChannelAudienceRow(channelLabel: channel.channelLabel)
@@ -343,17 +499,20 @@ final class EventDetailBottomSheetViewController: UIViewController {
         row.axis = .horizontal
         row.spacing = 8
         row.alignment = .center
-        let avatar = UIImageView()
-        avatar.layer.cornerRadius = 9
-        avatar.clipsToBounds = true
-        avatar.contentMode = .scaleAspectFill
+        let avatar = TextAvatarView(username: clanName, size: 18)
         avatar.translatesAutoresizingMaskIntoConstraints = false
         avatar.widthAnchor.constraint(equalToConstant: 18).isActive = true
         avatar.heightAnchor.constraint(equalToConstant: 18).isActive = true
         if !clanLogoURL.isEmpty {
+            let imageView = UIImageView(frame: avatar.bounds)
+            imageView.contentMode = .scaleAspectFill
+            avatar.addSubview(imageView)
             let proxied = ImgproxyURL.avatarProxyURL(from: clanLogoURL, width: 36, height: 36)
-            ImageCache.shared.loadImage(urlString: proxied) { image in
-                avatar.image = image
+            ImageCache.shared.loadImage(urlString: proxied) { [weak avatar, weak imageView] image in
+                if let image {
+                    imageView?.image = image
+                    avatar?.showImageMode()
+                }
             }
         }
         let label = UILabel()
@@ -424,8 +583,7 @@ final class EventDetailBottomSheetViewController: UIViewController {
             onPresentJoinVoice?(voiceChannel)
             return
         }
-        if event.hasMeetRoom, !event.meetRoom.externalLink.isEmpty,
-           let url = URL(string: event.meetRoom.externalLink) {
+        if let url = MezonConfig.externalEventURL(event.meetRoom.externalLink) {
             UIApplication.shared.open(url)
         }
     }
@@ -458,12 +616,49 @@ final class EventDetailBottomSheetViewController: UIViewController {
         let row = UIStackView()
         row.axis = .horizontal
         row.spacing = 8
-        row.alignment = .center
-        EventDisplayHelper.configureInterestButton(interestButton, isInterested: isCurrentUserInterested())
-        interestButton.removeTarget(self, action: #selector(interestedTapped), for: .touchUpInside)
-        interestButton.addTarget(self, action: #selector(interestedTapped), for: .touchUpInside)
-        row.addArrangedSubview(interestButton)
+        row.alignment = .fill
+        row.distribution = .fillEqually
+        if event.address.isEmpty, eventURL != nil {
+            let share = actionButton(L(L10n.Common.share), symbol: "square.and.arrow.up")
+            share.action = { [weak self, weak share] in
+                guard let share else { return }
+                self?.shareEvent(from: share)
+            }
+            row.addArrangedSubview(share)
+        }
+        if EventDisplayHelper.resolvedStatus(for: event) != .ongoing {
+            EventDisplayHelper.configureInterestButton(interestButton, isInterested: isCurrentUserInterested())
+            interestButton.removeTarget(self, action: #selector(interestedTapped), for: .touchUpInside)
+            interestButton.addTarget(self, action: #selector(interestedTapped), for: .touchUpInside)
+            row.addArrangedSubview(interestButton)
+        } else if EventEditorAccess.canEnd(event, context: context) {
+            row.addArrangedSubview(actionButton(L(L10n.EventMenu.endEvent), symbol: "xmark.circle") { [weak self] in
+                guard let self, EventEditorAccess.canEnd(self.event, context: self.context) else { return }
+                self.confirmDeleteEvent()
+            })
+        }
+        row.isHidden = row.arrangedSubviews.isEmpty
         return row
+    }
+
+    private func actionButton(_ title: String, symbol: String, action: (() -> Void)? = nil) -> EventEditorButton {
+        let button = EventEditorButton()
+        button.setTitle(title, for: .normal)
+        button.setImage(UIImage(systemName: symbol, withConfiguration: UIImage.SymbolConfiguration(pointSize: 13)), for: .normal)
+        button.tintColor = UIColor.theme.textStrong
+        button.setTitleColor(UIColor.theme.textStrong, for: .normal)
+        button.backgroundColor = UIColor.theme.secondary
+        button.layer.cornerRadius = 8
+        button.layer.borderWidth = 1
+        button.layer.borderColor = UIColor.theme.border.withAlphaComponent(0.4).cgColor
+        button.titleLabel?.font = .systemFont(ofSize: 13, weight: .medium)
+        button.titleLabel?.numberOfLines = 2
+        button.titleLabel?.textAlignment = .center
+        button.contentEdgeInsets = UIEdgeInsets(top: 10, left: 6, bottom: 10, right: 6)
+        button.imageEdgeInsets = UIEdgeInsets(top: 0, left: -3, bottom: 0, right: 3)
+        button.heightAnchor.constraint(greaterThanOrEqualToConstant: 44).isActive = true
+        button.action = action
+        return button
     }
 
     @objc private func interestedTapped() {

--- a/MezonChat/Features/ChannelList/Event/EventEditorAccess.swift
+++ b/MezonChat/Features/ChannelList/Event/EventEditorAccess.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+enum EventEditorAccess {
+    @MainActor
+    static func canEdit(_ event: Mezon_Api_EventManagement, context: AccountContext) -> Bool {
+        let userId = Int64(context.currentUser?.id ?? context.account.id) ?? 0
+        return (userId != 0 && userId == event.creatorID) ||
+            context.rolePermissions.hasClanPermission(.clanOwner, clanId: event.clanID) ||
+            context.rolePermissions.hasClanPermission(.manageClan, clanId: event.clanID) ||
+            context.rolePermissions.hasClanPermission(.administrator, clanId: event.clanID)
+    }
+
+    @MainActor
+    static func canEnd(_ event: Mezon_Api_EventManagement, context: AccountContext) -> Bool {
+        EventDisplayHelper.resolvedStatus(for: event) == .ongoing &&
+            context.rolePermissions.hasClanPermission(.clanOwner, clanId: event.clanID)
+    }
+
+    static func voiceChannels(_ channels: [Mezon_Api_ChannelDescription]) -> [Mezon_Api_ChannelDescription] {
+        channels.filter { $0.type == MezonConstants.ChannelType.mezonVoice.rawValue }
+    }
+
+    static func announcementChannels(_ channels: [Mezon_Api_ChannelDescription]) -> [Mezon_Api_ChannelDescription] {
+        channels.filter {
+            $0.channelPrivate != 0 && ($0.type == MezonConstants.ChannelType.channel.rawValue || $0.type == MezonConstants.ChannelType.thread.rawValue)
+        }
+    }
+}

--- a/MezonChat/Features/ChannelList/Event/EventEditorComponents.swift
+++ b/MezonChat/Features/ChannelList/Event/EventEditorComponents.swift
@@ -1,0 +1,312 @@
+import UIKit
+
+enum EventEditorPalette {
+    static var surface: UIColor { UIColor.theme.secondaryLight }
+    static var field: UIColor { UIColor.theme.tertiary }
+    static var border: UIColor { UIColor.theme.textDisabled.withAlphaComponent(0.45) }
+}
+
+final class EventEditorButton: UIButton {
+    var action: (() -> Void)?
+    init() {
+        super.init(frame: .zero)
+        addTarget(self, action: #selector(tapped), for: .touchUpInside)
+    }
+    required init?(coder: NSCoder) { fatalError() }
+    @objc private func tapped() { action?() }
+}
+
+final class EventEditorFieldButton: UIControl {
+    let valueLabel = UILabel()
+    let captionLabel = UILabel()
+    var action: (() -> Void)?
+    init(caption: String) {
+        super.init(frame: .zero)
+        backgroundColor = EventEditorPalette.field
+        layer.cornerRadius = 12
+        layer.borderWidth = 1
+        layer.borderColor = EventEditorPalette.border.cgColor
+        captionLabel.text = caption
+        captionLabel.font = .systemFont(ofSize: 12)
+        captionLabel.textColor = UIColor.theme.text
+        captionLabel.numberOfLines = 0
+        valueLabel.font = .systemFont(ofSize: 14)
+        valueLabel.textColor = UIColor.theme.textStrong
+        valueLabel.numberOfLines = 2
+        let chevron = UIImageView(image: UIImage(systemName: "chevron.right"))
+        chevron.tintColor = UIColor.theme.textDisabled
+        chevron.contentMode = .scaleAspectFit
+        chevron.widthAnchor.constraint(equalToConstant: 10).isActive = true
+        let row = UIStackView(arrangedSubviews: [valueLabel, chevron])
+        row.spacing = 8
+        let stack = UIStackView(arrangedSubviews: [captionLabel, row])
+        stack.axis = .vertical
+        stack.spacing = 8
+        stack.isUserInteractionEnabled = false
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: topAnchor, constant: 12),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12),
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
+            heightAnchor.constraint(greaterThanOrEqualToConstant: 64)
+        ])
+        addTarget(self, action: #selector(tapped), for: .touchUpInside)
+        isAccessibilityElement = true
+        accessibilityTraits = .button
+        accessibilityLabel = caption
+    }
+    required init?(coder: NSCoder) { fatalError() }
+    @objc private func tapped() { action?() }
+    func setValue(_ value: String) {
+        valueLabel.text = value
+        accessibilityValue = value
+    }
+}
+
+final class EventEditorChoiceViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
+    struct Choice {
+        let id: Int64
+        let title: String
+        let icon: String?
+    }
+    private let choices: [Choice]
+    private var filtered: [Choice]
+    private let selectedId: Int64?
+    private let onSelect: (Int64) -> Void
+    private let allowsSearch: Bool
+    private let table = UITableView(frame: .zero, style: .plain)
+    private let searchContainer = UIView()
+    private let searchField = UITextField()
+    private var searchWorkItem: DispatchWorkItem?
+
+    init(title: String, choices: [Choice], selectedId: Int64?, allowsSearch: Bool = true, onSelect: @escaping (Int64) -> Void) {
+        self.choices = choices
+        self.filtered = choices
+        self.selectedId = selectedId
+        self.allowsSearch = allowsSearch
+        self.onSelect = onSelect
+        super.init(nibName: nil, bundle: nil)
+        self.title = title
+        modalPresentationStyle = .pageSheet
+    }
+    required init?(coder: NSCoder) { fatalError() }
+
+    deinit { searchWorkItem?.cancel() }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = EventEditorPalette.surface
+        if #available(iOS 15.0, *) {
+            sheetPresentationController?.detents = [.medium(), .large()]
+        }
+        let titleLabel = UILabel()
+        titleLabel.text = title
+        titleLabel.font = .systemFont(ofSize: 20, weight: .bold)
+        titleLabel.textColor = UIColor.theme.textStrong
+        titleLabel.numberOfLines = 0
+        let close = EventEditorButton()
+        close.setImage(UIImage(systemName: "xmark"), for: .normal)
+        close.tintColor = UIColor.theme.text
+        close.accessibilityLabel = L(L10n.EventEditor.close)
+        close.widthAnchor.constraint(equalToConstant: 44).isActive = true
+        close.heightAnchor.constraint(equalToConstant: 44).isActive = true
+        close.action = { [weak self] in self?.dismiss(animated: true) }
+        let header = UIStackView(arrangedSubviews: [titleLabel, close])
+        header.alignment = .center
+        searchContainer.backgroundColor = EventEditorPalette.field
+        searchContainer.layer.cornerRadius = 12
+        searchContainer.layer.borderWidth = 1
+        searchContainer.layer.borderColor = EventEditorPalette.border.cgColor
+        searchContainer.isHidden = !allowsSearch
+
+        let searchIcon = UIImageView(image: UIImage(systemName: "magnifyingglass"))
+        searchIcon.tintColor = UIColor.theme.text
+        searchIcon.contentMode = .scaleAspectFit
+        searchIcon.translatesAutoresizingMaskIntoConstraints = false
+
+        searchField.font = .systemFont(ofSize: 16)
+        searchField.textColor = UIColor.theme.textStrong
+        searchField.tintColor = UIColor.theme.textStrong
+        searchField.attributedPlaceholder = NSAttributedString(
+            string: L(L10n.EventEditor.search),
+            attributes: [.foregroundColor: UIColor.theme.text]
+        )
+        searchField.returnKeyType = .search
+        searchField.autocorrectionType = .no
+        searchField.autocapitalizationType = .none
+        searchField.clearButtonMode = .whileEditing
+        searchField.addTarget(self, action: #selector(searchTextChanged), for: .editingChanged)
+        searchField.translatesAutoresizingMaskIntoConstraints = false
+
+        searchContainer.addSubview(searchIcon)
+        searchContainer.addSubview(searchField)
+        NSLayoutConstraint.activate([
+            searchContainer.heightAnchor.constraint(equalToConstant: 48),
+            searchIcon.leadingAnchor.constraint(equalTo: searchContainer.leadingAnchor, constant: 14),
+            searchIcon.centerYAnchor.constraint(equalTo: searchContainer.centerYAnchor),
+            searchIcon.widthAnchor.constraint(equalToConstant: 22),
+            searchIcon.heightAnchor.constraint(equalToConstant: 22),
+            searchField.leadingAnchor.constraint(equalTo: searchIcon.trailingAnchor, constant: 10),
+            searchField.trailingAnchor.constraint(equalTo: searchContainer.trailingAnchor, constant: -14),
+            searchField.topAnchor.constraint(equalTo: searchContainer.topAnchor),
+            searchField.bottomAnchor.constraint(equalTo: searchContainer.bottomAnchor)
+        ])
+
+        let stack = UIStackView(arrangedSubviews: [header, searchContainer, table])
+        stack.axis = .vertical
+        stack.spacing = 12
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            stack.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+            stack.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 24),
+            stack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+        table.backgroundColor = .clear
+        table.separatorStyle = .none
+        table.dataSource = self
+        table.delegate = self
+        table.keyboardDismissMode = .onDrag
+        table.rowHeight = UITableView.automaticDimension
+        table.estimatedRowHeight = 60
+        updateEmptyState()
+    }
+    func numberOfSections(in tableView: UITableView) -> Int { filtered.count }
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int { 1 }
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat { 8 }
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? { UIView() }
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let choice = filtered[indexPath.section]
+        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
+        let selected = choice.id == selectedId
+        cell.backgroundColor = EventEditorPalette.field
+        cell.selectionStyle = .none
+        cell.layer.cornerRadius = 12
+        cell.layer.borderWidth = selected ? 1 : 0
+        cell.layer.borderColor = selected ? UIColor.theme.bgViolet.cgColor : UIColor.clear.cgColor
+        let title = UILabel()
+        title.text = choice.title
+        title.font = .systemFont(ofSize: 16)
+        title.textColor = UIColor.theme.textStrong
+        title.numberOfLines = allowsSearch ? 1 : 0
+        title.lineBreakMode = allowsSearch ? .byTruncatingTail : .byWordWrapping
+        title.setContentCompressionResistancePriority(.required, for: .vertical)
+        let row = UIStackView()
+        row.alignment = .center
+        row.spacing = 12
+        if let iconName = choice.icon {
+            let image = UIImage(named: iconName) ?? UIImage(systemName: iconName)
+            let icon = UIImageView(image: image?.withRenderingMode(.alwaysTemplate))
+            icon.tintColor = UIColor.theme.textStrong
+            icon.contentMode = .scaleAspectFit
+            icon.widthAnchor.constraint(equalToConstant: 24).isActive = true
+            icon.heightAnchor.constraint(equalToConstant: 24).isActive = true
+            row.addArrangedSubview(icon)
+        }
+        row.addArrangedSubview(title)
+        if selected {
+            cell.accessibilityTraits.insert(.selected)
+        }
+        row.translatesAutoresizingMaskIntoConstraints = false
+        cell.contentView.addSubview(row)
+        NSLayoutConstraint.activate([
+            row.topAnchor.constraint(equalTo: cell.contentView.topAnchor, constant: 16),
+            row.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor, constant: -16),
+            row.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor, constant: 14),
+            row.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor, constant: -14),
+            row.heightAnchor.constraint(greaterThanOrEqualToConstant: 24)
+        ])
+        cell.accessibilityLabel = choice.title
+        return cell
+    }
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let id = filtered[indexPath.section].id
+        dismiss(animated: true) { [onSelect] in onSelect(id) }
+    }
+    @objc private func searchTextChanged() {
+        searchWorkItem?.cancel()
+        let searchText = searchField.text ?? ""
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.filtered = searchText.isEmpty ? self.choices : self.choices.filter { $0.title.localizedStandardContains(searchText) }
+            self.table.reloadData()
+            self.updateEmptyState()
+        }
+        searchWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: work)
+    }
+    private func updateEmptyState() {
+        let label = UILabel()
+        label.text = L(L10n.EventEditor.noChannels)
+        label.textColor = UIColor.theme.textDisabled
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        table.backgroundView = filtered.isEmpty ? label : nil
+    }
+}
+
+final class EventEditorDateViewController: UIViewController {
+    private let picker = UIDatePicker()
+    private let date: Date
+    private let mode: UIDatePicker.Mode
+    private let minimum: Date?
+    private let onSelect: (Date) -> Void
+    init(title: String, date: Date, mode: UIDatePicker.Mode, minimum: Date?, onSelect: @escaping (Date) -> Void) {
+        self.date = date
+        self.mode = mode
+        self.minimum = minimum
+        self.onSelect = onSelect
+        super.init(nibName: nil, bundle: nil)
+        self.title = title
+        modalPresentationStyle = .pageSheet
+    }
+    required init?(coder: NSCoder) { fatalError() }
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = EventEditorPalette.surface
+        if #available(iOS 15.0, *) {
+            sheetPresentationController?.detents = [.medium()]
+        }
+        let titleLabel = UILabel()
+        titleLabel.text = title
+        titleLabel.textColor = UIColor.theme.textStrong
+        titleLabel.font = .systemFont(ofSize: 18, weight: .bold)
+        titleLabel.numberOfLines = 0
+        let done = EventEditorButton()
+        done.setTitle(L(L10n.EventEditor.done), for: .normal)
+        done.setTitleColor(UIColor(red: 0.39, green: 0.38, blue: 0.91, alpha: 1), for: .normal)
+        done.widthAnchor.constraint(greaterThanOrEqualToConstant: 60).isActive = true
+        done.heightAnchor.constraint(equalToConstant: 44).isActive = true
+        done.action = { [weak self] in
+            guard let self else { return }
+            let value = self.picker.date
+            self.dismiss(animated: true) { [onSelect = self.onSelect] in onSelect(value) }
+        }
+        let header = UIStackView(arrangedSubviews: [titleLabel, done])
+        header.alignment = .center
+        picker.datePickerMode = mode
+        picker.locale = LanguageManager.shared.current.locale
+        if #available(iOS 13.4, *) { picker.preferredDatePickerStyle = .wheels }
+        let currentTheme = ThemeManager.shared.current
+        let effectiveTheme = currentTheme == .system
+            ? (traitCollection.userInterfaceStyle == .dark ? AppTheme.dark : AppTheme.light)
+            : currentTheme
+        picker.overrideUserInterfaceStyle = (effectiveTheme == .light || effectiveTheme == .sunrise) ? .light : .dark
+        picker.minimumDate = minimum
+        picker.date = date
+        let stack = UIStackView(arrangedSubviews: [header, picker])
+        stack.axis = .vertical
+        stack.spacing = 12
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 24),
+            stack.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            stack.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+            stack.bottomAnchor.constraint(lessThanOrEqualTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -12)
+        ])
+    }
+}

--- a/MezonChat/Features/ChannelList/Event/EventEditorDraft.swift
+++ b/MezonChat/Features/ChannelList/Event/EventEditorDraft.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+enum EventLocationType: CaseIterable {
+    case voice, location, external
+}
+
+enum EventRepeatType {
+    static let doesNotRepeat: Int32 = 1
+    static let weekly: Int32 = 2
+    static let everyOtherWeek: Int32 = 3
+    static let monthly: Int32 = 4
+    static let annually: Int32 = 5
+    static let everyWeekday: Int32 = 6
+}
+
+struct EventEditorDraft {
+    static let maximumCoverBytes = 1024 * 1024
+    static let maximumTitleLength = 128
+    var locationType: EventLocationType?
+    var voiceChannelId: Int64 = 0
+    var announcementChannelId: Int64 = 0
+    var address = ""
+    var title = ""
+    var description = ""
+    var logoURL = ""
+    var start: Date
+    var end: Date
+    var repeatType = EventRepeatType.doesNotRepeat
+
+    init(event: Mezon_Api_EventManagement? = nil, now: Date = Date(), calendar: Calendar = .current) {
+        let hour = calendar.dateInterval(of: .hour, for: now)?.start ?? now
+        start = hour < now ? calendar.date(byAdding: .hour, value: 1, to: hour) ?? now : hour
+        end = calendar.date(byAdding: .hour, value: 1, to: start) ?? start.addingTimeInterval(3600)
+        if let event {
+            locationType = event.channelVoiceID != 0 ? .voice : (!event.address.isEmpty ? .location : (event.isPrivate ? .external : .voice))
+            voiceChannelId = event.channelVoiceID
+            announcementChannelId = event.channelID
+            address = event.address
+            title = event.title
+            description = event.description_p
+            logoURL = event.logo
+            start = Date(timeIntervalSince1970: TimeInterval(event.startTimeSeconds))
+            end = Date(timeIntervalSince1970: TimeInterval(event.endTimeSeconds))
+            repeatType = event.repeatType
+        }
+    }
+
+    var channelVoiceId: Int64 { locationType == .voice ? voiceChannelId : 0 }
+    var locationAddress: String { locationType == .location ? address : "" }
+    var channelId: Int64 { announcementChannelId }
+    var startSeconds: UInt32 { UInt32(clamping: Int64(start.timeIntervalSince1970)) }
+    var endSeconds: UInt32 { UInt32(clamping: Int64(end.timeIntervalSince1970)) }
+
+    var isLocationValid: Bool {
+        switch locationType {
+        case .voice: return voiceChannelId != 0
+        case .location: return !address.isEmpty && address.utf16.count <= 100
+        case .external: return true
+        case nil: return false
+        }
+    }
+
+    var titleError: String? {
+        if title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return L(L10n.EventEditor.nameRequired) }
+        if title.utf16.count > Self.maximumTitleLength { return L(L10n.EventEditor.nameTooLong, Self.maximumTitleLength) }
+        if title.contains(where: { "`<>,/\"\\'".contains($0) }) { return L(L10n.EventEditor.invalidName) }
+        return nil
+    }
+
+    func startError(now: Date = Date(), calendar: Calendar = .current) -> String? {
+        let isPastToday = calendar.isDate(start, inSameDayAs: now) && start <= now
+        return repeatType == EventRepeatType.doesNotRepeat && isPastToday ? L(L10n.EventEditor.startError) : nil
+    }
+
+    func endError(calendar: Calendar = .current) -> String? {
+        calendar.isDate(start, inSameDayAs: end) && end <= start ? L(L10n.EventEditor.endError) : nil
+    }
+
+    func isDetailsValid(now: Date = Date(), calendar: Calendar = .current) -> Bool {
+        titleError == nil && startError(now: now, calendar: calendar) == nil && endError(calendar: calendar) == nil && description.utf16.count <= 255
+    }
+
+    func hasChanges(from event: Mezon_Api_EventManagement) -> Bool {
+        title != event.title || description != event.description_p || logoURL != event.logo ||
+        channelVoiceId != event.channelVoiceID || locationAddress != event.address ||
+        channelId != event.channelID || repeatType != event.repeatType ||
+        startSeconds != event.startTimeSeconds || endSeconds != event.endTimeSeconds
+    }
+
+    func createRequest(clanId: Int64, creatorId: Int64) -> Mezon_Api_CreateEventRequest {
+        var request = Mezon_Api_CreateEventRequest()
+        request.clanID = clanId
+        request.creatorID = creatorId
+        request.title = title
+        request.description_p = description
+        request.logo = logoURL
+        request.channelVoiceID = channelVoiceId
+        request.channelID = channelId
+        request.address = locationAddress
+        request.startTimeSeconds = startSeconds
+        request.endTimeSeconds = endSeconds
+        request.repeatType = repeatType
+        request.isPrivate = locationType == .external
+        return request
+    }
+
+    func updateRequest(clanId: Int64, original: Mezon_Api_EventManagement) -> Mezon_Api_UpdateEventRequest {
+        var request = Mezon_Api_UpdateEventRequest()
+        request.eventID = original.id
+        request.clanID = clanId
+        request.creatorID = original.creatorID
+        request.title = title == original.title ? "" : title
+        request.description_p = description
+        request.logo = logoURL
+        request.channelVoiceID = channelVoiceId == original.channelVoiceID ? 0 : channelVoiceId
+        request.channelID = channelId
+        request.channelIDOld = original.channelID
+        request.address = locationAddress == original.address ? "" : locationAddress
+        request.startTimeSeconds = startSeconds == original.startTimeSeconds ? 0 : startSeconds
+        request.endTimeSeconds = endSeconds == original.endTimeSeconds ? 0 : endSeconds
+        request.repeatType = repeatType == original.repeatType ? 0 : repeatType
+        return request
+    }
+
+    func applying(to original: Mezon_Api_EventManagement) -> Mezon_Api_EventManagement {
+        var event = original
+        event.title = title
+        event.description_p = description
+        event.logo = logoURL
+        event.channelVoiceID = channelVoiceId
+        event.channelID = channelId
+        event.address = locationAddress
+        event.startTimeSeconds = startSeconds
+        event.endTimeSeconds = endSeconds
+        event.repeatType = repeatType
+        return event
+    }
+
+    func repeatOptions(calendar: Calendar = .current, locale: Locale = LanguageManager.shared.current.locale) -> [(Int32, String)] {
+        let formatter = DateFormatter()
+        formatter.locale = locale
+        formatter.calendar = calendar
+        formatter.dateFormat = "EEEE"
+        let day = formatter.string(from: start)
+        formatter.dateFormat = "MMMM"
+        let month = formatter.string(from: start)
+        var options: [(Int32, String)] = [
+            (EventRepeatType.doesNotRepeat, L(L10n.EventEditor.repeatNone)),
+            (EventRepeatType.weekly, L(L10n.EventEditor.repeatWeekly, day)),
+            (EventRepeatType.everyOtherWeek, L(L10n.EventEditor.repeatOther, day)),
+            (EventRepeatType.monthly, L(L10n.EventEditor.repeatMonthly, calendar.component(.weekdayOrdinal, from: start), day)),
+            (EventRepeatType.annually, L(L10n.EventEditor.repeatAnnually, month, calendar.component(.day, from: start)))
+        ]
+        if !calendar.isDateInWeekend(start) { options.append((EventRepeatType.everyWeekday, L(L10n.EventEditor.repeatWeekday))) }
+        return options
+    }
+}

--- a/MezonChat/Features/ChannelList/Event/EventEditorViewController.swift
+++ b/MezonChat/Features/ChannelList/Event/EventEditorViewController.swift
@@ -1,0 +1,842 @@
+import UIKit
+import ImageIO
+
+final class EventEditorViewController: UIViewController, UITextFieldDelegate, UITextViewDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+    private let context: AccountContext
+    private let clanId: Int64
+    private let channels: [Mezon_Api_ChannelDescription]
+    private let original: Mezon_Api_EventManagement?
+    private var draft: EventEditorDraft
+    var onSaved: ((Mezon_Api_EventManagement?) -> Void)?
+
+    private let accent = UIColor(red: 0.39, green: 0.38, blue: 0.91, alpha: 1)
+    private let card = UIView()
+    private let header = UIStackView()
+    private let body = UIStackView()
+    private let scroll = UIScrollView()
+    private let footer = UIStackView()
+    private let stepLabel = UILabel()
+    private let nextButton = EventEditorButton()
+    private let backButton = EventEditorButton()
+    private let closeButton = EventEditorButton()
+    private let spinner = UIActivityIndicatorView(style: .medium)
+    private let errorLabel = UILabel()
+    private var progressBars: [UIView] = []
+    private var progressLabels: [UILabel] = []
+    private var optionDescriptions: [UILabel] = []
+    private var cardHeight: NSLayoutConstraint!
+    private var cardCenter: NSLayoutConstraint!
+    private var step = 0
+    private var keyboardHeight: CGFloat = 0
+    private var submitting = false
+    private var uploading = false
+    private var uploadTask: Task<Void, Never>?
+    private var submitTask: Task<Void, Never>?
+    private var dismissed = false
+
+    private let nameField = UITextField()
+    private let addressField = UITextField()
+    private let descriptionView = UITextView()
+    private let descriptionPlaceholder = UILabel()
+    private let descriptionCount = UILabel()
+    private let coverContainer = UIStackView()
+    private let nameError = UILabel()
+    private let addressError = UILabel()
+    private let startError = UILabel()
+    private let endError = UILabel()
+    private var dateFields: [EventEditorFieldButton] = []
+    private var repeatField: EventEditorFieldButton?
+    private var previewImage: UIImage?
+
+    init(context: AccountContext, clanId: Int64, channels: [Mezon_Api_ChannelDescription], event: Mezon_Api_EventManagement? = nil) {
+        self.context = context
+        self.clanId = clanId
+        self.channels = channels
+        self.original = event
+        self.draft = EventEditorDraft(event: event)
+        super.init(nibName: nil, bundle: nil)
+        modalPresentationStyle = .overFullScreen
+        modalTransitionStyle = .crossDissolve
+    }
+    required init?(coder: NSCoder) { fatalError() }
+    deinit {
+        uploadTask?.cancel()
+        submitTask?.cancel()
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        buildShell()
+        configureTextInputs()
+        renderStep()
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardChanged), name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(themeChanged), name: ThemeManager.didChangeNotification, object: nil)
+    }
+
+    private func buildShell() {
+        view.backgroundColor = UIColor.black.withAlphaComponent(0.55)
+        card.backgroundColor = EventEditorPalette.surface
+        card.layer.cornerRadius = 20
+        card.clipsToBounds = true
+        card.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(card)
+        header.axis = .vertical
+        header.spacing = 20
+        header.layoutMargins = UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
+        header.isLayoutMarginsRelativeArrangement = true
+        let title = label(L(original == nil ? L10n.EventEditor.create : L10n.EventEditor.edit), size: 20, weight: .bold)
+        stepLabel.font = .systemFont(ofSize: 13)
+        stepLabel.textColor = UIColor.theme.text
+        let titles = UIStackView(arrangedSubviews: [title, stepLabel])
+        titles.axis = .vertical
+        titles.spacing = 6
+        closeButton.setImage(UIImage(systemName: "xmark", withConfiguration: UIImage.SymbolConfiguration(pointSize: 22)), for: .normal)
+        closeButton.tintColor = UIColor.theme.text
+        closeButton.accessibilityLabel = L(L10n.EventEditor.close)
+        closeButton.widthAnchor.constraint(equalToConstant: 44).isActive = true
+        closeButton.heightAnchor.constraint(equalToConstant: 44).isActive = true
+        closeButton.action = { [weak self] in self?.close() }
+        let top = UIStackView(arrangedSubviews: [titles, closeButton])
+        top.alignment = .center
+        header.addArrangedSubview(top)
+        let progress = UIStackView()
+        progress.spacing = 8
+        progress.distribution = .fillEqually
+        for key in [L10n.EventEditor.location, L10n.EventEditor.details, L10n.EventEditor.preview] {
+            let bar = UIView()
+            bar.layer.cornerRadius = 2
+            bar.heightAnchor.constraint(equalToConstant: 4).isActive = true
+            let text = label(L(key), size: 12)
+            let column = UIStackView(arrangedSubviews: [bar, text])
+            column.axis = .vertical
+            column.spacing = 10
+            progress.addArrangedSubview(column)
+            progressBars.append(bar)
+            progressLabels.append(text)
+        }
+        header.addArrangedSubview(progress)
+        scroll.keyboardDismissMode = .interactive
+        scroll.showsVerticalScrollIndicator = false
+        body.axis = .vertical
+        body.spacing = 16
+        body.layoutMargins = UIEdgeInsets(top: 4, left: 20, bottom: 20, right: 20)
+        body.isLayoutMarginsRelativeArrangement = true
+        body.translatesAutoresizingMaskIntoConstraints = false
+        scroll.addSubview(body)
+        NSLayoutConstraint.activate([
+            body.topAnchor.constraint(equalTo: scroll.contentLayoutGuide.topAnchor),
+            body.leadingAnchor.constraint(equalTo: scroll.contentLayoutGuide.leadingAnchor),
+            body.trailingAnchor.constraint(equalTo: scroll.contentLayoutGuide.trailingAnchor),
+            body.bottomAnchor.constraint(equalTo: scroll.contentLayoutGuide.bottomAnchor),
+            body.widthAnchor.constraint(equalTo: scroll.frameLayoutGuide.widthAnchor)
+        ])
+        footer.axis = .vertical
+        footer.spacing = 10
+        footer.layoutMargins = UIEdgeInsets(top: 16, left: 20, bottom: 16, right: 20)
+        footer.isLayoutMarginsRelativeArrangement = true
+        configureError(errorLabel)
+        footer.addArrangedSubview(errorLabel)
+        let actions = UIStackView(arrangedSubviews: [backButton, nextButton])
+        actions.spacing = 12
+        actions.distribution = .fillEqually
+        for button in [backButton, nextButton] {
+            button.titleLabel?.font = .systemFont(ofSize: 16, weight: .bold)
+            button.titleLabel?.numberOfLines = 2
+            button.titleLabel?.textAlignment = .center
+            button.layer.cornerRadius = 12
+            button.heightAnchor.constraint(greaterThanOrEqualToConstant: 50).isActive = true
+            button.contentEdgeInsets = UIEdgeInsets(top: 12, left: 8, bottom: 12, right: 8)
+        }
+        backButton.layer.borderWidth = 1.5
+        backButton.layer.borderColor = accent.cgColor
+        backButton.setTitleColor(accent, for: .normal)
+        backButton.action = { [weak self] in
+            guard let self, !self.submitting else { return }
+            if self.step == 0 { self.close() } else { self.step -= 1; self.renderStep() }
+        }
+        nextButton.setTitleColor(.white, for: .normal)
+        nextButton.setTitleColor(UIColor.theme.textDisabled, for: .disabled)
+        nextButton.action = { [weak self] in self?.advance() }
+        spinner.color = .white
+        spinner.translatesAutoresizingMaskIntoConstraints = false
+        nextButton.addSubview(spinner)
+        NSLayoutConstraint.activate([
+            spinner.centerXAnchor.constraint(equalTo: nextButton.centerXAnchor),
+            spinner.centerYAnchor.constraint(equalTo: nextButton.centerYAnchor)
+        ])
+        footer.addArrangedSubview(actions)
+        let separator = UIView()
+        separator.backgroundColor = EventEditorPalette.border
+        separator.heightAnchor.constraint(equalToConstant: 1).isActive = true
+        let root = UIStackView(arrangedSubviews: [header, scroll, separator, footer])
+        root.axis = .vertical
+        root.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(root)
+        cardHeight = card.heightAnchor.constraint(equalToConstant: 600)
+        cardCenter = card.centerYAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerYAnchor)
+        let width = card.widthAnchor.constraint(equalTo: view.safeAreaLayoutGuide.widthAnchor, constant: -32)
+        width.priority = .defaultHigh
+        NSLayoutConstraint.activate([
+            card.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor),
+            cardCenter, cardHeight, width,
+            card.widthAnchor.constraint(lessThanOrEqualToConstant: 560),
+            root.topAnchor.constraint(equalTo: card.topAnchor), root.bottomAnchor.constraint(equalTo: card.bottomAnchor),
+            root.leadingAnchor.constraint(equalTo: card.leadingAnchor), root.trailingAnchor.constraint(equalTo: card.trailingAnchor)
+        ])
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        let width = card.bounds.width
+        guard width > 0 else { return }
+        for description in optionDescriptions {
+            description.preferredMaxLayoutWidth = max(1, width - 146)
+        }
+        let fitting = CGSize(width: width, height: UIView.layoutFittingCompressedSize.height)
+        let bodyHeight = body.systemLayoutSizeFitting(fitting, withHorizontalFittingPriority: .required, verticalFittingPriority: .fittingSizeLevel).height
+        let headerHeight = header.systemLayoutSizeFitting(fitting, withHorizontalFittingPriority: .required, verticalFittingPriority: .fittingSizeLevel).height
+        let footerHeight = footer.systemLayoutSizeFitting(fitting, withHorizontalFittingPriority: .required, verticalFittingPriority: .fittingSizeLevel).height
+        let safeHeight = view.safeAreaLayoutGuide.layoutFrame.height
+        let available = max(0, safeHeight - keyboardHeight - 24)
+        let height = min(bodyHeight + headerHeight + footerHeight + 1, min(780, available))
+        if abs(cardHeight.constant - height) > 0.5 { cardHeight.constant = height }
+    }
+
+    @objc private func keyboardChanged(_ notification: Notification) {
+        guard let frame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else { return }
+        let localFrame = view.convert(frame, from: nil)
+        keyboardHeight = max(0, view.safeAreaLayoutGuide.layoutFrame.maxY - localFrame.minY)
+        cardCenter.constant = -keyboardHeight / 2
+        view.setNeedsLayout()
+        let duration = notification.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double ?? 0.25
+        UIView.animate(withDuration: duration) { self.view.layoutIfNeeded() }
+        if nameField.isFirstResponder { scroll.scrollRectToVisible(nameField.convert(nameField.bounds, to: body).insetBy(dx: 0, dy: -12), animated: true) }
+        if descriptionView.isFirstResponder { scroll.scrollRectToVisible(descriptionView.convert(descriptionView.bounds, to: body).insetBy(dx: 0, dy: -12), animated: true) }
+    }
+
+    @objc private func themeChanged() {
+        card.backgroundColor = EventEditorPalette.surface
+        configureTextInputColors()
+        renderStep(preservingScrollPosition: true)
+    }
+
+    private func configureTextInputs() {
+        for field in [nameField, addressField] {
+            field.font = .systemFont(ofSize: 16)
+            field.clearButtonMode = .whileEditing
+            field.borderStyle = .none
+            field.layer.cornerRadius = 12
+            field.layer.borderWidth = 1
+            let inset = UIView(frame: CGRect(x: 0, y: 0, width: 12, height: 48))
+            field.leftView = inset
+            field.leftViewMode = .always
+            field.heightAnchor.constraint(equalToConstant: 48).isActive = true
+            field.delegate = self
+            field.addTarget(self, action: #selector(textChanged), for: .editingChanged)
+            field.returnKeyType = .done
+        }
+        nameField.accessibilityLabel = L(L10n.EventEditor.name)
+        nameField.text = draft.title
+        addressField.placeholder = L(L10n.EventEditor.addressPlaceholder)
+        addressField.accessibilityLabel = L(L10n.EventEditor.address)
+        addressField.text = draft.address
+        descriptionView.font = .systemFont(ofSize: 15)
+        descriptionView.delegate = self
+        descriptionView.text = draft.description
+        descriptionView.textContainerInset = UIEdgeInsets(top: 12, left: 8, bottom: 12, right: 8)
+        descriptionView.layer.cornerRadius = 12
+        descriptionView.layer.borderWidth = 1
+        descriptionView.heightAnchor.constraint(equalToConstant: 100).isActive = true
+        descriptionView.accessibilityLabel = L(L10n.EventEditor.description)
+        descriptionPlaceholder.text = L(L10n.EventEditor.descriptionPlaceholder)
+        descriptionPlaceholder.font = .systemFont(ofSize: 15)
+        descriptionPlaceholder.numberOfLines = 0
+        descriptionPlaceholder.isUserInteractionEnabled = false
+        descriptionPlaceholder.translatesAutoresizingMaskIntoConstraints = false
+        descriptionView.addSubview(descriptionPlaceholder)
+        NSLayoutConstraint.activate([
+            descriptionPlaceholder.topAnchor.constraint(equalTo: descriptionView.topAnchor, constant: 12),
+            descriptionPlaceholder.leadingAnchor.constraint(equalTo: descriptionView.leadingAnchor, constant: 12),
+            descriptionPlaceholder.widthAnchor.constraint(equalTo: descriptionView.widthAnchor, constant: -24)
+        ])
+        descriptionCount.font = .systemFont(ofSize: 11)
+        descriptionCount.textAlignment = .right
+        for error in [nameError, addressError, startError, endError] { configureError(error) }
+        configureTextInputColors()
+    }
+
+    private func configureTextInputColors() {
+        for field in [nameField, addressField] {
+            field.textColor = UIColor.theme.textStrong
+            field.backgroundColor = EventEditorPalette.field
+            field.layer.borderColor = EventEditorPalette.border.cgColor
+            field.tintColor = accent
+        }
+        nameField.attributedPlaceholder = NSAttributedString(
+            string: L(L10n.EventEditor.namePlaceholder),
+            attributes: [.foregroundColor: UIColor.theme.textDisabled]
+        )
+        descriptionView.textColor = UIColor.theme.textStrong
+        descriptionView.backgroundColor = EventEditorPalette.field
+        descriptionView.layer.borderColor = EventEditorPalette.border.cgColor
+        descriptionPlaceholder.textColor = UIColor.theme.textDisabled
+        descriptionCount.textColor = UIColor.theme.text
+    }
+
+    private func renderStep(preservingScrollPosition: Bool = false) {
+        let preservedOffset = scroll.contentOffset
+        view.endEditing(true)
+        body.arrangedSubviews.forEach { body.removeArrangedSubview($0); $0.removeFromSuperview() }
+        errorLabel.isHidden = true
+        optionDescriptions.removeAll()
+        stepLabel.text = L(L10n.EventEditor.step, step + 1)
+        for index in 0..<3 {
+            progressBars[index].backgroundColor = index <= step ? accent : EventEditorPalette.border
+            progressLabels[index].textColor = index == step ? accent : UIColor.theme.text
+            progressLabels[index].font = .systemFont(ofSize: 12, weight: index == step ? .bold : .regular)
+            progressLabels[index].accessibilityTraits = index == step ? [.staticText, .selected] : .staticText
+        }
+        if step == 0 { buildLocation() }
+        else if step == 1 { buildDetails() }
+        else { buildPreview() }
+        refreshValidation()
+        view.setNeedsLayout()
+        if preservingScrollPosition {
+            view.layoutIfNeeded()
+            let minimumY = -scroll.adjustedContentInset.top
+            let maximumY = max(
+                minimumY,
+                scroll.contentSize.height - scroll.bounds.height + scroll.adjustedContentInset.bottom
+            )
+            let restoredY = min(max(preservedOffset.y, minimumY), maximumY)
+            scroll.setContentOffset(CGPoint(x: preservedOffset.x, y: restoredY), animated: false)
+        } else {
+            scroll.setContentOffset(.zero, animated: false)
+            UIAccessibility.post(notification: .screenChanged, argument: stepLabel)
+        }
+    }
+
+    private func buildLocation() {
+        body.addArrangedSubview(label(L(L10n.EventEditor.chooseType), size: 17, weight: .bold))
+        body.addArrangedSubview(label(L(L10n.EventEditor.chooseTypeSubtitle), size: 13))
+        let options: [(EventLocationType, String, String, String)] = [
+            (.voice, L10n.EventEditor.voice, L10n.EventEditor.voiceSubtitle, "speaker.wave.2.fill"),
+            (.location, L10n.EventEditor.elsewhere, L10n.EventEditor.elsewhereSubtitle, "mappin.and.ellipse"),
+            (.external, L10n.EventEditor.external, L10n.EventEditor.externalSubtitle, "lock.fill")
+        ]
+        let voices = EventEditorAccess.voiceChannels(channels)
+        let optionStack = UIStackView()
+        optionStack.axis = .vertical
+        optionStack.spacing = 8
+        for (type, title, subtitle, symbol) in options {
+            if let original, (type == .external) != original.isPrivate { continue }
+            let selected = draft.locationType == type
+            let enabled = type != .voice || !voices.isEmpty || draft.voiceChannelId != 0
+            let button = EventEditorButton()
+            button.layer.cornerRadius = 12
+            button.layer.borderWidth = 1
+            button.layer.borderColor = (selected ? accent : EventEditorPalette.border).cgColor
+            button.backgroundColor = selected ? accent.withAlphaComponent(0.1) : EventEditorPalette.field
+            button.isEnabled = enabled
+            button.alpha = enabled ? 1 : 0.45
+            let icon = UIImageView(image: UIImage(systemName: symbol))
+            icon.tintColor = UIColor.theme.textStrong
+            icon.contentMode = .scaleAspectFit
+            icon.widthAnchor.constraint(equalToConstant: 24).isActive = true
+            let description = label(L(subtitle), size: 13)
+            description.setContentCompressionResistancePriority(.required, for: .vertical)
+            description.preferredMaxLayoutWidth = max(1, min(560, view.bounds.width - 32) - 146)
+            optionDescriptions.append(description)
+            let texts = UIStackView(arrangedSubviews: [label(L(title), size: 16, weight: .bold), description])
+            texts.axis = .vertical
+            texts.spacing = 6
+            let radio = UIImageView(image: UIImage(systemName: selected ? "largecircle.fill.circle" : "circle"))
+            radio.contentMode = .scaleAspectFit
+            radio.tintColor = selected ? accent : UIColor.theme.textDisabled
+            radio.widthAnchor.constraint(equalToConstant: 26).isActive = true
+            radio.heightAnchor.constraint(equalToConstant: 26).isActive = true
+            let row = UIStackView(arrangedSubviews: [icon, texts, radio])
+            row.spacing = 14
+            row.alignment = .center
+            row.isUserInteractionEnabled = false
+            row.translatesAutoresizingMaskIntoConstraints = false
+            button.addSubview(row)
+            NSLayoutConstraint.activate([
+                row.topAnchor.constraint(equalTo: button.topAnchor, constant: 16), row.bottomAnchor.constraint(equalTo: button.bottomAnchor, constant: -16),
+                row.leadingAnchor.constraint(equalTo: button.leadingAnchor, constant: 14), row.trailingAnchor.constraint(equalTo: button.trailingAnchor, constant: -14)
+            ])
+            button.accessibilityLabel = "\(L(title)). \(L(subtitle))"
+            button.accessibilityTraits = selected ? [.button, .selected] : .button
+            button.action = { [weak self] in
+                guard let self else { return }
+                self.draft.locationType = type
+                self.renderStep(preservingScrollPosition: true)
+            }
+            optionStack.addArrangedSubview(button)
+        }
+        body.addArrangedSubview(optionStack)
+        if draft.locationType == .voice {
+            let field = EventEditorFieldButton(caption: L(L10n.EventEditor.voice))
+            field.setValue(channelLabel(draft.voiceChannelId) ?? L(L10n.EventEditor.pickChannel))
+            field.action = { [weak self] in self?.pickChannel(voice: true) }
+            body.addArrangedSubview(field)
+        } else if draft.locationType == .location {
+            body.addArrangedSubview(labeledField(L(L10n.EventEditor.address) + " *", field: addressField, error: addressError))
+        }
+        if draft.locationType != .external {
+            let field = EventEditorFieldButton(caption: L(L10n.EventEditor.announcement))
+            field.setValue(channelLabel(draft.announcementChannelId) ?? L(L10n.EventEditor.pickChannel))
+            field.action = { [weak self] in self?.pickChannel(voice: false) }
+            body.addArrangedSubview(field)
+        }
+    }
+
+    private func buildDetails() {
+        body.addArrangedSubview(label(L(L10n.EventEditor.detailsTitle), size: 17, weight: .bold))
+        body.addArrangedSubview(label(L(L10n.EventEditor.detailsSubtitle), size: 13))
+        body.addArrangedSubview(labeledField(L(L10n.EventEditor.name) + " *", field: nameField, error: nameError))
+        dateFields = [L10n.EventEditor.startDate, L10n.EventEditor.startTime, L10n.EventEditor.endDate, L10n.EventEditor.endTime].enumerated().map { index, key in
+            let field = EventEditorFieldButton(caption: L(key))
+            field.action = { [weak self] in self?.pickDate(index) }
+            return field
+        }
+        let dates = UIStackView()
+        dates.axis = .vertical
+        dates.spacing = 8
+        for index in [0, 2] {
+            let row = UIStackView(arrangedSubviews: [dateFields[index], dateFields[index + 1]])
+            row.distribution = .fillEqually
+            row.spacing = 8
+            dates.addArrangedSubview(row)
+            dates.addArrangedSubview(index == 0 ? startError : endError)
+        }
+        body.addArrangedSubview(dates)
+        let repeatField = EventEditorFieldButton(caption: L(L10n.EventEditor.repeatLabel))
+        self.repeatField = repeatField
+        repeatField.action = { [weak self] in self?.pickRepeat() }
+        body.addArrangedSubview(repeatField)
+        let description = UIStackView(arrangedSubviews: [label(L(L10n.EventEditor.description), size: 15, weight: .bold), descriptionView, descriptionCount])
+        description.axis = .vertical
+        description.spacing = 6
+        body.addArrangedSubview(description)
+        body.addArrangedSubview(label(L(L10n.EventEditor.cover), size: 14, weight: .bold))
+        body.addArrangedSubview(coverContainer)
+        refreshCover()
+        refreshDateLabels()
+    }
+
+    private func refreshCover() {
+        coverContainer.arrangedSubviews.forEach {
+            coverContainer.removeArrangedSubview($0)
+            $0.removeFromSuperview()
+        }
+        coverContainer.addArrangedSubview(makeCover())
+    }
+
+    private func makeCover() -> UIView {
+        let wrapper = UIView()
+        wrapper.backgroundColor = EventEditorPalette.field
+        wrapper.layer.cornerRadius = 12
+        wrapper.layer.borderWidth = 1
+        wrapper.layer.borderColor = EventEditorPalette.border.cgColor
+        wrapper.clipsToBounds = true
+        wrapper.heightAnchor.constraint(equalToConstant: 128).isActive = true
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        wrapper.addSubview(imageView)
+        loadCover(into: imageView)
+        let pick = EventEditorButton()
+        pick.translatesAutoresizingMaskIntoConstraints = false
+        pick.setTitle(draft.logoURL.isEmpty ? L(L10n.EventEditor.addCover) : "", for: .normal)
+        pick.titleLabel?.font = .systemFont(ofSize: 13)
+        pick.titleLabel?.numberOfLines = 0
+        pick.setTitleColor(accent, for: .normal)
+        pick.accessibilityLabel = L(L10n.EventEditor.addCover)
+        pick.isEnabled = !uploading
+        pick.action = { [weak self] in self?.pickCover() }
+        wrapper.addSubview(pick)
+        NSLayoutConstraint.activate([
+            imageView.topAnchor.constraint(equalTo: wrapper.topAnchor), imageView.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor),
+            imageView.leadingAnchor.constraint(equalTo: wrapper.leadingAnchor), imageView.trailingAnchor.constraint(equalTo: wrapper.trailingAnchor),
+            pick.topAnchor.constraint(equalTo: wrapper.topAnchor), pick.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor),
+            pick.leadingAnchor.constraint(equalTo: wrapper.leadingAnchor), pick.trailingAnchor.constraint(equalTo: wrapper.trailingAnchor)
+        ])
+        if !draft.logoURL.isEmpty {
+            let remove = EventEditorButton()
+            remove.setImage(UIImage(systemName: "xmark.circle.fill"), for: .normal)
+            remove.tintColor = .systemRed
+            remove.accessibilityLabel = L(L10n.EventEditor.removeCover)
+            remove.translatesAutoresizingMaskIntoConstraints = false
+            remove.isEnabled = !uploading
+            remove.action = { [weak self] in
+                guard let self else { return }
+                self.draft.logoURL = ""
+                self.previewImage = nil
+                self.refreshCover()
+                self.refreshValidation()
+            }
+            wrapper.addSubview(remove)
+            NSLayoutConstraint.activate([
+                remove.widthAnchor.constraint(equalToConstant: 44), remove.heightAnchor.constraint(equalToConstant: 44),
+                remove.topAnchor.constraint(equalTo: wrapper.topAnchor), remove.trailingAnchor.constraint(equalTo: wrapper.trailingAnchor)
+            ])
+        }
+        if uploading {
+            let indicator = UIActivityIndicatorView(style: .medium)
+            indicator.translatesAutoresizingMaskIntoConstraints = false
+            wrapper.addSubview(indicator)
+            NSLayoutConstraint.activate([indicator.centerXAnchor.constraint(equalTo: wrapper.centerXAnchor), indicator.centerYAnchor.constraint(equalTo: wrapper.centerYAnchor)])
+            indicator.startAnimating()
+        }
+        return wrapper
+    }
+
+    private func buildPreview() {
+        let content = UIStackView()
+        content.axis = .vertical
+        content.spacing = 10
+        content.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        content.isLayoutMarginsRelativeArrangement = true
+        let wrapper = UIView()
+        wrapper.backgroundColor = EventEditorPalette.field
+        wrapper.layer.cornerRadius = 12
+        content.translatesAutoresizingMaskIntoConstraints = false
+        wrapper.addSubview(content)
+        NSLayoutConstraint.activate([
+            content.topAnchor.constraint(equalTo: wrapper.topAnchor), content.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor),
+            content.leadingAnchor.constraint(equalTo: wrapper.leadingAnchor), content.trailingAnchor.constraint(equalTo: wrapper.trailingAnchor)
+        ])
+        content.addArrangedSubview(iconRow("calendar", text: formatted(draft.start, template: "EEE MMM d jm")))
+        if !draft.logoURL.isEmpty {
+            let image = UIImageView()
+            image.contentMode = .scaleAspectFill
+            image.clipsToBounds = true
+            image.layer.cornerRadius = 8
+            image.heightAnchor.constraint(equalToConstant: 112).isActive = true
+            loadCover(into: image)
+            content.addArrangedSubview(image)
+        }
+        let badgeKey = draft.locationType == .external ? L10n.EventMenu.privateEvent : (draft.channelId == 0 ? L10n.EventMenu.clanEvent : L10n.EventMenu.channelEvent)
+        let badgeColor = draft.locationType == .external ? EventDisplayHelper.externalEventBadgeColor : (draft.channelId == 0 ? EventDisplayHelper.clanEventBadgeColor : EventDisplayHelper.channelEventBadgeColor)
+        let badge = EventDisplayHelper.makeBadgeView(text: L(badgeKey), color: badgeColor)
+        let badgeRow = UIStackView(arrangedSubviews: [badge, UIView()])
+        badge.setContentHuggingPriority(.required, for: .horizontal)
+        content.addArrangedSubview(badgeRow)
+        content.addArrangedSubview(label(draft.title, size: 20, weight: .bold))
+        if !draft.description.isEmpty { content.addArrangedSubview(label(draft.description, size: 14)) }
+        let location: String
+        switch draft.locationType {
+        case .voice: location = channelLabel(draft.voiceChannelId) ?? L(L10n.EventMenu.privateRoom)
+        case .location: location = draft.address
+        default: location = L(L10n.EventMenu.privateEvent)
+        }
+        content.addArrangedSubview(iconRow(draft.locationType == .location ? "mappin.and.ellipse" : (draft.locationType == .external ? "lock.fill" : "speaker.wave.2.fill"), text: location))
+        if draft.repeatType != EventRepeatType.doesNotRepeat { content.addArrangedSubview(iconRow("repeat", text: repeatLabel())) }
+        if let channel = channelLabel(draft.channelId), draft.channelId != 0 {
+            content.addArrangedSubview(label(L(L10n.EventMenu.channelAudience, channel), size: 12))
+        }
+        body.addArrangedSubview(wrapper)
+        body.addArrangedSubview(label(L(L10n.EventEditor.previewTitle), size: 17, weight: .bold))
+        let key = original != nil ? L10n.EventEditor.previewEdit : (draft.locationType == .voice ? L10n.EventEditor.previewVoice : (draft.locationType == .external ? L10n.EventEditor.previewExternal : L10n.EventEditor.previewLocation))
+        body.addArrangedSubview(label(L(key), size: 14))
+    }
+
+    @objc private func textChanged() {
+        draft.title = nameField.text ?? ""
+        draft.address = addressField.text ?? ""
+        refreshValidation()
+    }
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool { textField.resignFirstResponder(); return true }
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        guard textField === nameField else { return true }
+        let current = textField.text ?? ""
+        let proposed = (current as NSString).replacingCharacters(in: range, with: string)
+        return proposed.utf16.count <= EventEditorDraft.maximumTitleLength || proposed.utf16.count < current.utf16.count
+    }
+    func textViewDidChange(_ textView: UITextView) {
+        if textView.markedTextRange == nil, textView.text.utf16.count > 255 {
+            var value = textView.text ?? ""
+            while value.utf16.count > 255 { value.removeLast() }
+            textView.text = value
+        }
+        draft.description = textView.text
+        refreshValidation()
+    }
+
+    private func refreshValidation() {
+        setError(nameError, draft.title.isEmpty ? nil : draft.titleError)
+        setError(addressError, draft.address.utf16.count > 100 ? L(L10n.EventEditor.addressError) : nil)
+        setError(startError, draft.startError())
+        setError(endError, draft.endError())
+        descriptionPlaceholder.isHidden = !draft.description.isEmpty
+        descriptionCount.text = "\(draft.description.utf16.count)/255"
+        let valid: Bool
+        if step == 0 { valid = draft.isLocationValid }
+        else { valid = draft.isLocationValid && draft.isDetailsValid() && (step != 2 || original.map { draft.hasChanges(from: $0) } ?? true) }
+        nextButton.isEnabled = valid && !submitting && !uploading
+        nextButton.backgroundColor = nextButton.isEnabled ? accent : EventEditorPalette.border
+        let title = step < 2 ? L10n.EventEditor.next : (original == nil ? L10n.EventEditor.create : L10n.EventEditor.update)
+        nextButton.setTitle(submitting ? "" : L(title), for: .normal)
+        nextButton.accessibilityLabel = L(title)
+        backButton.setTitle(L(step == 0 ? L10n.EventEditor.cancel : L10n.EventEditor.back), for: .normal)
+        backButton.isEnabled = !submitting
+        closeButton.isEnabled = !submitting
+        body.isUserInteractionEnabled = !submitting
+        if submitting { spinner.startAnimating() } else { spinner.stopAnimating() }
+        view.setNeedsLayout()
+    }
+
+    private func advance() {
+        view.endEditing(true)
+        refreshValidation() 
+        guard nextButton.isEnabled else { return }
+        if step < 2 { step += 1; renderStep() } else { submit() }
+    }
+
+    private func pickChannel(voice: Bool) {
+        view.endEditing(true)
+        let options = voice ? EventEditorAccess.voiceChannels(channels) : EventEditorAccess.announcementChannels(channels)
+        let choices = options.map { EventEditorChoiceViewController.Choice(id: $0.channelID, title: $0.channelLabel, icon: $0.channelListIconAssetName()) }
+        let vc = EventEditorChoiceViewController(title: L(voice ? L10n.EventEditor.voice : L10n.EventEditor.announcement), choices: choices, selectedId: voice ? draft.voiceChannelId : draft.announcementChannelId) { [weak self] id in
+            guard let self else { return }
+            if voice {
+                self.draft.voiceChannelId = id
+            } else {
+                self.draft.announcementChannelId = self.draft.announcementChannelId == id ? 0 : id
+            }
+            self.renderStep(preservingScrollPosition: true)
+        }
+        present(vc, animated: true)
+    }
+
+    private func pickDate(_ index: Int) {
+        view.endEditing(true)
+        let isStart = index < 2
+        let isDate = index % 2 == 0
+        let current = isStart ? draft.start : draft.end
+        let calendar = Calendar.current
+        let minimum = isDate ? calendar.startOfDay(for: isStart ? Date() : draft.start) : nil
+        let vc = EventEditorDateViewController(title: dateFields[index].captionLabel.text ?? "", date: current, mode: isDate ? .date : .time, minimum: minimum) { [weak self] picked in
+            guard let self else { return }
+            let date = isDate ? picked : current
+            let time = isDate ? current : picked
+            var components = calendar.dateComponents([.year, .month, .day], from: date)
+            let clock = calendar.dateComponents([.hour, .minute], from: time)
+            components.hour = clock.hour
+            components.minute = clock.minute
+            components.second = 0
+            guard let combined = calendar.date(from: components) else { return }
+            if isStart {
+                self.draft.start = combined
+                if isDate && calendar.startOfDay(for: combined) > calendar.startOfDay(for: self.draft.end) {
+                    var endComponents = calendar.dateComponents([.year, .month, .day], from: combined)
+                    let endClock = calendar.dateComponents([.hour, .minute], from: self.draft.end)
+                    endComponents.hour = endClock.hour
+                    endComponents.minute = endClock.minute
+                    endComponents.second = 0
+                    if let adjustedEnd = calendar.date(from: endComponents) {
+                        self.draft.end = adjustedEnd
+                    }
+                }
+            } else { self.draft.end = combined }
+            self.refreshDateLabels()
+            self.refreshValidation()
+        }
+        present(vc, animated: true)
+    }
+
+    private func pickRepeat() {
+        view.endEditing(true)
+        let choices = draft.repeatOptions().map { EventEditorChoiceViewController.Choice(id: Int64($0.0), title: $0.1, icon: nil) }
+        let vc = EventEditorChoiceViewController(title: L(L10n.EventEditor.repeatLabel), choices: choices, selectedId: Int64(draft.repeatType), allowsSearch: false) { [weak self] id in
+            self?.draft.repeatType = Int32(id)
+            self?.refreshDateLabels()
+            self?.refreshValidation()
+        }
+        present(vc, animated: true)
+    }
+
+    private func refreshDateLabels() {
+        guard dateFields.count == 4 else { return }
+        dateFields[0].setValue(formatted(draft.start, template: "MMM d y"))
+        dateFields[1].setValue(formatted(draft.start, template: "jm"))
+        dateFields[2].setValue(formatted(draft.end, template: "MMM d y"))
+        dateFields[3].setValue(formatted(draft.end, template: "jm"))
+        repeatField?.setValue(repeatLabel())
+    }
+    private func repeatLabel() -> String {
+        draft.repeatOptions().first { $0.0 == draft.repeatType }?.1 ?? L(draft.repeatType == EventRepeatType.everyWeekday ? L10n.EventEditor.repeatWeekday : L10n.EventEditor.repeatNone)
+    }
+
+    private func pickCover() {
+        guard !uploading else { return }
+        view.endEditing(true)
+        let picker = UIImagePickerController()
+        picker.sourceType = .photoLibrary
+        picker.mediaTypes = ["public.image"]
+        picker.delegate = self
+        present(picker, animated: true)
+    }
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) { picker.dismiss(animated: true) }
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+        picker.dismiss(animated: true)
+        guard let image = info[.originalImage] as? UIImage else { showError(L(L10n.EventEditor.coverFailed)); return }
+        let data: Data
+        if let url = info[.imageURL] as? URL {
+            if let size = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize, size > EventEditorDraft.maximumCoverBytes {
+                showError(L(L10n.EventEditor.coverTooLarge)); return
+            }
+            guard let bytes = try? Data(contentsOf: url, options: .mappedIfSafe) else { showError(L(L10n.EventEditor.coverFailed)); return }
+            data = bytes
+        } else {
+            guard let bytes = image.jpegData(compressionQuality: 0.9) else { showError(L(L10n.EventEditor.coverFailed)); return }
+            data = bytes
+        }
+        guard data.count <= EventEditorDraft.maximumCoverBytes else { showError(L(L10n.EventEditor.coverTooLarge)); return }
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil), let type = CGImageSourceGetType(source) as String? else {
+            showError(L(L10n.EventEditor.coverFailed)); return
+        }
+        let formats = ["public.jpeg": ("image/jpeg", "jpg"), "public.png": ("image/png", "png"), "com.compuserve.gif": ("image/gif", "gif"), "public.heic": ("image/heic", "heic"), "public.heif": ("image/heif", "heif"), "org.webmproject.webp": ("image/webp", "webp"), "public.tiff": ("image/tiff", "tiff")]
+        guard let format = formats[type] else { showError(L(L10n.EventEditor.coverFailed)); return }
+        uploading = true
+        errorLabel.isHidden = true
+        refreshCover()
+        refreshValidation()
+        uploadTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                self.uploading = false
+                self.uploadTask = nil
+                if !self.dismissed {
+                    self.refreshCover()
+                    self.refreshValidation()
+                }
+            }
+            do {
+                guard let token = await self.context.getToken() else { throw EventEditorError.sessionExpired }
+                let upload = try await self.context.account.network.uploadAttachmentFile(
+                    filename: "\(UUID().uuidString)_event_cover.\(format.1)", filetype: format.0, size: data.count,
+                    width: image.cgImage?.width ?? Int(image.size.width * image.scale), height: image.cgImage?.height ?? Int(image.size.height * image.scale), token: token
+                )
+                try Task.checkCancellation()
+                try await self.context.account.network.uploadToMinIO(url: upload.url, data: data, contentType: format.0)
+                try Task.checkCancellation()
+                guard !self.dismissed else { return }
+                self.draft.logoURL = "\(MezonConfig.baseImgURL)/\(upload.filename)"
+                self.previewImage = image
+                ImageCache.shared.setImage(image, data: data, forKey: self.draft.logoURL)
+            } catch is CancellationError {
+            } catch {
+                self.showError(error.localizedDescription)
+            }
+        }
+    }
+
+    private func submit() {
+        guard !submitting, !uploading, draft.isLocationValid, draft.isDetailsValid() else { return }
+        if let original, !EventEditorAccess.canEdit(original, context: context) { showError(L(L10n.EventEditor.permissionDenied)); return }
+        submitting = true
+        errorLabel.isHidden = true
+        refreshValidation()
+        let submitted = draft
+        submitTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer { self.submitting = false; self.submitTask = nil; if !self.dismissed { self.refreshValidation() } }
+            do {
+                guard let token = await self.context.getToken() else { throw EventEditorError.sessionExpired }
+                if let original = self.original {
+                    try await self.context.engine.clanData.updateEvent(draft: submitted, clanId: self.clanId, original: original, token: token)
+                } else {
+                    let userId = Int64(self.context.currentUser?.id ?? self.context.account.id) ?? 0
+                    guard userId != 0 else { throw EventEditorError.sessionExpired }
+                    try await self.context.engine.clanData.createEvent(draft: submitted, clanId: self.clanId, creatorId: userId, token: token)
+                }
+                let updated = self.original.map { original in
+                    self.context.engine.clanData.getClanEvents(clanId: self.clanId)?.events.first { $0.id == original.id } ?? submitted.applying(to: original)
+                }
+                self.onSaved?(updated)
+                self.dismissed = true
+                self.dismiss(animated: true) {
+                    Toast.success(L(self.original == nil ? L10n.EventEditor.created : L10n.EventEditor.updated))
+                }
+            } catch { self.showError(error.localizedDescription) }
+        }
+    }
+
+    private func close() {
+        guard !submitting else { return }
+        dismissed = true
+        uploadTask?.cancel()
+        view.endEditing(true)
+        dismiss(animated: true)
+    }
+    private func showError(_ message: String) {
+        guard !dismissed else { return }
+        errorLabel.text = message
+        errorLabel.isHidden = false
+        UIAccessibility.post(notification: .announcement, argument: message)
+        view.setNeedsLayout()
+    }
+    private func loadCover(into imageView: UIImageView) {
+        if let previewImage { imageView.image = previewImage; return }
+        let url = draft.logoURL
+        guard !url.isEmpty else { return }
+        ImageCache.shared.loadImage(urlString: ImgproxyURL.create(from: url, width: 800, height: 256)) { [weak self, weak imageView] image in
+            guard let self, self.draft.logoURL == url, !self.dismissed else { return }
+            imageView?.image = image
+        }
+    }
+    private func channelLabel(_ id: Int64) -> String? { id == 0 ? nil : channels.first { $0.channelID == id }?.channelLabel }
+    private func formatted(_ date: Date, template: String) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = LanguageManager.shared.current.locale
+        formatter.setLocalizedDateFormatFromTemplate(template)
+        return formatter.string(from: date)
+    }
+    private func label(_ text: String, size: CGFloat, weight: UIFont.Weight = .regular) -> UILabel {
+        let label = UILabel()
+        label.text = text
+        label.numberOfLines = 0
+        label.font = .systemFont(ofSize: size, weight: weight)
+        label.textColor = weight == .regular ? UIColor.theme.text : UIColor.theme.textStrong
+        return label
+    }
+    private func labeledField(_ title: String, field: UIView, error: UILabel) -> UIView {
+        let caption = label(title, size: 15, weight: .bold)
+        if title.hasSuffix(" *") {
+            let attributed = NSMutableAttributedString(string: title)
+            attributed.addAttribute(.foregroundColor, value: UIColor.systemRed, range: NSRange(location: (title as NSString).length - 1, length: 1))
+            caption.attributedText = attributed
+        }
+        let stack = UIStackView(arrangedSubviews: [caption, field, error])
+        stack.axis = .vertical
+        stack.spacing = 6
+        return stack
+    }
+    private func configureError(_ label: UILabel) {
+        label.textColor = .systemRed
+        label.font = .systemFont(ofSize: 12)
+        label.numberOfLines = 0
+        label.isHidden = true
+    }
+    private func setError(_ label: UILabel, _ text: String?) { label.text = text; label.isHidden = text == nil }
+    private func iconRow(_ symbol: String, text: String) -> UIView {
+        let icon = UIImageView(image: UIImage(systemName: symbol))
+        icon.contentMode = .scaleAspectFit
+        icon.tintColor = UIColor.theme.textStrong
+        icon.widthAnchor.constraint(equalToConstant: 20).isActive = true
+        icon.heightAnchor.constraint(equalToConstant: 20).isActive = true
+        let row = UIStackView(arrangedSubviews: [icon, label(text, size: 14)])
+        row.alignment = .center
+        row.spacing = 8
+        return row
+    }
+}
+
+private enum EventEditorError: LocalizedError {
+    case sessionExpired
+    var errorDescription: String? { L(L10n.EventEditor.sessionExpired) }
+}

--- a/MezonChat/Features/ChannelList/Event/EventEditorViewController.swift
+++ b/MezonChat/Features/ChannelList/Event/EventEditorViewController.swift
@@ -238,7 +238,6 @@ final class EventEditorViewController: UIViewController, UITextFieldDelegate, UI
         }
         nameField.accessibilityLabel = L(L10n.EventEditor.name)
         nameField.text = draft.title
-        addressField.placeholder = L(L10n.EventEditor.addressPlaceholder)
         addressField.accessibilityLabel = L(L10n.EventEditor.address)
         addressField.text = draft.address
         descriptionView.font = .systemFont(ofSize: 15)
@@ -275,6 +274,10 @@ final class EventEditorViewController: UIViewController, UITextFieldDelegate, UI
         }
         nameField.attributedPlaceholder = NSAttributedString(
             string: L(L10n.EventEditor.namePlaceholder),
+            attributes: [.foregroundColor: UIColor.theme.textDisabled]
+        )
+        addressField.attributedPlaceholder = NSAttributedString(
+            string: L(L10n.EventEditor.addressPlaceholder),
             attributes: [.foregroundColor: UIColor.theme.textDisabled]
         )
         descriptionView.textColor = UIColor.theme.textStrong

--- a/MezonChat/Features/ChannelList/Event/EventViewerBottomSheetViewController.swift
+++ b/MezonChat/Features/ChannelList/Event/EventViewerBottomSheetViewController.swift
@@ -459,7 +459,7 @@ final class EventViewerBottomSheetViewController: UIViewController {
                     empty.bottomAnchor.constraint(equalTo: emptyStateView.bottomAnchor),
                 ])
             }
-            emptyStateView.isHidden = false
+            emptyStateView.isHidden = isFetching
             styleEmptyState(emptyStateView.subviews.first!)
         } else {
             emptyStateView.isHidden = true
@@ -473,9 +473,10 @@ final class EventViewerBottomSheetViewController: UIViewController {
             }
         }
 
-        loadingRow.isHidden = !isFetching
-        loadingIndicator.isHidden = !isFetching
-        if isFetching {
+        let shouldShowLoading = isFetching && events.isEmpty
+        loadingRow.isHidden = !shouldShowLoading
+        loadingIndicator.isHidden = !shouldShowLoading
+        if shouldShowLoading {
             loadingIndicator.startAnimating()
         } else {
             loadingIndicator.stopAnimating()

--- a/MezonChat/Features/ChannelList/Event/EventViewerBottomSheetViewController.swift
+++ b/MezonChat/Features/ChannelList/Event/EventViewerBottomSheetViewController.swift
@@ -590,19 +590,8 @@ final class EventViewerBottomSheetViewController: UIViewController {
                 self.reloadEvents()
             }
             guard let token = await self.context.getToken() else { return }
-            do {
-                let response = try await MezonHTTPClient.shared.listEvents(clanId: self.clanId, token: token)
-                self.loadedEvents = response.events
-                if let data = try? response.serializedData() {
-                    self.context.account.postbox.setPreferenceDataSync(
-                        key: PreferencesKeys.clanEvents(clanId: self.clanId),
-                        value: data
-                    )
-                }
-            } catch {
-                await self.context.engine.clanData.refetchEvents(clanId: self.clanId, token: token)
-                self.loadedEvents = self.context.engine.clanData.getClanEvents(clanId: self.clanId)?.events ?? []
-            }
+            await self.context.engine.clanData.refetchEvents(clanId: self.clanId, token: token)
+            self.loadedEvents = self.context.engine.clanData.getClanEvents(clanId: self.clanId)?.events ?? []
         }
     }
 }

--- a/MezonChat/Features/ChannelList/Event/EventViewerBottomSheetViewController.swift
+++ b/MezonChat/Features/ChannelList/Event/EventViewerBottomSheetViewController.swift
@@ -6,12 +6,10 @@ enum EventListFilter {
         currentUserId: Int64,
         channels: [Mezon_Api_ChannelDescription]
     ) -> [Mezon_Api_EventManagement] {
-        let accessibleChannelIds = Set(channels.map(\.channelID))
         let privateTextChannelIds = privateTextChannelIds(from: channels)
         return events.filter { event in
             let passesPrivacy = !event.isPrivate || event.creatorID == currentUserId
             let passesChannel = event.channelID == 0
-                || accessibleChannelIds.contains(event.channelID)
                 || privateTextChannelIds.contains(event.channelID)
             return passesPrivacy && passesChannel
         }
@@ -37,15 +35,21 @@ enum EventDisplayStatus: Int32 {
 }
 
 enum EventDisplayHelper {
+    static let clanEventBadgeColor = UIColor(rgb: 0x3B82F6)
+    static let channelEventBadgeColor = UIColor(rgb: 0xF97316)
+    static let externalEventBadgeColor = UIColor(rgb: 0xEF4444)
+
     static func resolvedStatus(for event: Mezon_Api_EventManagement, now: Date = Date()) -> EventDisplayStatus {
-        if let stored = EventDisplayStatus(rawValue: event.eventStatus) {
-            return stored
+        guard event.startTimeSeconds != 0 else {
+            return EventDisplayStatus(rawValue: event.eventStatus) ?? .created
         }
-        guard event.startTimeSeconds > 0 else { return .created }
         let start = Date(timeIntervalSince1970: TimeInterval(event.startTimeSeconds))
+        let end = event.endTimeSeconds != 0
+            ? Date(timeIntervalSince1970: TimeInterval(event.endTimeSeconds))
+            : start.addingTimeInterval(2 * 60 * 60)
+        if now >= start && now <= end { return .ongoing }
         let secondsLeft = start.timeIntervalSince(now)
-        if secondsLeft <= 0 { return .ongoing }
-        if secondsLeft <= 10 * 60 { return .upcoming }
+        if secondsLeft > 0 && secondsLeft <= 10 * 60 { return .upcoming }
         return .created
     }
 
@@ -83,22 +87,19 @@ enum EventDisplayHelper {
 
     static func headerTitle(count: Int) -> String {
         if count == 1 {
-            return "1 \(L(L10n.EventMenu.eventOne))"
+            return L(L10n.EventMenu.eventCountOne)
         }
-        if count > 1 {
-            return "\(count) \(L(L10n.EventMenu.title))"
-        }
-        return L(L10n.EventMenu.title)
+        return L(L10n.EventMenu.eventCountMany, count)
     }
 
     static func eventBadge(for event: Mezon_Api_EventManagement) -> (text: String, color: UIColor)? {
         if event.isPrivate {
-            return (L(L10n.EventMenu.privateEvent), UIColor(red: 0.35, green: 0.35, blue: 0.38, alpha: 1))
+            return (L(L10n.EventMenu.privateEvent), externalEventBadgeColor)
         }
         if event.channelID != 0 {
-            return (L(L10n.EventMenu.channelEvent), UIColor(red: 0.98, green: 0.55, blue: 0.15, alpha: 1))
+            return (L(L10n.EventMenu.channelEvent), channelEventBadgeColor)
         }
-        return (L(L10n.EventMenu.clanEvent), UIColor(red: 0.44, green: 0.42, blue: 0.95, alpha: 1))
+        return (L(L10n.EventMenu.clanEvent), clanEventBadgeColor)
     }
 
     static func makeBadgeView(text: String, color: UIColor) -> UIView {
@@ -131,6 +132,10 @@ enum EventDisplayHelper {
     static func configureInterestButton(_ button: UIButton, isInterested: Bool) {
         let title = isInterested ? L(L10n.EventMenu.itemUninterested) : L(L10n.EventMenu.itemInterested)
         let iconName = isInterested ? "bell.slash" : "bell"
+        configureActionButton(button, title: title, iconName: iconName)
+    }
+
+    static func configureActionButton(_ button: UIButton, title: String, iconName: String) {
         let symbolConfig = UIImage.SymbolConfiguration(pointSize: 13, weight: .medium)
         let image = UIImage(systemName: iconName, withConfiguration: symbolConfig)?
             .withRenderingMode(.alwaysTemplate)
@@ -176,6 +181,7 @@ final class EventViewerBottomSheetViewController: UIViewController {
     private let scrollView = UIScrollView()
     private let contentStack = UIStackView()
     private let headerTitleLabel = UILabel()
+    private let createButton = EventEditorButton()
     private let loadingIndicator = UIActivityIndicatorView(style: .medium)
     private let loadingRow = UIView()
     private let listStack = UIStackView()
@@ -216,8 +222,11 @@ final class EventViewerBottomSheetViewController: UIViewController {
         fetchEvents()
         eventsDisposable = context.engine.clanData.clanEventsUpdated.signal().start(next: { [weak self] updatedClanId in
             guard let self, updatedClanId == self.clanId else { return }
-            self.loadedEvents = self.context.engine.clanData.getClanEvents(clanId: self.clanId)?.events ?? []
-            self.reloadEvents()
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.loadedEvents = self.context.engine.clanData.getClanEvents(clanId: self.clanId)?.events ?? []
+                self.reloadEvents()
+            }
         })
         NotificationCenter.default.addObserver(
             self,
@@ -292,16 +301,30 @@ final class EventViewerBottomSheetViewController: UIViewController {
 
     private func makeHeaderRow() -> UIView {
         let container = UIView()
-        headerTitleLabel.font = .systemFont(ofSize: 16, weight: .bold)
+        headerTitleLabel.font = .systemFont(ofSize: 15, weight: .bold)
         headerTitleLabel.textAlignment = .center
         headerTitleLabel.numberOfLines = 1
         headerTitleLabel.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(headerTitleLabel)
+        createButton.setTitle(L(L10n.EventMenu.createButton), for: .normal)
+        createButton.titleLabel?.font = .systemFont(ofSize: 13, weight: .bold)
+        createButton.setTitleColor(.white, for: .normal)
+        createButton.backgroundColor = UIColor(red: 0.39, green: 0.38, blue: 0.91, alpha: 1)
+        createButton.layer.cornerRadius = 8
+        createButton.contentEdgeInsets = UIEdgeInsets(top: 7, left: 14, bottom: 7, right: 14)
+        createButton.setContentHuggingPriority(.required, for: .horizontal)
+        createButton.setContentCompressionResistancePriority(.required, for: .horizontal)
+        createButton.translatesAutoresizingMaskIntoConstraints = false
+        createButton.action = { [weak self] in self?.presentEventEditor() }
+        container.addSubview(createButton)
         NSLayoutConstraint.activate([
+            createButton.centerYAnchor.constraint(equalTo: headerTitleLabel.centerYAnchor),
+            createButton.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -16),
+            headerTitleLabel.centerXAnchor.constraint(equalTo: container.centerXAnchor),
             headerTitleLabel.topAnchor.constraint(equalTo: container.topAnchor, constant: 28),
-            headerTitleLabel.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -10),
-            headerTitleLabel.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
-            headerTitleLabel.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -16),
+            headerTitleLabel.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -12),
+            headerTitleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: container.leadingAnchor, constant: 16),
+            headerTitleLabel.trailingAnchor.constraint(lessThanOrEqualTo: createButton.leadingAnchor, constant: -12),
         ])
         return container
     }
@@ -470,7 +493,9 @@ final class EventViewerBottomSheetViewController: UIViewController {
             },
             voiceChannelLabel: voiceChannelLabel,
             textChannelLabel: textChannelLabel,
-            isInterested: userId != 0 && event.userIds.contains(userId)
+            isInterested: userId != 0 && event.userIds.contains(userId),
+            canEditEvent: EventEditorAccess.canEdit(event, context: context),
+            canEndEvent: EventEditorAccess.canEnd(event, context: context)
         )
         row.onTap = { [weak self] in
             guard let self else { return }
@@ -479,6 +504,35 @@ final class EventViewerBottomSheetViewController: UIViewController {
         }
         row.onToggleInterest = { [weak self] in
             self?.toggleEventInterest(event)
+        }
+        row.onEditEvent = { [weak self] in
+            guard let self,
+                  let latest = self.loadedEvents.first(where: { $0.id == event.id }),
+                  EventEditorAccess.canEdit(latest, context: self.context) else { return }
+            self.presentEventEditor(latest)
+        }
+        row.onEndEvent = { [weak self] in
+            guard let self,
+                  let latest = self.loadedEvents.first(where: { $0.id == event.id }),
+                  EventEditorAccess.canEnd(latest, context: self.context) else { return }
+            EventDeleteConfirmation.present(event: latest, clanId: self.clanId, context: self.context, from: self)
+        }
+        row.onOpenExternalLink = { url in
+            UIApplication.shared.open(url)
+        }
+        row.onCopyExternalLink = { url in
+            UIPasteboard.general.string = url.absoluteString
+            Toast.success(L(L10n.ClanInviteSheet.linkCopied))
+        }
+        row.onInviteToExternalEvent = { [weak self] url in
+            guard let self else { return }
+            let invite = ClanInviteSheetViewController(context: self.context, clanId: self.clanId, externalEventURL: url)
+            invite.modalPresentationStyle = .pageSheet
+            if #available(iOS 15.0, *) {
+                invite.sheetPresentationController?.prefersGrabberVisible = true
+                invite.sheetPresentationController?.detents = [.medium(), .large()]
+            }
+            self.present(invite, animated: true)
         }
         return row
     }
@@ -499,6 +553,11 @@ final class EventViewerBottomSheetViewController: UIViewController {
             self.loadedEvents = self.context.engine.clanData.getClanEvents(clanId: self.clanId)?.events ?? []
             self.reloadEvents()
         }
+    }
+
+    private func presentEventEditor(_ event: Mezon_Api_EventManagement? = nil) {
+        let editor = EventEditorViewController(context: context, clanId: clanId, channels: channels, event: event)
+        present(editor, animated: true)
     }
 
     private func presentEventDetail(_ event: Mezon_Api_EventManagement) {
@@ -551,13 +610,21 @@ private final class EventListItemView: UIView, UIGestureRecognizerDelegate {
 
     var onTap: (() -> Void)?
     var onToggleInterest: (() -> Void)?
+    var onEditEvent: (() -> Void)?
+    var onEndEvent: (() -> Void)?
+    var onOpenExternalLink: ((URL) -> Void)?
+    var onCopyExternalLink: ((URL) -> Void)?
+    var onInviteToExternalEvent: ((URL) -> Void)?
 
     private let event: Mezon_Api_EventManagement
     private let creator: ClanMemberRecord?
     private let voiceChannelLabel: String?
     private let textChannelLabel: String?
     private let isInterested: Bool
+    private let canEditEvent: Bool
+    private let canEndEvent: Bool
     private let cardView = UIView()
+    private let editButton = EventEditorButton()
     private let interestButton = UIButton(type: .custom)
     private let openDetailGesture = UITapGestureRecognizer()
 
@@ -566,13 +633,17 @@ private final class EventListItemView: UIView, UIGestureRecognizerDelegate {
         creator: ClanMemberRecord?,
         voiceChannelLabel: String?,
         textChannelLabel: String?,
-        isInterested: Bool
+        isInterested: Bool,
+        canEditEvent: Bool,
+        canEndEvent: Bool
     ) {
         self.event = event
         self.creator = creator
         self.voiceChannelLabel = voiceChannelLabel
         self.textChannelLabel = textChannelLabel
         self.isInterested = isInterested
+        self.canEditEvent = canEditEvent
+        self.canEndEvent = canEndEvent
         super.init(frame: .zero)
         build()
         applyTheme()
@@ -588,12 +659,12 @@ private final class EventListItemView: UIView, UIGestureRecognizerDelegate {
     }
 
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
-        if let touchedView = touch.view,
-           touchedView === interestButton || touchedView.isDescendant(of: interestButton) {
-            return false
+        var view = touch.view
+        while let current = view, current !== self {
+            if current is UIControl { return false }
+            view = current.superview
         }
-        let point = touch.location(in: interestButton)
-        return !interestButton.point(inside: point, with: nil)
+        return true
     }
 
     private func build() {
@@ -634,24 +705,70 @@ private final class EventListItemView: UIView, UIGestureRecognizerDelegate {
         }
 
         root.addArrangedSubview(contentStack)
-        root.addArrangedSubview(makeActionsRow())
+        if event.isPrivate, let url = MezonConfig.externalEventURL(event.meetRoom.externalLink) {
+            root.addArrangedSubview(makeExternalActionsRow(url: url))
+        }
+        if canEditEvent || EventDisplayHelper.resolvedStatus(for: event) != .ongoing || canEndEvent {
+            root.addArrangedSubview(makeActionsRow())
+        }
+    }
+
+    private func makeExternalActionsRow(url: URL) -> UIView {
+        let row = UIStackView()
+        row.axis = .horizontal
+        row.spacing = 8
+        row.distribution = .fillEqually
+        let actions: [(String, String, () -> Void)] = [
+            (L(L10n.EventMenu.openLink), "arrow.up.right.square", { [weak self] in self?.onOpenExternalLink?(url) }),
+            (L(L10n.ClanInviteSheet.invite), "person.badge.plus", { [weak self] in self?.onInviteToExternalEvent?(url) }),
+            (L(L10n.ClanInviteSheet.copy), "link", { [weak self] in self?.onCopyExternalLink?(url) })
+        ]
+        for (title, icon, action) in actions {
+            let button = EventEditorButton()
+            EventDisplayHelper.configureActionButton(button, title: title, iconName: icon)
+            button.titleLabel?.numberOfLines = 2
+            button.titleLabel?.textAlignment = .center
+            button.action = action
+            row.addArrangedSubview(button)
+        }
+        return row
     }
 
     private func makeActionsRow() -> UIView {
         let row = UIStackView()
         row.axis = .horizontal
         row.spacing = 8
-        row.alignment = .center
+        row.alignment = .fill
+        row.distribution = .fillEqually
         row.isUserInteractionEnabled = true
-        EventDisplayHelper.configureInterestButton(interestButton, isInterested: isInterested)
-        interestButton.addTarget(self, action: #selector(interestTapped), for: .touchUpInside)
-        interestButton.translatesAutoresizingMaskIntoConstraints = false
-        row.addArrangedSubview(interestButton)
+        if canEditEvent {
+            EventDisplayHelper.configureActionButton(editButton, title: L(L10n.EventEditor.edit), iconName: "pencil")
+            editButton.action = { [weak self] in self?.onEditEvent?() }
+            row.addArrangedSubview(editButton)
+        }
+        if EventDisplayHelper.resolvedStatus(for: event) != .ongoing || canEndEvent {
+            EventDisplayHelper.configureInterestButton(interestButton, isInterested: isInterested)
+            if canEndEvent {
+                interestButton.setTitle(L(L10n.EventMenu.endEvent), for: .normal)
+                interestButton.setImage(UIImage(systemName: "xmark.circle"), for: .normal)
+            }
+            interestButton.addTarget(self, action: #selector(interestTapped), for: .touchUpInside)
+            interestButton.translatesAutoresizingMaskIntoConstraints = false
+            row.addArrangedSubview(interestButton)
+        }
+        for button in [editButton, interestButton] {
+            button.titleLabel?.numberOfLines = 2
+            button.titleLabel?.textAlignment = .center
+        }
         return row
     }
 
     @objc private func interestTapped() {
-        onToggleInterest?()
+        if canEndEvent {
+            onEndEvent?()
+        } else {
+            onToggleInterest?()
+        }
     }
 
     private func makeInfoRow() -> UIView {

--- a/MezonChat/Features/Clans/ClanInviteSheetViewController.swift
+++ b/MezonChat/Features/Clans/ClanInviteSheetViewController.swift
@@ -1023,7 +1023,8 @@ private final class ClanInviteSheetContainerNode: ASDisplayNode {
         let qrW = qrSz.width
 
         shareButton.frame = CGRect(x: aLead, y: aTop, width: shareW, height: 62.sh)
-        copyButton.frame = CGRect(x: (w - copyW) / 2, y: aTop, width: copyW, height: 62.sh)
+        let copyX = qrButton.isHidden ? w - aTrail - copyW : (w - copyW) / 2
+        copyButton.frame = CGRect(x: copyX, y: aTop, width: copyW, height: 62.sh)
         qrButton.frame = CGRect(x: w - aTrail - qrW, y: aTop, width: qrW, height: 62.sh)
         dividerNode.frame = CGRect(
             x: 0,
@@ -1068,6 +1069,7 @@ final class ClanInviteSheetViewController: ViewController {
 
     private let context: AccountContext
     private let clanId: Int64
+    private let externalEventURL: URL?
     private let nativeModalPresenter = UIViewController()
 
     private var inviteLink: String?
@@ -1083,9 +1085,10 @@ final class ClanInviteSheetViewController: ViewController {
 
     private var containerNode: ClanInviteSheetContainerNode { displayNode as! ClanInviteSheetContainerNode }
 
-    init(context: AccountContext, clanId: Int64) {
+    init(context: AccountContext, clanId: Int64, externalEventURL: URL? = nil) {
         self.context = context
         self.clanId = clanId
+        self.externalEventURL = externalEventURL
         super.init(navigationBarPresentationData: nil)
     }
 
@@ -1103,6 +1106,7 @@ final class ClanInviteSheetViewController: ViewController {
         node.shareButton.setEnabled(false)
         node.copyButton.setEnabled(false)
         node.qrButton.setEnabled(false)
+        node.qrButton.isHidden = externalEventURL != nil
         node.emptyStateNode.actionButtonNode.addTarget(
             self,
             action: #selector(emptyActionTapped),
@@ -1178,9 +1182,10 @@ final class ClanInviteSheetViewController: ViewController {
                 let friends = try await friendsTask
                 let directs = try await directsTask
 
-                let memberIds = Set(context.account.postbox.read { tx in
-                    tx.getClanMembers(clanId: self.clanId).map { $0.userId }
-                })
+                let clanMembers = context.account.postbox.read { tx in tx.getClanMembers(clanId: self.clanId) }
+                let excludedUserIds = externalEventURL == nil
+                    ? Set(clanMembers.map(\.userId))
+                    : context.engine.friendsData.blockedUserIds()
                 cacheDirectChannels(directs)
 
                 let currentUserId = Int64(context.currentUser?.id ?? "") ?? 0
@@ -1191,7 +1196,7 @@ final class ClanInviteSheetViewController: ViewController {
                     guard friend.hasUser else { continue }
                     let u = friend.user
                     let uid = u.id
-                    guard uid != 0, uid != currentUserId, !memberIds.contains(uid) else { continue }
+                    guard uid != 0, uid != currentUserId, !excludedUserIds.contains(uid) else { continue }
                     let name = !u.displayName.isEmpty ? u.displayName : (u.username.isEmpty ? "Unknown" : u.username)
                     let avatar = u.avatarURL.isEmpty ? nil : u.avatarURL
                     merged["user_\(uid)"] = FriendItem(
@@ -1210,7 +1215,7 @@ final class ClanInviteSheetViewController: ViewController {
 
                     if isDM {
                         guard let uid = dm.userIds.first else { continue }
-                        guard uid != 0, uid != currentUserId, !memberIds.contains(uid) else { continue }
+                        guard uid != 0, uid != currentUserId, !excludedUserIds.contains(uid) else { continue }
                         guard dm.channelID != 0 else { continue }
                         let name = !dm.channelLabel.isEmpty
                             ? dm.channelLabel
@@ -1236,6 +1241,21 @@ final class ClanInviteSheetViewController: ViewController {
                             avatarURL: avatar,
                             isGroupDM: true,
                             target: .direct(channelId: dm.channelID, type: dm.type, isPublic: dm.channelPrivate == 0)
+                        )
+                    }
+                }
+
+                if externalEventURL != nil {
+                    for member in clanMembers where member.userId != 0 && member.userId != currentUserId {
+                        guard !excludedUserIds.contains(member.userId), merged["user_\(member.userId)"] == nil else { continue }
+                        let name = !member.clanNick.isEmpty ? member.clanNick : (!member.displayName.isEmpty ? member.displayName : member.username)
+                        let avatar = !member.clanAvatar.isEmpty ? member.clanAvatar : member.userAvatarURL
+                        merged["user_\(member.userId)"] = FriendItem(
+                            id: member.userId,
+                            name: name,
+                            avatarURL: avatar.isEmpty ? nil : avatar,
+                            isGroupDM: false,
+                            target: .friend(userId: member.userId)
                         )
                     }
                 }
@@ -1268,6 +1288,7 @@ final class ClanInviteSheetViewController: ViewController {
     }
 
     private func resolveInviteLink(token: String) async -> String? {
+        if let externalEventURL { return externalEventURL.absoluteString }
         guard let inviteContext = await resolveInviteContext(token: token) else {
             return nil
         }
@@ -1389,7 +1410,7 @@ final class ClanInviteSheetViewController: ViewController {
                 _ = try await context.account.network.sendChannelMessage(
                     clanId: 0,
                     channelId: dm.channelID,
-                    mode: MezonConstants.ChannelStreamMode.dm.rawValue,
+                    mode: item.isGroupDM ? MezonConstants.ChannelStreamMode.group.rawValue : MezonConstants.ChannelStreamMode.dm.rawValue,
                     isPublic: isPublic,
                     content: content,
                     token: token
@@ -1408,7 +1429,7 @@ final class ClanInviteSheetViewController: ViewController {
         ]
         var payload: [String: Any] = ["t": url]
 
-        if let inviteId = extractInviteId(from: url), !inviteId.isEmpty {
+        if externalEventURL == nil, let inviteId = extractInviteId(from: url), !inviteId.isEmpty {
             do {
                 let inviteInfo = try await context.account.network.getInviteInfo(code: inviteId, token: token)
                 let memberCount = inviteInfo.member_count ?? 0

--- a/MezonChat/Networking/MezonConfig.swift
+++ b/MezonChat/Networking/MezonConfig.swift
@@ -40,6 +40,20 @@ enum MezonConfig {
         "\(chatWebAppBaseURL)/chat/clans/\(clanId)/channels/\(channelId)/canvas/\(canvasId)"
     }
 
+    static func eventShareURL(clanId: Int64, channelId: Int64) -> URL? {
+        URL(string: "\(chatWebAppBaseURL)/chat/clans/\(clanId)/channels/\(channelId)")
+    }
+
+    static func externalEventURL(_ link: String) -> URL? {
+        let link = link.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !link.isEmpty,
+              let baseURL = URL(string: "\(chatWebAppBaseURL)/"),
+              let url = URL(string: link, relativeTo: baseURL)?.absoluteURL,
+              let scheme = url.scheme?.lowercased(), ["http", "https"].contains(scheme),
+              url.host != nil else { return nil }
+        return url
+    }
+
     private static func infoPlistString(_ key: String) -> String? {
         guard let raw = Bundle.main.object(forInfoDictionaryKey: key) as? String else { return nil }
         let t = raw.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/MezonChat/Networking/MezonHTTPClient.swift
+++ b/MezonChat/Networking/MezonHTTPClient.swift
@@ -1551,6 +1551,30 @@ final class MezonHTTPClient {
         )
     }
 
+    func createEvent(request: Mezon_Api_CreateEventRequest, token: String) async throws {
+        try await postProtoIgnoringBody(
+            path: "/mezon.api.Mezon/CreateEvent",
+            message: request,
+            auth: .bearer(token)
+        )
+    }
+
+    func updateEvent(request: Mezon_Api_UpdateEventRequest, token: String) async throws {
+        try await postProtoIgnoringBody(
+            path: "/mezon.api.Mezon/UpdateEvent",
+            message: request,
+            auth: .bearer(token)
+        )
+    }
+
+    func deleteEvent(request: Mezon_Api_DeleteEventRequest, token: String) async throws {
+        try await postProtoIgnoringBody(
+            path: "/mezon.api.Mezon/DeleteEvent",
+            message: request,
+            auth: .bearer(token)
+        )
+    }
+
     func addUserEvent(request: Mezon_Api_UserEventRequest, token: String) async throws {
         try await postProtoIgnoringBody(
             path: "/mezon.api.Mezon/AddUserEvent",

--- a/MezonChat/Networking/MezonSocket.swift
+++ b/MezonChat/Networking/MezonSocket.swift
@@ -27,6 +27,7 @@ enum SocketEvent {
     case clanUpdated(Mezon_Realtime_ClanUpdatedEvent)
     case clanProfileUpdated(Mezon_Realtime_ClanProfileUpdatedEvent)
     case clanDeleted(Mezon_Realtime_ClanDeletedEvent)
+    case clanEventCreated(Mezon_Api_CreateEventRequest)
     case userClanRemoved(Mezon_Realtime_UserClanRemoved)
     case userClanAdded(Mezon_Realtime_AddClanUserEvent)
 
@@ -947,6 +948,8 @@ final class MezonSocket: NSObject {
             eventPipe.putNext(.clanProfileUpdated(m))
         case .clanDeletedEvent(let m):
             eventPipe.putNext(.clanDeleted(m))
+        case .clanEventCreated(let m):
+            eventPipe.putNext(.clanEventCreated(m))
         case .userClanRemovedEvent(let m):
             eventPipe.putNext(.userClanRemoved(m))
         case .addClanUserEvent(let m):


### PR DESCRIPTION
task: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-438
Root cause:
iOS was missing create/edit event support and several event behaviors were inconsistent with Android and web.
Solution:
Added the complete create/edit flow and aligned validation, channel selection, event actions, status handling, external links, realtime updates, and visual states across platforms.
Test cases:
1. Create voice, location, and external events and confirm each event appears correctly.
2. Edit an event and confirm the saved changes appear in both the list and detail screens.
3. Confirm event names longer than 128 characters cannot be submitted.
4. Confirm only eligible announcement channels and threads appear in the picker.
5. Confirm long channel and voice names stay on one line with ....
6. Confirm Share, Open Link, Invite, Copy Link, Edit, Delete, and End Event work when available.
7. Confirm an ongoing event hides Interested and shows End Event only to the clan owner.
8. Create or update an event from another device and confirm the event list refreshes automatically.
9. Confirm a clan without a logo displays the first letter of its name in event details.
