### PR TITLE
260910-IOS-Fix share modal can't open from share sheet of invite clan

### DIFF
--- a/MezonChat/Core/Display/ViewController.swift
+++ b/MezonChat/Core/Display/ViewController.swift
@@ -592,6 +592,14 @@ public protocol CustomViewControllerNavigationDataSummary: AnyObject {
         self.view.window?.rootViewController?.present(viewControllerToPresent, animated: flag, completion: completion)
     }
 
+    final func presentNativeController(
+        _ viewControllerToPresent: UIViewController,
+        animated flag: Bool,
+        completion: (() -> Void)? = nil
+    ) {
+        super.present(viewControllerToPresent, animated: flag, completion: completion)
+    }
+
     override open func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
         if let navigationController = self.navigationController as? NavigationController {
             var animated = flag

--- a/MezonChat/Features/Clans/ClanInviteSheetViewController.swift
+++ b/MezonChat/Features/Clans/ClanInviteSheetViewController.swift
@@ -1078,7 +1078,6 @@ final class ClanInviteSheetViewController: ViewController {
     private let context: AccountContext
     private let clanId: Int64
     private let channelId: Int64?
-    private let nativeModalPresenter = UIViewController()
 
     private var inviteLink: String?
     private var clanName = ""
@@ -1126,7 +1125,6 @@ final class ClanInviteSheetViewController: ViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        attachNativeModalPresenter()
         containerNode.searchWrapNode.textField.addTarget(self, action: #selector(searchChanged), for: .editingChanged)
         containerNode.searchWrapNode.clearButton.addTarget(self, action: #selector(clearSearchTapped), for: .touchUpInside)
         applyTheme()
@@ -1134,33 +1132,16 @@ final class ClanInviteSheetViewController: ViewController {
     }
 
     override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
-        if let modal = nativeModalPresenter.presentedViewController ?? presentedViewController {
+        if let modal = presentedViewController {
             modal.dismiss(animated: flag, completion: completion)
         } else {
             super.dismiss(animated: flag, completion: completion)
         }
     }
 
-    private func attachNativeModalPresenter() {
-        nativeModalPresenter.definesPresentationContext = true
-        nativeModalPresenter.view.backgroundColor = .clear
-        nativeModalPresenter.view.isUserInteractionEnabled = false
-        nativeModalPresenter.view.translatesAutoresizingMaskIntoConstraints = false
-
-        addChild(nativeModalPresenter)
-        view.insertSubview(nativeModalPresenter.view, at: 0)
-        NSLayoutConstraint.activate([
-            nativeModalPresenter.view.topAnchor.constraint(equalTo: view.topAnchor),
-            nativeModalPresenter.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            nativeModalPresenter.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            nativeModalPresenter.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
-        nativeModalPresenter.didMove(toParent: self)
-    }
-
     private func presentNativeModal(_ controller: UIViewController) {
-        guard nativeModalPresenter.presentedViewController == nil else { return }
-        nativeModalPresenter.present(controller, animated: true)
+        guard presentedViewController == nil else { return }
+        presentNativeController(controller, animated: true)
     }
 
     private func applyTheme() {

--- a/MezonChat/Features/Main/MezonRootController.swift
+++ b/MezonChat/Features/Main/MezonRootController.swift
@@ -876,19 +876,27 @@ final class MezonRootController: NavigationController {
         if let presented = anchor.presentedViewController {
             if presented is SharingViewController {
                 presented.dismiss(animated: false) {
-                    anchor.present(sharingVC, animated: true)
+                    self.presentFromCurrentAnchor(sharingVC, on: anchor)
                 }
                 return
             }
             if isEphemeralShareSheet(presented) {
                 presented.dismiss(animated: false) {
-                    anchor.present(sharingVC, animated: true)
+                    self.presentFromCurrentAnchor(sharingVC, on: anchor)
                 }
                 return
             }
         }
 
-        anchor.present(sharingVC, animated: true)
+        presentFromCurrentAnchor(sharingVC, on: anchor)
+    }
+
+    private func presentFromCurrentAnchor(_ controller: UIViewController, on anchor: UIViewController) {
+        if let anchor = anchor as? ViewController {
+            anchor.presentNativeController(controller, animated: true)
+        } else {
+            anchor.present(controller, animated: true)
+        }
     }
 
     // MARK: - Deep links


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-465
Root Cause
The invite screen opened the iOS share menu through a hidden child screen, preventing Mezon from correctly opening its internal sharing screen.
Solution
Use the active invite screen to open Share, QR, and Mezon sharing screens through the standard iOS presentation flow.
Test Cases
- Verify tapping Share Invite opens the iOS share menu.
- Verify selecting Mezon opens the Mezon sharing screen.
- Verify tapping QR Code opens the invite QR screen.
- Verify sharing the QR code to Mezon opens the Mezon sharing screen.
- Verify canceling the share menu returns to the invite screen.
- Verify the flows work for both clan invites and channel invites.