### PR TITLE
260911-IOS-Fix count topic badge display incorrect

### DIFF
--- a/MezonChat/Core/Postbox/Messages/MessageTable.swift
+++ b/MezonChat/Core/Postbox/Messages/MessageTable.swift
@@ -473,11 +473,17 @@ final class MessageTable: Table {
         let existing = cache[channelId] ?? getMessages(channelId: channelId)
         let existingById = Dictionary(existing.map { ($0.id, $0) }, uniquingKeysWith: { $1 })
         let mergedRaw = belonging.map { incoming -> MessageRecord in
-            guard let previous = existingById[incoming.id] else { return incoming }
-            return MessageRecord.mergingIncomingPreservingEmptyAttachments(
-                incoming: incoming,
-                previous: previous
-            )
+            let merged: MessageRecord
+            if let previous = existingById[incoming.id] {
+                merged = MessageRecord.mergingIncomingPreservingEmptyAttachments(
+                    incoming: incoming,
+                    previous: previous
+                )
+            } else {
+                merged = incoming
+            }
+
+            return enrichTopicMeta(merged)
         }
         var mergedBelonging: [MessageRecord] = []
         var keptIds = Set<String>()


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-471
Root Cause
The app received the correct topic reply count first, but a later message-list response did not include the count and replaced it with zero.
Solution
Keep the latest known topic reply count when refreshing the message list if the new response does not provide one.
Test Cases
1. Open a channel containing a topic with replies and verify the reply count does not change to zero after loading finishes.
2. Open a channel containing a topic with no replies and verify it still displays 0 reply.
3. Verify normal messages are displayed and can be sent as expected.