### PR TITLE
260911-IOS-Fix user stream leave remain

### DIFF
--- a/MezonChat/Core/AccountContext/AccountContextImpl.swift
+++ b/MezonChat/Core/AccountContext/AccountContextImpl.swift
@@ -1296,7 +1296,13 @@ final class AccountContextImpl: AccountContext {
             )
 
         case .streamingLeaved(let ev):
-            engine.clanData.applyStreamLeaved(clanId: ev.clanID, entryId: ev.streamingUserID)
+            guard let channelId = Int64(ev.streamingChannelID),
+                  let userId = Int64(ev.streamingUserID) else { return }
+            engine.clanData.applyStreamLeaved(
+                clanId: ev.clanID,
+                channelId: channelId,
+                userId: userId
+            )
 
         case .voiceEnded(let ev):
             let cid = Int64(ev.voiceChannelID) ?? 0

--- a/MezonChat/Core/MezonEngine/MezonEngine+ClanData.swift
+++ b/MezonChat/Core/MezonEngine/MezonEngine+ClanData.swift
@@ -906,17 +906,6 @@ extension MezonEngine {
             persistStreamUsersList(list, clanId: clanId)
         }
 
-        func applyStreamLeaved(clanId: Int64, entryId: String) {
-            guard clanId != 0, !entryId.isEmpty else { return }
-            var list = resolvedStreamUsersList(clanId: clanId) ?? Mezon_Api_StreamingChannelUserList()
-            if let numericId = Int64(entryId) {
-                list.streamingChannelUsers.removeAll { $0.id == numericId }
-            } else {
-                list.streamingChannelUsers.removeAll { "\($0.id)" == entryId }
-            }
-            persistStreamUsersList(list, clanId: clanId)
-        }
-
         private func persistVoiceUsersList(_ list: Mezon_Api_VoiceChannelUserList, clanId: Int64) {
             if let data = try? list.serializedData() {
                 postbox.setPreferenceData(key: PreferencesKeys.clanVoiceUsers(clanId: clanId), value: data)


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-463
Root Cause
iOS treated streaming_user_id from the leave event as a stream entry ID, so the user was not removed from the cached participant list and remained visible until the app restarted.
Solution
Use streaming_user_id as the user ID and remove the matching user from the specified streaming room, then update the UI with the new participant list.
Test Cases
1. Have User B leave a streaming room and verify that User B disappears immediately from User A’s screen without restarting the app.
2. With several users in the room, have one user leave and verify that only that user disappears.
3. Have a user leave and rejoin the same room and verify that the user appears only once.
4. Have a user move from one streaming room to another and verify that the user disappears from the old room and appears in the new room.
5. Close and reopen the app after a user leaves and verify that the displayed participant list remains correct.